### PR TITLE
Add creative evaluation module (LLM-as-judge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ a_stash/
 **cloud_funktions/creative_crf/message.json
 .adk
 .adk/*
+.next/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
+.python-version
 output/*
 *.env
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,15 @@ cd frontend && npm run test:watch  # watch mode
 
 # Python tests (pytest) — requires GCP credentials (module-level genai.Client)
 uv run pytest tests/ -v
+
+# ADK evals — end-to-end agent evaluation with LLM-as-judge (real API calls, ~5 min per case)
+uv run adk eval trend_trawler tests/eval/evalsets/trend_trawler_evalset.json \
+  --config_file_path=tests/eval/eval_config.json --print_detailed_results
 ```
 
-- Frontend: `frontend/src/__tests__/` — pure logic tests (SSE parsing, form validation, GCS URI building, widget layouts, trend markdown parsing, extractItems)
+- Frontend: `frontend/src/__tests__/` — pure logic tests (SSE parsing, form validation, GCS URI building, widget layouts, trend markdown parsing, extractItems, interactive mode pause/resume)
 - Python: `tests/` — Pydantic schema validation, agent pipeline structure, tool functions, callbacks (citation regex, state init, rate limiting), deployment utilities, cloud function logic
+- ADK Evals: `tests/eval/` — end-to-end agent evaluation using `adk eval` CLI with rubric-based LLM-as-judge scoring (response quality + tool use quality). Runs against real APIs.
 - Integration: `deployment/integration_test.py` — live GCP checks (health, session lifecycle, smoke tests). Requires deployed agents.
 - CI: `.github/workflows/frontend-tests.yml` — runs frontend tests on push/PR to `main` when `frontend/**` changes
 
@@ -65,7 +70,11 @@ python deployment/integration_test.py --check all                             # 
 
 **Phase 1 — `trend_trawler/`**: Gathers top 25 Google Search trends, researches cultural context via web search, filters to 3 most campaign-relevant trends, saves to BigQuery.
 
-**Phase 2 — `creative_agent/`**: Takes a single trend + campaign metadata, runs parallel web research (campaign researcher + trend researcher as sub-agents), synthesizes a strategic brief, generates ad copy and HTML gallery, exports research PDF and artifacts to GCS.
+**Phase 2 — `creative_agent/`**: Takes a single trend + campaign metadata, runs parallel web research (campaign researcher + trend researcher as sub-agents), synthesizes a strategic brief, generates ad copy and visual concepts, evaluates all creatives, and exports research PDF, HTML gallery, and evaluation report to GCS.
+
+**Phase 2 (interactive) — `interactive_creative/`**: Same pipeline as `creative_agent`, but pauses at 3 checkpoints for human review via ADK's `LongRunningFunctionTool`: (1) after research report, (2) after ad copies, (3) after visual concepts. Uses `ResumabilityConfig(is_resumable=True)`.
+
+**Evaluation — `creative_eval/`**: LLM-as-judge module that scores each ad copy and visual concept across 6 dimensions (12 total). Uses Gemini 2.5 Pro with structured output. Scores normalized 0.0–1.0, passing threshold 0.7. Produces `CreativeEvaluationReport` saved as JSON to GCS.
 
 ### Agent Composition
 
@@ -77,26 +86,34 @@ trend_trawler (root Agent)
 └── Persistence tools (BigQuery, GCS)
 
 creative_agent (root Agent)
-├── merge_parallel_insights (SequentialAgent)
+├── combined_research_pipeline (SequentialAgent)
 │   ├── parallel_planner_agent (ParallelAgent)
 │   │   ├── gs_sequential_planner (trend_researcher sub-agent)
 │   │   └── ca_sequential_planner (campaign_researcher sub-agent)
 │   └── merge_planners (synthesizes insights)
-├── combined_web_evaluator
-├── enhanced_combined_searcher
-└── combined_report_composer (HTML/PDF output)
+├── ad_creative_pipeline (SequentialAgent)
+├── visual_generation_pipeline (SequentialAgent)
+├── visual_generator (image generation)
+├── creative_eval_agent (LLM-as-judge scoring)
+└── Persistence tools (GCS, BigQuery, HTML gallery)
+
+interactive_creative (root Agent, resumable)
+├── [same sub-agents as creative_agent]
+├── review_research (LongRunningFunctionTool checkpoint)
+├── review_ad_copies (LongRunningFunctionTool checkpoint)
+└── review_visual_concepts (LongRunningFunctionTool checkpoint)
 ```
 
-Key ADK patterns used: `Agent`, `SequentialAgent`, `ParallelAgent`, `AgentTool` (wraps agents as tools).
+Key ADK patterns used: `Agent`, `SequentialAgent`, `ParallelAgent`, `AgentTool` (wraps agents as tools), `LongRunningFunctionTool` (pause/resume for human-in-the-loop).
 
 ### Frontend — `frontend/`
 
 Next.js 16 (App Router) + TypeScript + Tailwind CSS + shadcn/ui. Light theme with Sora font. Consumes the ADK `api_server` REST + SSE endpoints at `localhost:8000`.
 
 **Pages:**
-- `/` — Campaign input form (brand, audience, product, selling points, agent selector)
-- `/run/[sessionId]` — Live SSE event stream with timeline, pipeline state widgets (modal overlays), campaign metadata sidebar
-- `/results/[sessionId]` — Artifacts gallery, research PDF viewer, session state inspector
+- `/` — Campaign input form (brand, audience, product, selling points, agent selector: `trend_trawler`, `creative_agent`, `interactive_creative`)
+- `/run/[sessionId]` — Live SSE event stream with timeline, pipeline state widgets (modal overlays), campaign metadata sidebar. Interactive mode adds pause/resume review panels at each checkpoint.
+- `/results/[sessionId]` — Artifacts gallery, research PDF viewer, evaluation report, session state inspector
 
 **Key files:**
 - `frontend/src/app/layout.tsx` — Root layout, fonts (Sora + JetBrains Mono), glass header
@@ -136,6 +153,11 @@ Agents use `before_agent_callback` to initialize session state, `before_model_ca
 - `*/callbacks.py` — State initialization, rate limiting, citation processing
 - `*/prompts.py` — Agent instruction templates
 - `*/config.py` — Model selection, env vars, rate limit settings
+- `interactive_creative/review_tools.py` — `LongRunningFunctionTool` pause tools for human-in-the-loop checkpoints
+- `creative_eval/evaluate.py` — Core LLM-as-judge evaluation logic
+- `creative_eval/schemas.py` — Pydantic models for evaluation reports
+- `tests/eval/eval_config.json` — ADK eval criteria config (rubric-based scoring)
+- `tests/eval/evalsets/` — ADK eval cases per agent
 - `deployment/deploy_agent.py` — Agent Engine deploy/list/delete CLI
 - `deployment/test_deployment.py` — Invoke deployed agents for testing
 - `cloud_funktions/creative_crf/main.py` — Orchestrator and worker entry points
@@ -143,7 +165,7 @@ Agents use `before_agent_callback` to initialize session state, `before_model_ca
 ## Requirements
 
 - Python >=3.13
-- `google-adk>=1.27.3`
+- `google-adk[eval]>=1.28.0`
 - Node.js >=18 (for frontend)
 - GCP project with BigQuery, Cloud Storage, PubSub, and Agent Engine enabled
 - `.env` file populated from `.env.example`

--- a/README.md
+++ b/README.md
@@ -745,6 +745,14 @@ uv run pytest tests/ -v
 
 # Creative evaluation test (real Gemini API calls, ~2 min)
 uv run python -m creative_eval.run_eval_test
+
+# ADK evals — end-to-end agent evaluation with LLM-as-judge (real API calls, ~5 min per case)
+uv run adk eval trend_trawler tests/eval/evalsets/trend_trawler_evalset.json \
+  --config_file_path=tests/eval/eval_config.json --print_detailed_results
+
+# Run a single eval case
+uv run adk eval trend_trawler tests/eval/evalsets/trend_trawler_evalset.json:prs_guitars_campaign \
+  --config_file_path=tests/eval/eval_config.json --print_detailed_results
 ```
 
 ```bash
@@ -836,6 +844,10 @@ python deployment/integration_test.py --check all                             # 
 │   └── next.config.ts
 ├── tests
 │   ├── __init__.py
+│   ├── eval
+│   │   ├── eval_config.json
+│   │   └── evalsets
+│   │       └── trend_trawler_evalset.json
 │   ├── test_callbacks.py
 │   ├── test_creative_eval.py
 │   ├── test_crf_logic.py

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 
 * Given a campaign and trending topic, the `creative_agent` conducts web research and generates candidate ad copy and creatives
+* The `creative_eval` module scores every generated ad copy and visual concept using an LLM-as-judge approach across 12 quality dimensions
+* The `interactive_creative` agent adds human-in-the-loop review checkpoints — pause after research, ad copies, and visual concepts for approval before continuing
 
 </details>
 
@@ -232,8 +234,28 @@ user: Brand Name: "YOUR BRAND OF CHOICE"
       Key Selling Points: "YOU KEY SELLING POINT(S)"
       target_search_trend: "YOUR_SEARCH_TREND_OF_CHOICE"
 
-agent: `[end-to-end workflow >> candidate creatives]` 
+agent: `[end-to-end workflow >> candidate creatives]`
 ```
+
+**[1.c] choose `interactive_creative` for human-in-the-loop mode...**
+
+Same inputs as the `creative_agent`, but the pipeline pauses at 3 checkpoints for human review:
+
+1. **After research** — review the research report, approve or request changes
+2. **After ad copies** — review generated ad copies before visual concept generation
+3. **After visual concepts** — review visual concepts and image prompts before image generation
+
+At each checkpoint the UI displays a review panel where you can approve and continue, or provide feedback. Uses ADK's `LongRunningFunctionTool` for pause/resume.
+
+### Creative Evaluation
+
+The `creative_eval` module runs automatically as part of both the `creative_agent` and `interactive_creative` pipelines. It evaluates every generated ad copy and visual concept using an LLM-as-judge approach (Gemini 2.5 Pro).
+
+**Ad Copy Dimensions (6):** strategic alignment, trend authenticity, platform viability, copy quality, audience fit, CTA strength
+
+**Visual Concept Dimensions (6):** trend-visual connection, brand representation, audience appeal, prompt technical quality, stopping power, concept coherence
+
+Each dimension is scored 1–10. Scores are normalized to 0.0–1.0 with a **0.7 passing threshold**. The evaluation report includes per-dimension verdicts with rationale, strengths, suggested improvements, and a summary with pass rates and weakest dimensions. The report is saved as JSON to GCS.
 
 ### example output
 
@@ -301,12 +323,13 @@ npm run dev
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 **Features:**
-* Campaign input form with agent selector (`trend_trawler` or `creative_agent`)
+* Campaign input form with agent selector (`trend_trawler`, `creative_agent`, or `interactive_creative`)
 * Live SSE event stream with timeline-style visualization
 * Pipeline state widgets (ad copy drafts, visual concepts, critiques) as modal overlays
+* **Interactive mode** — human-in-the-loop review checkpoints after research, ad copies, and visual concepts (pause/resume via `LongRunningFunctionTool`)
 * Authenticated GCS proxy for viewing research PDFs and generated images
 * Clickable trend cards — run `trend_trawler`, then click a recommended trend to launch `creative_agent` with pre-filled metadata
-* Results page with artifact gallery, HTML portfolio viewer, and session state inspector
+* Results page with artifact gallery, HTML portfolio viewer, evaluation report, and session state inspector
 
 
 ## Deployment
@@ -773,6 +796,10 @@ python deployment/integration_test.py --check all                             # 
 │   ├── prompts.py
 │   ├── run_eval_test.py
 │   └── schemas.py
+├── interactive_creative
+│   ├── __init__.py
+│   ├── agent.py
+│   └── review_tools.py
 ├── deployment
 │   ├── deploy_agent.py
 │   ├── integration_test.py
@@ -785,6 +812,7 @@ python deployment/integration_test.py --check all                             # 
 │   │   │   ├── extract-items.test.ts
 │   │   │   ├── form-validation.test.ts
 │   │   │   ├── gcs-uri.test.ts
+│   │   │   ├── interactive-mode.test.ts
 │   │   │   ├── parse-trends.test.ts
 │   │   │   └── widget-layouts.test.ts
 │   │   ├── app
@@ -833,6 +861,8 @@ python deployment/integration_test.py --check all                             # 
 
 * ~~deployment script for Vertex AI Agent Engine~~
 * ~~event-based triggers~~
+* ~~creative evaluation (LLM-as-judge)~~
+* ~~interactive mode (human-in-the-loop review checkpoints)~~
 * scheduled runs
 * email / notification
 * easy export to ~*live editor tool* to nano-banana

--- a/README.md
+++ b/README.md
@@ -719,6 +719,9 @@ npm run test:watch    # watch mode
 ```bash
 # Python tests (pytest) — requires GCP credentials
 uv run pytest tests/ -v
+
+# Creative evaluation test (real Gemini API calls, ~2 min)
+uv run python -m creative_eval.run_eval_test
 ```
 
 ```bash
@@ -762,6 +765,14 @@ python deployment/integration_test.py --check all                             # 
 │   │       ├── agent.py
 │   │       └── __init__.py
 │   └── tools.py
+├── creative_eval
+│   ├── __init__.py
+│   ├── agent.py
+│   ├── config.py
+│   ├── evaluate.py
+│   ├── prompts.py
+│   ├── run_eval_test.py
+│   └── schemas.py
 ├── deployment
 │   ├── deploy_agent.py
 │   ├── integration_test.py
@@ -798,6 +809,7 @@ python deployment/integration_test.py --check all                             # 
 ├── tests
 │   ├── __init__.py
 │   ├── test_callbacks.py
+│   ├── test_creative_eval.py
 │   ├── test_crf_logic.py
 │   ├── test_deploy_utils.py
 │   ├── test_pipeline_structure.py

--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -14,6 +14,7 @@ from .sub_agents.trend_researcher.agent import gs_sequential_planner
 from .config import config
 from . import callbacks
 from . import tools
+from creative_eval.agent import creative_eval_agent
 
 
 # --- config ---
@@ -773,8 +774,9 @@ root_agent = Agent(
     4. Use the `ad_creative_pipeline` tool to generate ad copies.
     5. Use the `visual_generation_pipeline` tool to generate visual concepts.
     6. Use the `visual_generator` tool to generate image creatives.
-    7. Use the `save_creative_gallery_html` tool to build an HTML file for displaying a portfolio of the generated creatives generated during the session.
-    8. Use the `write_trends_to_bq` tool to insert rows to BigQuery.
+    7. Use the `creative_eval_agent` tool to evaluate all generated ad copies and visual concepts for quality.
+    8. Use the `save_creative_gallery_html` tool to build an HTML file for displaying a portfolio of the generated creatives generated during the session.
+    9. Use the `write_trends_to_bq` tool to insert rows to BigQuery.
     </AVAILABLE_TOOLS>
 
 
@@ -800,9 +802,10 @@ root_agent = Agent(
     3. Invoke the `ad_creative_pipeline` tool to generate a set of candidate ad copies.
     4. Then, call the `visual_generation_pipeline` tool to generate visual concepts for the finalized ad copies.
     5. Next, call the `visual_generator` tool to generate high-fidelity image creatives based on the visual concepts.
-    6. Then, call the `save_creative_gallery_html` tool to create an HTML portfolio and save it to Cloud Storage.
-    7. Finally as the last step, call the `write_trends_to_bq` tool to save trend information to BigQuery for logging and analytics.
-    8. Once the previous steps are complete, perform the following action:
+    6. Call the `creative_eval_agent` tool to evaluate the quality of all generated ad copies and visual concepts. This will score each creative on dimensions like trend authenticity, copy quality, audience fit, and stopping power, and store a detailed evaluation report in the session state.
+    7. Then, call the `save_creative_gallery_html` tool to create an HTML portfolio and save it to Cloud Storage.
+    8. Finally as the last step, call the `write_trends_to_bq` tool to save trend information to BigQuery for logging and analytics.
+    9. Once the previous steps are complete, perform the following action:
 
     Action 1: Display Cloud Storage location to the user
     Display the Cloud Storage URI to the user by combining the 'gcs_bucket', 'gcs_folder', and 'agent_output_dir' state keys like this: {gcs_bucket}/{gcs_folder}/{agent_output_dir}
@@ -815,6 +818,7 @@ root_agent = Agent(
         AgentTool(agent=ad_creative_pipeline),
         AgentTool(agent=visual_generation_pipeline),
         AgentTool(agent=visual_generator),
+        AgentTool(agent=creative_eval_agent),
         tools.save_draft_report_artifact,
         tools.save_creative_gallery_html,
         tools.write_trends_to_bq,

--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -775,8 +775,9 @@ root_agent = Agent(
     5. Use the `visual_generation_pipeline` tool to generate visual concepts.
     6. Use the `visual_generator` tool to generate image creatives.
     7. Use the `creative_eval_agent` tool to evaluate all generated ad copies and visual concepts for quality.
-    8. Use the `save_creative_gallery_html` tool to build an HTML file for displaying a portfolio of the generated creatives generated during the session.
-    9. Use the `write_trends_to_bq` tool to insert rows to BigQuery.
+    8. Use the `save_eval_report_to_gcs` tool to save the creative evaluation report JSON to Cloud Storage.
+    9. Use the `save_creative_gallery_html` tool to build an HTML file for displaying a portfolio of the generated creatives generated during the session.
+    10. Use the `write_trends_to_bq` tool to insert rows to BigQuery.
     </AVAILABLE_TOOLS>
 
 
@@ -803,8 +804,9 @@ root_agent = Agent(
     4. Then, call the `visual_generation_pipeline` tool to generate visual concepts for the finalized ad copies.
     5. Next, call the `visual_generator` tool to generate high-fidelity image creatives based on the visual concepts.
     6. Call the `creative_eval_agent` tool to evaluate the quality of all generated ad copies and visual concepts. This will score each creative on dimensions like trend authenticity, copy quality, audience fit, and stopping power, and store a detailed evaluation report in the session state.
-    7. Then, call the `save_creative_gallery_html` tool to create an HTML portfolio and save it to Cloud Storage.
-    8. Finally as the last step, call the `write_trends_to_bq` tool to save trend information to BigQuery for logging and analytics.
+    7. Call the `save_eval_report_to_gcs` tool to save the creative evaluation report JSON to Cloud Storage.
+    8. Then, call the `save_creative_gallery_html` tool to create an HTML portfolio and save it to Cloud Storage.
+    9. Finally as the last step, call the `write_trends_to_bq` tool to save trend information to BigQuery for logging and analytics.
     9. Once the previous steps are complete, perform the following action:
 
     Action 1: Display Cloud Storage location to the user
@@ -819,6 +821,7 @@ root_agent = Agent(
         AgentTool(agent=visual_generation_pipeline),
         AgentTool(agent=visual_generator),
         AgentTool(agent=creative_eval_agent),
+        tools.save_eval_report_to_gcs,
         tools.save_draft_report_artifact,
         tools.save_creative_gallery_html,
         tools.write_trends_to_bq,

--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -723,26 +723,30 @@ visual_concept_finalizer = Agent(
 )
 
 
-# Sequential agent for visual generation
-visual_generation_pipeline = SequentialAgent(
-    name="visual_generation_pipeline",
-    description="Generates visual concepts with an actor-critic workflow.",
-    sub_agents=[
-        visual_concept_drafter,
-        visual_concept_critic,
-        visual_concept_finalizer,
-    ],
-)
-
-
 # --- VISUAL GENERATOR AGENT ---
+# Runs generate_image over the finalized visual concepts. In creative_agent it is
+# chained into visual_production_pipeline (below) so image rendering is deterministic
+# and the orchestrator cannot skip it. interactive_creative deliberately invokes it as
+# a separate step AFTER a human review checkpoint (review concepts before spending on
+# image generation), so it must also remain usable as a standalone agent.
 visual_generator = Agent(
     model=config.critic_model,
     name="visual_generator",
     include_contents="none",  # new
     description="Generate final visuals using image generation tools",
+    # thinking_budget=0: this is a mechanical single-tool step, not a reasoning task.
+    # Without it, gemini-3 would emit MULTIPLE parallel `generate_image` calls in one
+    # turn — and parallel calls all read state before any commits, so the tool's
+    # idempotency guard (_images_generated) can't dedupe them, causing every image to
+    # be rendered 2x (double the image-gen cost). One call is all that's needed:
+    # generate_image itself loops over every concept in final_visual_concepts.
+    planner=BuiltInPlanner(
+        thinking_config=types.ThinkingConfig(thinking_budget=0, include_thoughts=False)
+    ),
     instruction="""You are a visual content producer generating image creatives.
-    Your job is to invoke the `generate_image` tool.
+    Call the `generate_image` tool EXACTLY ONCE — a single function call, never in
+    parallel and never more than once. It renders images for all concepts on its own.
+    After it returns, reply with a one-line confirmation. Do not call it again.
     """,
     tools=[tools.generate_image],
     generate_content_config=types.GenerateContentConfig(
@@ -754,6 +758,34 @@ visual_generator = Agent(
         },
     ),
     before_model_callback=callbacks.rate_limit_callback,
+)
+
+
+# Sequential agent for visual concepts (draft -> critique -> finalize). Shared with
+# interactive_creative, which pauses for human review after this stage before rendering.
+visual_generation_pipeline = SequentialAgent(
+    name="visual_generation_pipeline",
+    description="Generates visual concepts with an actor-critic workflow.",
+    sub_agents=[
+        visual_concept_drafter,
+        visual_concept_critic,
+        visual_concept_finalizer,
+    ],
+)
+
+
+# creative_agent (non-interactive) renders images immediately after finalizing
+# concepts, as one deterministic unit. This removes the orchestrator's opportunity to
+# skip image generation — which it did when creative_eval_agent looked like the next
+# step, jumping straight from visual concepts to evaluation. interactive_creative does
+# NOT use this: it keeps concepts and images split around a review checkpoint.
+visual_production_pipeline = SequentialAgent(
+    name="visual_production_pipeline",
+    description="Generate visual concepts, then render their image creatives.",
+    sub_agents=[
+        visual_generation_pipeline,
+        visual_generator,
+    ],
 )
 
 
@@ -772,12 +804,11 @@ root_agent = Agent(
     2. Use the `combined_research_pipeline` tool to conduct web research on the campaign metadata and selected trends.
     3. Use the `save_draft_report_artifact` tool to save a research PDf report to Cloud Storage.
     4. Use the `ad_creative_pipeline` tool to generate ad copies.
-    5. Use the `visual_generation_pipeline` tool to generate visual concepts.
-    6. Use the `visual_generator` tool to generate image creatives.
-    7. Use the `creative_eval_agent` tool to evaluate all generated ad copies and visual concepts for quality.
-    8. Use the `save_eval_report_to_gcs` tool to save the creative evaluation report JSON to Cloud Storage.
-    9. Use the `save_creative_gallery_html` tool to build an HTML file for displaying a portfolio of the generated creatives generated during the session.
-    10. Use the `write_trends_to_bq` tool to insert rows to BigQuery.
+    5. Use the `visual_production_pipeline` tool to generate visual concepts and render their image creatives.
+    6. Use the `creative_eval_agent` tool to evaluate all generated ad copies and visual concepts for quality.
+    7. Use the `save_eval_report_to_gcs` tool to save the creative evaluation report JSON to Cloud Storage.
+    8. Use the `save_creative_gallery_html` tool to build an HTML file for displaying a portfolio of the generated creatives generated during the session.
+    9. Use the `write_trends_to_bq` tool to insert rows to BigQuery.
     </AVAILABLE_TOOLS>
 
 
@@ -801,12 +832,11 @@ root_agent = Agent(
     1. First, use the `combined_research_pipeline` tool to conduct web research, leveraging the stored campaign metadata and trends.
     2. Once all research tasks are complete, use the `save_draft_report_artifact` tool to save the research as a markdown file in Cloud Storage.
     3. Invoke the `ad_creative_pipeline` tool to generate a set of candidate ad copies.
-    4. Then, call the `visual_generation_pipeline` tool to generate visual concepts for the finalized ad copies.
-    5. Next, call the `visual_generator` tool to generate high-fidelity image creatives based on the visual concepts.
-    6. Call the `creative_eval_agent` tool to evaluate the quality of all generated ad copies and visual concepts. This will score each creative on dimensions like trend authenticity, copy quality, audience fit, and stopping power, and store a detailed evaluation report in the session state.
-    7. Call the `save_eval_report_to_gcs` tool to save the creative evaluation report JSON to Cloud Storage.
-    8. Then, call the `save_creative_gallery_html` tool to create an HTML portfolio and save it to Cloud Storage.
-    9. Finally as the last step, call the `write_trends_to_bq` tool to save trend information to BigQuery for logging and analytics.
+    4. Then, call the `visual_production_pipeline` tool to generate visual concepts for the finalized ad copies and render high-fidelity image creatives for each concept.
+    5. Call the `creative_eval_agent` tool to evaluate the quality of all generated ad copies and visual concepts. This will score each creative on dimensions like trend authenticity, copy quality, audience fit, and stopping power, and store a detailed evaluation report in the session state.
+    6. Call the `save_eval_report_to_gcs` tool to save the creative evaluation report JSON to Cloud Storage.
+    7. Then, call the `save_creative_gallery_html` tool to create an HTML portfolio and save it to Cloud Storage.
+    8. Finally as the last step, call the `write_trends_to_bq` tool to save trend information to BigQuery for logging and analytics.
     9. Once the previous steps are complete, perform the following action:
 
     Action 1: Display Cloud Storage location to the user
@@ -818,8 +848,7 @@ root_agent = Agent(
     tools=[
         AgentTool(agent=combined_research_pipeline),
         AgentTool(agent=ad_creative_pipeline),
-        AgentTool(agent=visual_generation_pipeline),
-        AgentTool(agent=visual_generator),
+        AgentTool(agent=visual_production_pipeline),
         AgentTool(agent=creative_eval_agent),
         tools.save_eval_report_to_gcs,
         tools.save_draft_report_artifact,

--- a/creative_agent/config.py
+++ b/creative_agent/config.py
@@ -33,12 +33,12 @@ class ResearchConfiguration:
     """
 
     state_init = "_state_init"
-    critic_model: str = "gemini-2.5-pro"
-    worker_model: str = "gemini-2.5-flash"
-    video_analysis_model: str = "gemini-2.5-pro"
-    lite_planner_model: str = "gemini-2.5-flash-lite"
-    image_gen_model: str = "imagen-4.0-generate-001" # "gemini-2.5-flash-image"
-    video_gen_model: str = "veo-3.0-generate-001" # "veo-3.1-generate-preview"
+    critic_model: str = "gemini-2.5-pro" # gemini-3-pro-preview
+    worker_model: str = "gemini-2.5-flash" # gemini-3-flash-preview
+    video_analysis_model: str = "gemini-2.5-pro" # gemini-3-pro-preview
+    lite_planner_model: str = "gemini-2.5-flash-lite" # gemini-3-flash-preview
+    image_gen_model: str = "imagen-4.0-generate-001" # "imagen-4.0-ultra-generate-001
+    video_gen_model: str = "veo-3.1-generate-001" # "veo-3.0-generate-001"
     max_results_yt_trends: int = 45
 
     # Adjust these values to limit the rate at which the agent queries the LLM API.

--- a/creative_agent/config.py
+++ b/creative_agent/config.py
@@ -33,11 +33,11 @@ class ResearchConfiguration:
     """
 
     state_init = "_state_init"
-    critic_model: str = "gemini-2.5-pro" # gemini-3-pro-preview
-    worker_model: str = "gemini-2.5-flash" # gemini-3-flash-preview
-    video_analysis_model: str = "gemini-2.5-pro" # gemini-3-pro-preview
-    lite_planner_model: str = "gemini-2.5-flash-lite" # gemini-3-flash-preview
-    image_gen_model: str = "imagen-4.0-generate-001" # "imagen-4.0-ultra-generate-001
+    critic_model: str = "gemini-3.1-pro-preview" # gemini-3-pro-preview
+    worker_model: str = "gemini-3.5-flash" # gemini-3-flash-preview
+    video_analysis_model: str = "gemini-3.1-pro-preview" # gemini-3-pro-preview
+    lite_planner_model: str = "gemini-3.1-flash-lite" # gemini-3-flash-preview
+    image_gen_model: str = "gemini-3.1-flash-image"
     video_gen_model: str = "veo-3.1-generate-001" # "veo-3.0-generate-001"
     max_results_yt_trends: int = 45
 

--- a/creative_agent/tools.py
+++ b/creative_agent/tools.py
@@ -203,6 +203,8 @@ async def generate_image(
                     image_bytes=image_bytes,
                     filename=artifact_key,
                 )
+                if isinstance(img_gcs_uri, dict) and img_gcs_uri.get("status") == "error":
+                    logging.error(f"GCS upload failed for '{artifact_key}': {img_gcs_uri.get('message')}")
 
                 # save ADK artifact
                 img_artifact = types.Part.from_bytes(
@@ -1089,6 +1091,44 @@ async def save_draft_report_artifact(tool_context: ToolContext) -> dict:
 #     }
 
 
+def save_eval_report_to_gcs(tool_context: ToolContext) -> dict:
+    """
+    Saves the creative evaluation report JSON to Cloud Storage.
+
+    Args:
+        tool_context (ToolContext): The tool context.
+
+    Returns:
+        dict: Status and the GCS URI of the saved evaluation report.
+    """
+    report_data = tool_context.state.get("creative_evaluation_report")
+    if not report_data:
+        return {"status": "error", "message": "No creative_evaluation_report found in session state."}
+
+    gcs_folder = tool_context.state["gcs_folder"]
+    gcs_subdir = tool_context.state["agent_output_dir"]
+    filename = "creative_eval_report.json"
+    gcs_blob_name = f"{gcs_folder}/{gcs_subdir}/{filename}"
+    gcs_uri = f"gs://{config.GCS_BUCKET_NAME}/{gcs_blob_name}"
+
+    try:
+        report_json = json.dumps(report_data, indent=2, default=str)
+
+        storage_client = _get_gcs_client()
+        bucket = storage_client.bucket(config.GCS_BUCKET_NAME)
+        blob = bucket.blob(gcs_blob_name)
+        blob.upload_from_string(report_json, content_type="application/json")
+
+        tool_context.state["eval_report_gcs_uri"] = gcs_uri
+        logging.info(f"Saved creative eval report to: '{gcs_uri}'")
+
+        return {"status": "success", "gcs_uri": gcs_uri}
+
+    except Exception as e:
+        logging.exception(f"Error saving eval report to GCS: {e}")
+        return {"status": "error", "message": str(e)}
+
+
 def write_trends_to_bq(tool_context: ToolContext) -> dict:
     """
     Writes selected trends to a BigQuery Table.
@@ -1202,6 +1242,7 @@ def _save_to_gcs(
         return gcs_uri
 
     except Exception as e_gcs:
+        logging.error(f"GCS upload failed for '{filename}': {e_gcs}")
         return {
             "status": "error",
             "message": f"Image generated but failed to upload to GCS: {e_gcs}",

--- a/creative_agent/tools.py
+++ b/creative_agent/tools.py
@@ -174,22 +174,28 @@ async def generate_image(
 
         try:
 
-            response = client.models.generate_images(
+            response = client.models.generate_content(
                 model=config.image_gen_model,
-                prompt=entry["image_generation_prompt"],
-                config=types.GenerateImagesConfig(
-                    number_of_images=1,
-                    enhance_prompt=False,
+                contents=entry["image_generation_prompt"],
+                config=types.GenerateContentConfig(
+                    response_modalities=["IMAGE"],
                 ),
             )
 
-            if (
-                response.generated_images is not None
-                and response.generated_images[0].image is not None
-                and response.generated_images[0].image.image_bytes is not None
-            ):
-                # extract bytes && define artifact key
-                image_bytes = response.generated_images[0].image.image_bytes
+            # Gemini image models return the image as inline data on a content part,
+            # unlike Imagen's generate_images (which returns response.generated_images).
+            image_bytes = None
+            image_mime_type = "image/png"
+            candidates = response.candidates or []
+            if candidates and candidates[0].content and candidates[0].content.parts:
+                for part in candidates[0].content.parts:
+                    if part.inline_data is not None and part.inline_data.data:
+                        image_bytes = part.inline_data.data
+                        image_mime_type = part.inline_data.mime_type or image_mime_type
+                        break
+
+            if image_bytes is not None:
+                # define artifact key
                 ARTIFACT_NAME = (
                     entry["concept_name"]
                     .translate(REMOVE_PUNCTUATION)
@@ -208,7 +214,7 @@ async def generate_image(
 
                 # save ADK artifact
                 img_artifact = types.Part.from_bytes(
-                    data=image_bytes, mime_type="image/png"
+                    data=image_bytes, mime_type=image_mime_type
                 )
                 await tool_context.save_artifact(
                     filename=artifact_key, artifact=img_artifact

--- a/creative_eval/__init__.py
+++ b/creative_eval/__init__.py
@@ -1,0 +1,10 @@
+"""Creative evaluation module for scoring ad copy and visual concepts."""
+
+from .schemas import (
+    CreativeScore,
+    AdCopyEvaluation,
+    VisualConceptEvaluation,
+    CreativeEvaluationReport,
+    EvalVerdict,
+)
+from .config import EvalConfig

--- a/creative_eval/agent.py
+++ b/creative_eval/agent.py
@@ -1,0 +1,134 @@
+"""ADK agent integration for creative evaluation.
+
+Provides an evaluation agent that can be plugged into the creative_agent
+pipeline as an additional step after visual generation.
+
+Usage:
+    from creative_eval.agent import creative_eval_agent
+
+    # Add to root_agent tools:
+    tools=[..., AgentTool(agent=creative_eval_agent)]
+"""
+
+import json
+import logging
+from google.adk.agents import Agent
+from google.genai import types
+
+from .config import EvalConfig
+from .evaluate import evaluate_ad_copy, evaluate_visual_concept, _build_summary
+from .schemas import CreativeEvaluationReport
+
+logger = logging.getLogger(__name__)
+
+_config = EvalConfig()
+
+
+def evaluate_all_creatives(tool_context) -> dict:
+    """Evaluate all finalized ad copies and visual concepts in session state.
+
+    Reads from state keys:
+      - ad_copy_critique (FinalAdCopyList JSON)
+      - final_visual_concepts (VisualConceptFinalList JSON)
+      - brand, target_product, target_audience, key_selling_points, target_search_trends
+
+    Writes to state key:
+      - creative_evaluation_report (CreativeEvaluationReport JSON)
+
+    Returns:
+        Summary dict with pass rates and weakest dimensions.
+    """
+    state = tool_context.state
+
+    # Extract campaign context from state
+    campaign_context = {
+        "brand": state.get("brand", ""),
+        "target_product": state.get("target_product", ""),
+        "target_audience": state.get("target_audience", ""),
+        "key_selling_points": state.get("key_selling_points", ""),
+        "target_search_trend": state.get("target_search_trends", ""),
+    }
+
+    # Parse ad copies from state
+    ad_copy_raw = state.get("ad_copy_critique", {})
+    if isinstance(ad_copy_raw, str):
+        ad_copy_raw = json.loads(ad_copy_raw)
+    ad_copies = ad_copy_raw.get("ad_copies", []) if isinstance(ad_copy_raw, dict) else []
+
+    # Parse visual concepts from state
+    visual_raw = state.get("final_visual_concepts", {})
+    if isinstance(visual_raw, str):
+        visual_raw = json.loads(visual_raw)
+    visual_concepts = visual_raw.get("visual_concepts", []) if isinstance(visual_raw, dict) else []
+
+    if not ad_copies and not visual_concepts:
+        return {
+            "status": "error",
+            "message": "No ad copies or visual concepts found in session state to evaluate.",
+        }
+
+    logger.info(
+        f"Evaluating {len(ad_copies)} ad copies and {len(visual_concepts)} visual concepts..."
+    )
+
+    # Evaluate ad copies
+    ad_evals = []
+    for ac in ad_copies:
+        if isinstance(ac, str):
+            ac = json.loads(ac)
+        ad_evals.append(evaluate_ad_copy(ac, campaign_context, _config))
+
+    # Evaluate visual concepts
+    visual_evals = []
+    for vc in visual_concepts:
+        if isinstance(vc, str):
+            vc = json.loads(vc)
+        visual_evals.append(evaluate_visual_concept(vc, campaign_context, _config))
+
+    summary = _build_summary(ad_evals, visual_evals)
+
+    report = CreativeEvaluationReport(
+        brand=campaign_context["brand"],
+        target_product=campaign_context["target_product"],
+        target_search_trend=campaign_context["target_search_trend"],
+        ad_copy_evaluations=ad_evals,
+        visual_concept_evaluations=visual_evals,
+        summary=summary,
+    )
+
+    # Store in session state
+    state["creative_evaluation_report"] = report.model_dump()
+
+    return {
+        "status": "success",
+        "total_ad_copies": summary.total_ad_copies,
+        "ad_copies_passed": summary.ad_copies_passed,
+        "avg_ad_copy_score": summary.avg_ad_copy_score,
+        "total_visual_concepts": summary.total_visual_concepts,
+        "visual_concepts_passed": summary.visual_concepts_passed,
+        "avg_visual_score": summary.avg_visual_score,
+        "overall_pass_rate": summary.overall_pass_rate,
+        "weakest_dimensions": summary.weakest_dimensions,
+    }
+
+
+# ADK Agent that wraps the evaluation tool
+creative_eval_agent = Agent(
+    model=_config.eval_model,
+    name="creative_eval_agent",
+    include_contents="none",
+    description="Evaluate the quality of generated ad copies and visual concepts using LLM-as-judge scoring.",
+    instruction="""Role: You are a Creative Quality Evaluation Specialist.
+
+    Your task is to evaluate all finalized ad copies and visual concepts using the `evaluate_all_creatives` tool.
+
+    <INSTRUCTIONS>
+    1. Call the `evaluate_all_creatives` tool to score all creatives in the session.
+    2. Report the results: overall pass rate, average scores, and weakest dimensions.
+    3. Highlight any creatives that failed (score < 0.7) and explain why.
+    </INSTRUCTIONS>
+
+    Call the tool now and report the results.
+    """,
+    tools=[evaluate_all_creatives],
+)

--- a/creative_eval/agent.py
+++ b/creative_eval/agent.py
@@ -13,10 +13,9 @@ Usage:
 import json
 import logging
 from google.adk.agents import Agent
-from google.genai import types
 
 from .config import EvalConfig
-from .evaluate import evaluate_ad_copy, evaluate_visual_concept, _build_summary
+from .evaluate import evaluate_all_concurrently, _build_summary
 from .schemas import CreativeEvaluationReport
 
 logger = logging.getLogger(__name__)
@@ -53,13 +52,17 @@ def evaluate_all_creatives(tool_context) -> dict:
     ad_copy_raw = state.get("ad_copy_critique", {})
     if isinstance(ad_copy_raw, str):
         ad_copy_raw = json.loads(ad_copy_raw)
-    ad_copies = ad_copy_raw.get("ad_copies", []) if isinstance(ad_copy_raw, dict) else []
+    ad_copies = (
+        ad_copy_raw.get("ad_copies", []) if isinstance(ad_copy_raw, dict) else []
+    )
 
     # Parse visual concepts from state
     visual_raw = state.get("final_visual_concepts", {})
     if isinstance(visual_raw, str):
         visual_raw = json.loads(visual_raw)
-    visual_concepts = visual_raw.get("visual_concepts", []) if isinstance(visual_raw, dict) else []
+    visual_concepts = (
+        visual_raw.get("visual_concepts", []) if isinstance(visual_raw, dict) else []
+    )
 
     if not ad_copies and not visual_concepts:
         return {
@@ -68,22 +71,21 @@ def evaluate_all_creatives(tool_context) -> dict:
         }
 
     logger.info(
-        f"Evaluating {len(ad_copies)} ad copies and {len(visual_concepts)} visual concepts..."
+        f"Evaluating {len(ad_copies)} ad copies and {len(visual_concepts)} visual "
+        f"concepts concurrently (max {_config.max_eval_workers} workers)..."
     )
 
-    # Evaluate ad copies
-    ad_evals = []
-    for ac in ad_copies:
-        if isinstance(ac, str):
-            ac = json.loads(ac)
-        ad_evals.append(evaluate_ad_copy(ac, campaign_context, _config))
+    # Normalize any JSON-string entries to dicts before scoring
+    ad_copies = [json.loads(ac) if isinstance(ac, str) else ac for ac in ad_copies]
+    visual_concepts = [
+        json.loads(vc) if isinstance(vc, str) else vc for vc in visual_concepts
+    ]
 
-    # Evaluate visual concepts
-    visual_evals = []
-    for vc in visual_concepts:
-        if isinstance(vc, str):
-            vc = json.loads(vc)
-        visual_evals.append(evaluate_visual_concept(vc, campaign_context, _config))
+    # Score every creative in parallel — each is an independent judge call, so
+    # this collapses eval wall-clock from ~N*28s to roughly one call's latency.
+    ad_evals, visual_evals = evaluate_all_concurrently(
+        ad_copies, visual_concepts, campaign_context, _config
+    )
 
     summary = _build_summary(ad_evals, visual_evals)
 

--- a/creative_eval/config.py
+++ b/creative_eval/config.py
@@ -1,0 +1,40 @@
+"""Configuration for creative evaluation."""
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class EvalConfig:
+    """Configuration for the creative evaluation pipeline."""
+
+    # Evaluation model (judge)
+    eval_model: str = "gemini-2.5-pro"
+
+    # Score thresholds
+    passing_threshold: float = 0.7
+    max_retries: int = 3
+
+    # Scoring dimensions and weights for ad copy
+    ad_copy_dimensions: list[str] = field(default_factory=lambda: [
+        "strategic_alignment",
+        "trend_authenticity",
+        "platform_viability",
+        "copy_quality",
+        "audience_fit",
+        "call_to_action_strength",
+    ])
+
+    # Scoring dimensions and weights for visual concepts
+    visual_dimensions: list[str] = field(default_factory=lambda: [
+        "trend_visual_connection",
+        "brand_product_representation",
+        "audience_appeal",
+        "prompt_technical_quality",
+        "stopping_power",
+        "concept_coherence",
+    ])
+
+    # GCP settings (inherit from environment)
+    project_id: str = field(default_factory=lambda: os.getenv("GOOGLE_CLOUD_PROJECT", ""))
+    location: str = field(default_factory=lambda: os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1"))

--- a/creative_eval/config.py
+++ b/creative_eval/config.py
@@ -15,26 +15,40 @@ class EvalConfig:
     passing_threshold: float = 0.7
     max_retries: int = 3
 
+    # Max concurrent judge calls. Each creative is scored by an independent
+    # Gemini call, so evaluating them in a thread pool cuts eval wall-clock from
+    # ~N*28s (sequential) to roughly one call's latency. Keep this at/above the
+    # typical creative count (6 ad copies + 6 visual concepts = 12).
+    max_eval_workers: int = 12
+
     # Scoring dimensions and weights for ad copy
-    ad_copy_dimensions: list[str] = field(default_factory=lambda: [
-        "strategic_alignment",
-        "trend_authenticity",
-        "platform_viability",
-        "copy_quality",
-        "audience_fit",
-        "call_to_action_strength",
-    ])
+    ad_copy_dimensions: list[str] = field(
+        default_factory=lambda: [
+            "strategic_alignment",
+            "trend_authenticity",
+            "platform_viability",
+            "copy_quality",
+            "audience_fit",
+            "call_to_action_strength",
+        ]
+    )
 
     # Scoring dimensions and weights for visual concepts
-    visual_dimensions: list[str] = field(default_factory=lambda: [
-        "trend_visual_connection",
-        "brand_product_representation",
-        "audience_appeal",
-        "prompt_technical_quality",
-        "stopping_power",
-        "concept_coherence",
-    ])
+    visual_dimensions: list[str] = field(
+        default_factory=lambda: [
+            "trend_visual_connection",
+            "brand_product_representation",
+            "audience_appeal",
+            "prompt_technical_quality",
+            "stopping_power",
+            "concept_coherence",
+        ]
+    )
 
     # GCP settings (inherit from environment)
-    project_id: str = field(default_factory=lambda: os.getenv("GOOGLE_CLOUD_PROJECT", ""))
-    location: str = field(default_factory=lambda: os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1"))
+    project_id: str = field(
+        default_factory=lambda: os.getenv("GOOGLE_CLOUD_PROJECT", "")
+    )
+    location: str = field(
+        default_factory=lambda: os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+    )

--- a/creative_eval/evaluate.py
+++ b/creative_eval/evaluate.py
@@ -1,0 +1,287 @@
+"""Standalone creative evaluation pipeline (no ADK dependency).
+
+Usage:
+    from creative_eval.evaluate import evaluate_creatives
+    from creative_eval.config import EvalConfig
+
+    report = evaluate_creatives(
+        campaign_context={...},
+        ad_copies=[...],          # list of FinalAdCopy dicts
+        visual_concepts=[...],    # list of VisualConceptFinal dicts
+        config=EvalConfig(),
+    )
+"""
+
+import json
+import logging
+from google import genai
+
+from .config import EvalConfig
+from .schemas import (
+    AdCopyEvaluation,
+    VisualConceptEvaluation,
+    CreativeEvaluationReport,
+    CreativeScore,
+    EvalVerdict,
+    EvaluationSummary,
+)
+from . import prompts
+
+logger = logging.getLogger(__name__)
+
+
+def _get_client(config: EvalConfig) -> genai.Client:
+    """Create a Gemini client."""
+    return genai.Client(
+        vertexai=True,
+        project=config.project_id,
+        location=config.location,
+    )
+
+
+def _score_from_verdicts(
+    verdicts: list[EvalVerdict], threshold: float
+) -> CreativeScore:
+    """Compute an aggregate CreativeScore from individual verdicts."""
+    if not verdicts:
+        return CreativeScore(
+            overall_score=0.0,
+            passed=False,
+            verdicts=[],
+            strengths=[],
+            improvements=[],
+        )
+
+    avg_score = sum(v.score for v in verdicts) / (len(verdicts) * 10)
+    passed = avg_score >= threshold
+
+    strengths = [
+        v.dimension for v in sorted(verdicts, key=lambda v: v.score, reverse=True)
+        if v.verdict == "pass"
+    ][:3]
+
+    improvements = [
+        v.dimension for v in sorted(verdicts, key=lambda v: v.score)
+        if v.verdict == "fail"
+    ][:3]
+
+    return CreativeScore(
+        overall_score=round(avg_score, 3),
+        passed=passed,
+        verdicts=verdicts,
+        strengths=strengths,
+        improvements=improvements,
+    )
+
+
+def evaluate_ad_copy(
+    ad_copy: dict,
+    campaign_context: dict,
+    config: EvalConfig,
+    client: genai.Client | None = None,
+) -> AdCopyEvaluation:
+    """Evaluate a single ad copy using Gemini-as-judge.
+
+    Args:
+        ad_copy: Dict with FinalAdCopy fields.
+        campaign_context: Dict with brand, target_product, target_audience,
+                          key_selling_points, target_search_trend.
+        config: Evaluation configuration.
+        client: Optional pre-created Gemini client.
+
+    Returns:
+        AdCopyEvaluation with per-dimension scores.
+    """
+    if client is None:
+        client = _get_client(config)
+
+    # Build the prompt
+    user_prompt = prompts.AD_COPY_EVAL_USER.format(
+        **campaign_context,
+        **ad_copy,
+    )
+
+    try:
+        response = client.models.generate_content(
+            model=config.eval_model,
+            contents=user_prompt,
+            config=genai.types.GenerateContentConfig(
+                system_instruction=prompts.AD_COPY_EVAL_SYSTEM,
+                response_mime_type="application/json",
+                response_schema=AdCopyEvaluation,
+                temperature=0.3,
+            ),
+        )
+
+        result = AdCopyEvaluation.model_validate_json(response.text)
+
+        # Recompute overall_score from verdicts for consistency
+        recomputed = _score_from_verdicts(result.score.verdicts, config.passing_threshold)
+        result.score.overall_score = recomputed.overall_score
+        result.score.passed = recomputed.passed
+
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to evaluate ad copy {ad_copy.get('original_id', '?')}: {e}")
+        # Return a zero-score evaluation on failure
+        return AdCopyEvaluation(
+            original_id=ad_copy.get("original_id", 0),
+            headline=ad_copy.get("headline", ""),
+            tone_style=ad_copy.get("tone_style", ""),
+            score=CreativeScore(
+                overall_score=0.0,
+                passed=False,
+                verdicts=[],
+                strengths=[],
+                improvements=["evaluation_failed"],
+            ),
+        )
+
+
+def evaluate_visual_concept(
+    visual_concept: dict,
+    campaign_context: dict,
+    config: EvalConfig,
+    client: genai.Client | None = None,
+) -> VisualConceptEvaluation:
+    """Evaluate a single visual concept using Gemini-as-judge.
+
+    Args:
+        visual_concept: Dict with VisualConceptFinal fields.
+        campaign_context: Dict with brand, target_product, target_audience,
+                          key_selling_points, target_search_trend.
+        config: Evaluation configuration.
+        client: Optional pre-created Gemini client.
+
+    Returns:
+        VisualConceptEvaluation with per-dimension scores.
+    """
+    if client is None:
+        client = _get_client(config)
+
+    user_prompt = prompts.VISUAL_CONCEPT_EVAL_USER.format(
+        **campaign_context,
+        **visual_concept,
+    )
+
+    try:
+        response = client.models.generate_content(
+            model=config.eval_model,
+            contents=user_prompt,
+            config=genai.types.GenerateContentConfig(
+                system_instruction=prompts.VISUAL_CONCEPT_EVAL_SYSTEM,
+                response_mime_type="application/json",
+                response_schema=VisualConceptEvaluation,
+                temperature=0.3,
+            ),
+        )
+
+        result = VisualConceptEvaluation.model_validate_json(response.text)
+
+        recomputed = _score_from_verdicts(result.score.verdicts, config.passing_threshold)
+        result.score.overall_score = recomputed.overall_score
+        result.score.passed = recomputed.passed
+
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to evaluate visual concept {visual_concept.get('concept_name', '?')}: {e}")
+        return VisualConceptEvaluation(
+            ad_copy_id=visual_concept.get("ad_copy_id", 0),
+            concept_name=visual_concept.get("concept_name", ""),
+            score=CreativeScore(
+                overall_score=0.0,
+                passed=False,
+                verdicts=[],
+                strengths=[],
+                improvements=["evaluation_failed"],
+            ),
+        )
+
+
+def _build_summary(
+    ad_evals: list[AdCopyEvaluation],
+    visual_evals: list[VisualConceptEvaluation],
+) -> EvaluationSummary:
+    """Build aggregate statistics from individual evaluations."""
+    ad_scores = [e.score.overall_score for e in ad_evals]
+    vis_scores = [e.score.overall_score for e in visual_evals]
+
+    total = len(ad_evals) + len(visual_evals)
+    passed = sum(1 for e in ad_evals if e.score.passed) + sum(1 for e in visual_evals if e.score.passed)
+
+    # Find weakest dimensions across all verdicts
+    dim_scores: dict[str, list[int]] = {}
+    for eval_item in [*ad_evals, *visual_evals]:
+        for v in eval_item.score.verdicts:
+            dim_scores.setdefault(v.dimension, []).append(v.score)
+
+    dim_avgs = {dim: sum(s) / len(s) for dim, s in dim_scores.items()}
+    weakest = sorted(dim_avgs, key=dim_avgs.get)[:3]
+
+    return EvaluationSummary(
+        total_ad_copies=len(ad_evals),
+        ad_copies_passed=sum(1 for e in ad_evals if e.score.passed),
+        avg_ad_copy_score=round(sum(ad_scores) / len(ad_scores), 3) if ad_scores else 0.0,
+        total_visual_concepts=len(visual_evals),
+        visual_concepts_passed=sum(1 for e in visual_evals if e.score.passed),
+        avg_visual_score=round(sum(vis_scores) / len(vis_scores), 3) if vis_scores else 0.0,
+        overall_pass_rate=round(passed / total, 3) if total > 0 else 0.0,
+        weakest_dimensions=weakest,
+    )
+
+
+def evaluate_creatives(
+    campaign_context: dict,
+    ad_copies: list[dict],
+    visual_concepts: list[dict],
+    config: EvalConfig | None = None,
+) -> CreativeEvaluationReport:
+    """Evaluate all creatives from a single agent run.
+
+    Args:
+        campaign_context: Dict with keys: brand, target_product, target_audience,
+                          key_selling_points, target_search_trend.
+        ad_copies: List of FinalAdCopy dicts.
+        visual_concepts: List of VisualConceptFinal dicts.
+        config: Optional EvalConfig (uses defaults if None).
+
+    Returns:
+        CreativeEvaluationReport with per-creative and aggregate scores.
+    """
+    if config is None:
+        config = EvalConfig()
+
+    client = _get_client(config)
+
+    logger.info(f"Evaluating {len(ad_copies)} ad copies and {len(visual_concepts)} visual concepts...")
+
+    ad_evals = []
+    for i, ac in enumerate(ad_copies):
+        logger.info(f"  Evaluating ad copy {i + 1}/{len(ad_copies)}: {ac.get('headline', '?')}")
+        ad_evals.append(evaluate_ad_copy(ac, campaign_context, config, client))
+
+    visual_evals = []
+    for i, vc in enumerate(visual_concepts):
+        logger.info(f"  Evaluating visual concept {i + 1}/{len(visual_concepts)}: {vc.get('concept_name', '?')}")
+        visual_evals.append(evaluate_visual_concept(vc, campaign_context, config, client))
+
+    summary = _build_summary(ad_evals, visual_evals)
+
+    report = CreativeEvaluationReport(
+        brand=campaign_context["brand"],
+        target_product=campaign_context["target_product"],
+        target_search_trend=campaign_context["target_search_trend"],
+        ad_copy_evaluations=ad_evals,
+        visual_concept_evaluations=visual_evals,
+        summary=summary,
+    )
+
+    logger.info(
+        f"Evaluation complete: {summary.ad_copies_passed}/{summary.total_ad_copies} ad copies passed, "
+        f"{summary.visual_concepts_passed}/{summary.total_visual_concepts} visual concepts passed. "
+        f"Overall pass rate: {summary.overall_pass_rate:.1%}"
+    )
+
+    return report

--- a/creative_eval/evaluate.py
+++ b/creative_eval/evaluate.py
@@ -12,8 +12,9 @@ Usage:
     )
 """
 
-import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
+
 from google import genai
 
 from .config import EvalConfig
@@ -56,12 +57,14 @@ def _score_from_verdicts(
     passed = avg_score >= threshold
 
     strengths = [
-        v.dimension for v in sorted(verdicts, key=lambda v: v.score, reverse=True)
+        v.dimension
+        for v in sorted(verdicts, key=lambda v: v.score, reverse=True)
         if v.verdict == "pass"
     ][:3]
 
     improvements = [
-        v.dimension for v in sorted(verdicts, key=lambda v: v.score)
+        v.dimension
+        for v in sorted(verdicts, key=lambda v: v.score)
         if v.verdict == "fail"
     ][:3]
 
@@ -116,14 +119,18 @@ def evaluate_ad_copy(
         result = AdCopyEvaluation.model_validate_json(response.text)
 
         # Recompute overall_score from verdicts for consistency
-        recomputed = _score_from_verdicts(result.score.verdicts, config.passing_threshold)
+        recomputed = _score_from_verdicts(
+            result.score.verdicts, config.passing_threshold
+        )
         result.score.overall_score = recomputed.overall_score
         result.score.passed = recomputed.passed
 
         return result
 
     except Exception as e:
-        logger.error(f"Failed to evaluate ad copy {ad_copy.get('original_id', '?')}: {e}")
+        logger.error(
+            f"Failed to evaluate ad copy {ad_copy.get('original_id', '?')}: {e}"
+        )
         # Return a zero-score evaluation on failure
         return AdCopyEvaluation(
             original_id=ad_copy.get("original_id", 0),
@@ -179,14 +186,18 @@ def evaluate_visual_concept(
 
         result = VisualConceptEvaluation.model_validate_json(response.text)
 
-        recomputed = _score_from_verdicts(result.score.verdicts, config.passing_threshold)
+        recomputed = _score_from_verdicts(
+            result.score.verdicts, config.passing_threshold
+        )
         result.score.overall_score = recomputed.overall_score
         result.score.passed = recomputed.passed
 
         return result
 
     except Exception as e:
-        logger.error(f"Failed to evaluate visual concept {visual_concept.get('concept_name', '?')}: {e}")
+        logger.error(
+            f"Failed to evaluate visual concept {visual_concept.get('concept_name', '?')}: {e}"
+        )
         return VisualConceptEvaluation(
             ad_copy_id=visual_concept.get("ad_copy_id", 0),
             concept_name=visual_concept.get("concept_name", ""),
@@ -200,6 +211,48 @@ def evaluate_visual_concept(
         )
 
 
+def evaluate_all_concurrently(
+    ad_copies: list[dict],
+    visual_concepts: list[dict],
+    campaign_context: dict,
+    config: EvalConfig,
+    client: genai.Client | None = None,
+) -> tuple[list[AdCopyEvaluation], list[VisualConceptEvaluation]]:
+    """Evaluate all ad copies and visual concepts concurrently, preserving order.
+
+    Each creative is judged by an independent Gemini call, so running them in a
+    thread pool collapses eval wall-clock from ~N*28s (sequential) to roughly a
+    single call's latency. Results are returned in the same order as the inputs.
+    Individual failures are already handled inside evaluate_ad_copy /
+    evaluate_visual_concept (they return a zero-score evaluation), so a single
+    bad creative can't sink the whole batch.
+    """
+    if client is None:
+        client = _get_client(config)
+
+    total = len(ad_copies) + len(visual_concepts)
+    if total == 0:
+        return [], []
+
+    max_workers = max(1, min(config.max_eval_workers, total))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        ad_futures = [
+            executor.submit(evaluate_ad_copy, ac, campaign_context, config, client)
+            for ac in ad_copies
+        ]
+        vis_futures = [
+            executor.submit(
+                evaluate_visual_concept, vc, campaign_context, config, client
+            )
+            for vc in visual_concepts
+        ]
+        # .result() preserves submission order and re-raises unexpected errors
+        ad_evals = [f.result() for f in ad_futures]
+        visual_evals = [f.result() for f in vis_futures]
+
+    return ad_evals, visual_evals
+
+
 def _build_summary(
     ad_evals: list[AdCopyEvaluation],
     visual_evals: list[VisualConceptEvaluation],
@@ -209,7 +262,9 @@ def _build_summary(
     vis_scores = [e.score.overall_score for e in visual_evals]
 
     total = len(ad_evals) + len(visual_evals)
-    passed = sum(1 for e in ad_evals if e.score.passed) + sum(1 for e in visual_evals if e.score.passed)
+    passed = sum(1 for e in ad_evals if e.score.passed) + sum(
+        1 for e in visual_evals if e.score.passed
+    )
 
     # Find weakest dimensions across all verdicts
     dim_scores: dict[str, list[int]] = {}
@@ -223,10 +278,14 @@ def _build_summary(
     return EvaluationSummary(
         total_ad_copies=len(ad_evals),
         ad_copies_passed=sum(1 for e in ad_evals if e.score.passed),
-        avg_ad_copy_score=round(sum(ad_scores) / len(ad_scores), 3) if ad_scores else 0.0,
+        avg_ad_copy_score=round(sum(ad_scores) / len(ad_scores), 3)
+        if ad_scores
+        else 0.0,
         total_visual_concepts=len(visual_evals),
         visual_concepts_passed=sum(1 for e in visual_evals if e.score.passed),
-        avg_visual_score=round(sum(vis_scores) / len(vis_scores), 3) if vis_scores else 0.0,
+        avg_visual_score=round(sum(vis_scores) / len(vis_scores), 3)
+        if vis_scores
+        else 0.0,
         overall_pass_rate=round(passed / total, 3) if total > 0 else 0.0,
         weakest_dimensions=weakest,
     )
@@ -255,17 +314,14 @@ def evaluate_creatives(
 
     client = _get_client(config)
 
-    logger.info(f"Evaluating {len(ad_copies)} ad copies and {len(visual_concepts)} visual concepts...")
+    logger.info(
+        f"Evaluating {len(ad_copies)} ad copies and {len(visual_concepts)} visual "
+        f"concepts concurrently (max {config.max_eval_workers} workers)..."
+    )
 
-    ad_evals = []
-    for i, ac in enumerate(ad_copies):
-        logger.info(f"  Evaluating ad copy {i + 1}/{len(ad_copies)}: {ac.get('headline', '?')}")
-        ad_evals.append(evaluate_ad_copy(ac, campaign_context, config, client))
-
-    visual_evals = []
-    for i, vc in enumerate(visual_concepts):
-        logger.info(f"  Evaluating visual concept {i + 1}/{len(visual_concepts)}: {vc.get('concept_name', '?')}")
-        visual_evals.append(evaluate_visual_concept(vc, campaign_context, config, client))
+    ad_evals, visual_evals = evaluate_all_concurrently(
+        ad_copies, visual_concepts, campaign_context, config, client
+    )
 
     summary = _build_summary(ad_evals, visual_evals)
 

--- a/creative_eval/prompts.py
+++ b/creative_eval/prompts.py
@@ -1,0 +1,113 @@
+"""Evaluation prompts for creative scoring."""
+
+AD_COPY_EVAL_SYSTEM = """You are an expert advertising strategist and creative quality evaluator.
+Your task is to rigorously score a finalized ad copy against specific evaluation dimensions.
+
+You will receive:
+- Campaign context (brand, product, audience, trend)
+- The ad copy to evaluate (headline, body, caption, CTA, etc.)
+- A list of evaluation dimensions to score
+
+For EACH dimension, provide:
+- A score from 1-10
+- A verdict: "pass" (score >= 7) or "fail" (score < 7)
+- A 1-2 sentence rationale
+
+Then provide an overall assessment with strengths and improvements."""
+
+AD_COPY_EVAL_USER = """Evaluate this ad copy against the campaign context.
+
+<CAMPAIGN_CONTEXT>
+Brand: {brand}
+Target Product: {target_product}
+Target Audience: {target_audience}
+Key Selling Points: {key_selling_points}
+Target Search Trend: {target_search_trend}
+</CAMPAIGN_CONTEXT>
+
+<AD_COPY>
+Headline: {headline}
+Body Text: {body_text}
+Tone/Style: {tone_style}
+Trend Connection: {trend_connection}
+Audience Appeal: {audience_appeal_rationale}
+Social Caption: {social_caption}
+Call to Action: {call_to_action}
+Performance Rationale: {detailed_performance_rationale}
+</AD_COPY>
+
+<EVALUATION_DIMENSIONS>
+Score each dimension from 1-10:
+
+1. **strategic_alignment**: How well does the ad copy synthesize the product, key selling points, and target audience? Does the headline/body accurately represent the brand and product benefits?
+
+2. **trend_authenticity**: Does the use of the trending topic feel natural, relevant, and not forced? Is the trend connection genuine or superficial?
+
+3. **platform_viability**: Is the tone, length, and style highly suitable for Instagram/TikTok? Would this perform well in a fast-scrolling social media feed?
+
+4. **copy_quality**: Is the headline compelling and clear? Is the body text concise yet persuasive? Is the writing grammatically correct and polished?
+
+5. **audience_fit**: Would the target audience specifically engage with this? Does the messaging resonate with their interests, values, and communication style?
+
+6. **call_to_action_strength**: Is the CTA compelling, action-oriented, and specific? Does it create urgency or desire?
+</EVALUATION_DIMENSIONS>
+
+**Output a single JSON object matching the AdCopyEvaluation schema.**"""
+
+
+VISUAL_CONCEPT_EVAL_SYSTEM = """You are an expert visual creative director and advertising evaluator.
+Your task is to rigorously score a finalized visual concept against specific evaluation dimensions.
+
+You will receive:
+- Campaign context (brand, product, audience, trend)
+- The visual concept to evaluate (concept name, summary, image prompt, etc.)
+- A list of evaluation dimensions to score
+
+For EACH dimension, provide:
+- A score from 1-10
+- A verdict: "pass" (score >= 7) or "fail" (score < 7)
+- A 1-2 sentence rationale
+
+Then provide an overall assessment with strengths and improvements."""
+
+VISUAL_CONCEPT_EVAL_USER = """Evaluate this visual concept against the campaign context.
+
+<CAMPAIGN_CONTEXT>
+Brand: {brand}
+Target Product: {target_product}
+Target Audience: {target_audience}
+Key Selling Points: {key_selling_points}
+Target Search Trend: {target_search_trend}
+</CAMPAIGN_CONTEXT>
+
+<VISUAL_CONCEPT>
+Concept Name: {concept_name}
+Trend: {trend}
+Trend Reference: {trend_reference}
+Markets Product: {markets_product}
+Audience Appeal: {audience_appeal}
+Selection Rationale: {selection_rationale}
+Headline: {headline}
+Social Caption: {social_caption}
+Call to Action: {call_to_action}
+Concept Summary: {concept_summary}
+Image Generation Prompt: {image_generation_prompt}
+</VISUAL_CONCEPT>
+
+<EVALUATION_DIMENSIONS>
+Score each dimension from 1-10:
+
+1. **trend_visual_connection**: Does the visual concept naturally and creatively incorporate the trending topic? Is the connection visually clear without being forced?
+
+2. **brand_product_representation**: Does the concept accurately and attractively represent the brand and product? Would viewers correctly identify what is being advertised?
+
+3. **audience_appeal**: Would the target audience find this visually compelling? Does the style, tone, and aesthetic match their preferences?
+
+4. **prompt_technical_quality**: Is the image generation prompt technically strong? Does it specify style, lighting, composition, aspect ratio, and use high-fidelity keywords? Is it over 100 words?
+
+5. **stopping_power**: Would this image stop someone scrolling through a social media feed? Does it have visual impact, strong composition, and emotional resonance?
+
+6. **concept_coherence**: Do all elements (headline, caption, CTA, visual) work together as a unified creative? Is the message consistent across copy and visual?
+</EVALUATION_DIMENSIONS>
+
+**Output a single JSON object matching the VisualConceptEvaluation schema.**"""

--- a/creative_eval/run_eval_test.py
+++ b/creative_eval/run_eval_test.py
@@ -1,0 +1,157 @@
+"""Quick test script to run creative evaluation against sample data.
+
+Usage:
+    uv run python -m creative_eval.run_eval_test
+"""
+
+import json
+import logging
+
+from .config import EvalConfig
+from .evaluate import evaluate_creatives
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+# Sample campaign context
+CAMPAIGN_CONTEXT = {
+    "brand": "Paul Reed Smith (PRS)",
+    "target_product": "PRS SE CE24 Electric Guitar",
+    "target_audience": "millennials who follow jam bands (e.g., Widespread Panic and Phish), respond positively to nostalgic messages, and love surreal memes",
+    "key_selling_points": "The 85/15 S Humbucker pickups deliver a wide tonal range, from thick humbucker tones to clear single-coil sounds, making the guitar suitable for various genres.",
+    "target_search_trend": "tswift engaged",
+}
+
+# Sample finalized ad copies (realistic outputs from creative_agent)
+SAMPLE_AD_COPIES = [
+    {
+        "original_id": 1,
+        "tone_style": "Humorous",
+        "headline": "She Said Yes, You Said Solo",
+        "body_text": "While the world celebrates Taylor's ring, celebrate your own commitment — to tone. The PRS SE CE24's 85/15 S pickups go from thick humbuckers to sparkling single-coils faster than you can say 'I do.'",
+        "trend_connection": "Playfully ties the Taylor Swift engagement buzz to a musician's commitment to their instrument and sound.",
+        "audience_appeal_rationale": "Jam band millennials appreciate clever wordplay and the idea of being 'married' to their craft.",
+        "social_caption": "She's got the ring. You've got the riff. #PRS #SE_CE24",
+        "call_to_action": "Find your perfect match — shop the SE CE24 now",
+        "detailed_performance_rationale": "Combines trending pop culture moment with relatable musician humor. The wordplay creates shareable social content while highlighting the guitar's versatility.",
+    },
+    {
+        "original_id": 2,
+        "tone_style": "Aspirational",
+        "headline": "Every Love Story Deserves a Soundtrack",
+        "body_text": "The world is celebrating love right now. Add your voice to the chorus with the PRS SE CE24 — an instrument built to make every moment legendary, from stadium anthems to intimate serenades.",
+        "trend_connection": "Uses the universal love theme sparked by Taylor Swift's engagement to position the guitar as the soundtrack to life's biggest moments.",
+        "audience_appeal_rationale": "Appeals to musicians who see their playing as part of life's emotional tapestry, resonating with the nostalgic sensibilities of jam band fans.",
+        "social_caption": "Write the soundtrack to your own love story 🎸 #PRS #SE_CE24",
+        "call_to_action": "Start your next chapter — explore the SE CE24",
+        "detailed_performance_rationale": "Elevates the product by connecting it to universal emotional moments. The aspirational tone aligns with the dream of creating meaningful music.",
+    },
+    {
+        "original_id": 3,
+        "tone_style": "Relatable/Meme-based",
+        "headline": "POV: Your Guitar is More Reliable Than Any Relationship",
+        "body_text": "Trends come and go. Engagements make headlines. But your PRS SE CE24? She's always in tune (unlike your ex). 85/15 pickups that never ghost you.",
+        "trend_connection": "Leverages the engagement news cycle with a self-deprecating, meme-ready comparison between relationships and the reliability of a great guitar.",
+        "audience_appeal_rationale": "The meme-native, self-deprecating humor resonates strongly with millennials who consume surreal and ironic content.",
+        "social_caption": "relationships are temporary. tone is forever. #PRS #SE_CE24 #neverghosts",
+        "call_to_action": "Commit to great tone — grab the SE CE24",
+        "detailed_performance_rationale": "Meme-format copy is highly shareable on Instagram/TikTok. The contrast between fleeting trends and lasting guitar quality creates memorable, scroll-stopping content.",
+    },
+]
+
+# Sample finalized visual concepts
+SAMPLE_VISUAL_CONCEPTS = [
+    {
+        "ad_copy_id": 1,
+        "concept_name": "The Proposal Riff",
+        "trend": "tswift engaged",
+        "trend_reference": "A guitarist on one knee presenting a PRS SE CE24 like an engagement ring, mirroring the trending engagement imagery.",
+        "markets_product": "Centers the PRS SE CE24 as the focal point, showcasing its elegant design and craftsmanship in a dramatic setting.",
+        "audience_appeal": "The humorous subversion of the proposal scene appeals to musicians who joke about their relationship with their instruments.",
+        "selection_rationale": "Highest viral potential due to the visual pun. Immediately recognizable reference to the trending topic with clear product placement.",
+        "headline": "She Said Yes, You Said Solo",
+        "social_caption": "She's got the ring. You've got the riff. #PRS #SE_CE24",
+        "call_to_action": "Find your perfect match — shop the SE CE24 now",
+        "concept_summary": "A cinematic scene of a guitarist on one knee presenting a PRS SE CE24 to an imaginary audience, spotlight illuminating the guitar's finish like a diamond ring, in a dimly lit concert venue.",
+        "image_generation_prompt": "Photorealistic 9:16 vertical portrait of a male musician in his 30s kneeling on a dark concert stage, dramatically presenting a PRS SE CE24 electric guitar as if proposing. The guitar is held at eye level, angled to catch a single warm spotlight that creates a brilliant gleam on its sunburst finish. The background is a blurred, atmospheric concert venue with soft amber bokeh lights suggesting a crowd. Shot with a 85mm telephoto lens, shallow depth of field, cinematic color grading with warm amber tones and deep shadows. Award-winning studio lighting quality, 8K resolution, ultra-detailed texture on the guitar's maple top and chrome hardware.",
+    },
+    {
+        "ad_copy_id": 3,
+        "concept_name": "The Ghost-Free Zone",
+        "trend": "tswift engaged",
+        "trend_reference": "Uses the cultural conversation around relationships and commitment sparked by the engagement news, subverted through meme-culture visual language.",
+        "markets_product": "Features the PRS SE CE24 as the 'reliable partner' in a split-screen comparison, highlighting its premium build quality.",
+        "audience_appeal": "Meme-native visual format that millennials instantly recognize and share, with ironic humor about relationship reliability vs guitar reliability.",
+        "selection_rationale": "Strong meme potential with split-screen format. The visual contrast is immediately engaging and the message is clear without reading the copy.",
+        "headline": "POV: Your Guitar is More Reliable Than Any Relationship",
+        "social_caption": "relationships are temporary. tone is forever. #PRS #SE_CE24 #neverghosts",
+        "call_to_action": "Commit to great tone — grab the SE CE24",
+        "concept_summary": "A meme-style split-screen comparing a 'ghosted' phone notification on the left with a pristine PRS SE CE24 bathed in warm light on the right, captioned with relationship vs guitar reliability humor.",
+        "image_generation_prompt": "Photorealistic 9:16 vertical split-screen social media meme format. Left half shows a cracked smartphone screen displaying a 'Read 2 days ago' message notification in cold blue light, conveying rejection and ghosting. Right half shows a pristine PRS SE CE24 electric guitar standing upright on a professional guitar stand, bathed in warm golden light from a studio softbox, with the guitar's sunburst finish gleaming. The contrast between cold rejection and warm reliability is stark. Clean white text overlay space at top. Shot in studio with professional product photography lighting, macro detail on guitar hardware and finish, 8K resolution, commercial photography quality.",
+    },
+]
+
+
+def main():
+    config = EvalConfig()
+    print(f"\nRunning creative evaluation with model: {config.eval_model}")
+    print(f"Passing threshold: {config.passing_threshold}")
+    print(f"Evaluating {len(SAMPLE_AD_COPIES)} ad copies and {len(SAMPLE_VISUAL_CONCEPTS)} visual concepts\n")
+    print("=" * 60)
+
+    report = evaluate_creatives(
+        campaign_context=CAMPAIGN_CONTEXT,
+        ad_copies=SAMPLE_AD_COPIES,
+        visual_concepts=SAMPLE_VISUAL_CONCEPTS,
+        config=config,
+    )
+
+    # Print results
+    print("\n" + "=" * 60)
+    print("EVALUATION RESULTS")
+    print("=" * 60)
+
+    print(f"\n--- Ad Copy Scores ---")
+    for ac_eval in report.ad_copy_evaluations:
+        status = "PASS" if ac_eval.score.passed else "FAIL"
+        print(f"\n  [{status}] #{ac_eval.original_id} \"{ac_eval.headline}\" ({ac_eval.tone_style})")
+        print(f"    Overall: {ac_eval.score.overall_score:.1%}")
+        for v in ac_eval.score.verdicts:
+            v_status = "+" if v.verdict == "pass" else "-"
+            print(f"    [{v_status}] {v.dimension}: {v.score}/10 — {v.rationale}")
+        if ac_eval.score.strengths:
+            print(f"    Strengths: {', '.join(ac_eval.score.strengths)}")
+        if ac_eval.score.improvements:
+            print(f"    Improve: {', '.join(ac_eval.score.improvements)}")
+
+    print(f"\n--- Visual Concept Scores ---")
+    for vc_eval in report.visual_concept_evaluations:
+        status = "PASS" if vc_eval.score.passed else "FAIL"
+        print(f"\n  [{status}] \"{vc_eval.concept_name}\"")
+        print(f"    Overall: {vc_eval.score.overall_score:.1%}")
+        for v in vc_eval.score.verdicts:
+            v_status = "+" if v.verdict == "pass" else "-"
+            print(f"    [{v_status}] {v.dimension}: {v.score}/10 — {v.rationale}")
+        if vc_eval.score.strengths:
+            print(f"    Strengths: {', '.join(vc_eval.score.strengths)}")
+        if vc_eval.score.improvements:
+            print(f"    Improve: {', '.join(vc_eval.score.improvements)}")
+
+    print(f"\n--- Summary ---")
+    s = report.summary
+    print(f"  Ad copies:       {s.ad_copies_passed}/{s.total_ad_copies} passed (avg: {s.avg_ad_copy_score:.1%})")
+    print(f"  Visual concepts: {s.visual_concepts_passed}/{s.total_visual_concepts} passed (avg: {s.avg_visual_score:.1%})")
+    print(f"  Overall pass rate: {s.overall_pass_rate:.1%}")
+    print(f"  Weakest dimensions: {', '.join(s.weakest_dimensions)}")
+    print("=" * 60)
+
+    # Save full report
+    report_path = "creative_eval_test_report.json"
+    with open(report_path, "w") as f:
+        f.write(report.model_dump_json(indent=2))
+    print(f"\nFull report saved to: {report_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/creative_eval/schemas.py
+++ b/creative_eval/schemas.py
@@ -1,0 +1,98 @@
+"""Pydantic schemas for creative evaluation results."""
+
+from __future__ import annotations
+
+from typing import Literal
+from pydantic import BaseModel, Field
+
+
+class EvalVerdict(BaseModel):
+    """A single rubric verdict — pass/fail on one evaluation dimension."""
+
+    dimension: str = Field(
+        description="The evaluation dimension (e.g., 'trend_authenticity', 'copy_quality')."
+    )
+    score: int = Field(
+        description="Score from 1 to 10 for this dimension.",
+        ge=1,
+        le=10,
+    )
+    verdict: Literal["pass", "fail"] = Field(
+        description="'pass' if score >= 7, 'fail' otherwise."
+    )
+    rationale: str = Field(
+        description="1-2 sentence explanation of the score."
+    )
+
+
+class CreativeScore(BaseModel):
+    """Aggregate score for a single creative (ad copy or visual concept)."""
+
+    overall_score: float = Field(
+        description="Weighted average score across all dimensions (0.0-1.0).",
+        ge=0.0,
+        le=1.0,
+    )
+    passed: bool = Field(
+        description="True if overall_score >= passing threshold."
+    )
+    verdicts: list[EvalVerdict] = Field(
+        description="Per-dimension verdicts."
+    )
+    strengths: list[str] = Field(
+        description="Top 2-3 strengths identified."
+    )
+    improvements: list[str] = Field(
+        description="Top 2-3 suggested improvements."
+    )
+
+
+class AdCopyEvaluation(BaseModel):
+    """Evaluation result for a single finalized ad copy."""
+
+    original_id: int = Field(description="Maps to FinalAdCopy.original_id.")
+    headline: str = Field(description="The headline that was evaluated.")
+    tone_style: str = Field(description="The tone/style of this ad copy.")
+    score: CreativeScore = Field(description="Scoring details.")
+
+
+class VisualConceptEvaluation(BaseModel):
+    """Evaluation result for a single finalized visual concept."""
+
+    ad_copy_id: int = Field(description="Maps to VisualConceptFinal.ad_copy_id.")
+    concept_name: str = Field(description="The concept that was evaluated.")
+    score: CreativeScore = Field(description="Scoring details.")
+
+
+class EvaluationSummary(BaseModel):
+    """Aggregate statistics for the evaluation report."""
+
+    total_ad_copies: int = Field(description="Number of ad copies evaluated.")
+    ad_copies_passed: int = Field(description="Number of ad copies that passed.")
+    avg_ad_copy_score: float = Field(description="Average score across ad copies.")
+    total_visual_concepts: int = Field(description="Number of visual concepts evaluated.")
+    visual_concepts_passed: int = Field(description="Number of visual concepts that passed.")
+    avg_visual_score: float = Field(description="Average score across visual concepts.")
+    overall_pass_rate: float = Field(
+        description="Combined pass rate across all creatives (0.0-1.0)."
+    )
+    weakest_dimensions: list[str] = Field(
+        description="Dimensions with the lowest average scores across all creatives."
+    )
+
+
+class CreativeEvaluationReport(BaseModel):
+    """Complete evaluation report for all creatives from a single agent run."""
+
+    brand: str = Field(description="The brand being evaluated.")
+    target_product: str = Field(description="The product being advertised.")
+    target_search_trend: str = Field(description="The trend used for this creative set.")
+    ad_copy_evaluations: list[AdCopyEvaluation] = Field(
+        description="Evaluation results for each finalized ad copy."
+    )
+    visual_concept_evaluations: list[VisualConceptEvaluation] = Field(
+        description="Evaluation results for each finalized visual concept."
+    )
+    summary: EvaluationSummary = Field(
+        description="Aggregate statistics across all creatives."
+    )

--- a/creative_eval_test_report.json
+++ b/creative_eval_test_report.json
@@ -1,0 +1,302 @@
+{
+  "brand": "Paul Reed Smith (PRS)",
+  "target_product": "PRS SE CE24 Electric Guitar",
+  "target_search_trend": "tswift engaged",
+  "ad_copy_evaluations": [
+    {
+      "original_id": 12345,
+      "headline": "She Said Yes, You Said Solo",
+      "tone_style": "Humorous",
+      "score": {
+        "overall_score": 0.867,
+        "passed": true,
+        "verdicts": [
+          {
+            "dimension": "strategic_alignment",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The copy expertly connects the trend-based narrative to the product's key selling point, the versatile 85/15 S pickups, making the benefit clear and memorable."
+          },
+          {
+            "dimension": "trend_authenticity",
+            "score": 8,
+            "verdict": "pass",
+            "rationale": "The ad uses the trend as a clever parallel rather than a forced endorsement, making the connection feel authentic to the brand's witty voice."
+          },
+          {
+            "dimension": "platform_viability",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "With a punchy headline, concise body, and shareable caption, this ad is perfectly structured to stop scrolling and perform well on fast-paced social feeds."
+          },
+          {
+            "dimension": "copy_quality",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "The wordplay is exceptional, from the headline to the CTA, creating a cohesive and highly polished piece of copy that is both persuasive and entertaining."
+          },
+          {
+            "dimension": "audience_fit",
+            "score": 8,
+            "verdict": "pass",
+            "rationale": "The ad's humor and focus on 'commitment to tone' strongly resonates with the dedicated, gear-focused mindset of millennial jam band enthusiasts."
+          },
+          {
+            "dimension": "call_to_action_strength",
+            "score": 8,
+            "verdict": "pass",
+            "rationale": "The CTA cleverly continues the ad's central theme ('Find your perfect match'), making it compelling and highly relevant even without explicit urgency."
+          }
+        ],
+        "strengths": [
+          "The core wordplay ('She Said Yes, You Said Solo') is an exceptionally strong and memorable hook.",
+          "Seamlessly integrates the key selling point (pickup versatility) into the humorous, trend-based narrative.",
+          "The tone and format are perfectly suited for social media, making the ad feel native to platforms like Instagram."
+        ],
+        "improvements": [
+          "The reliance on a mainstream pop culture moment, while clever, carries a minor risk of alienating the most anti-pop segment of the jam band audience.",
+          "The CTA could be strengthened by adding a soft-urgency element to encourage immediate action."
+        ]
+      }
+    },
+    {
+      "original_id": 1,
+      "headline": "Every Love Story Deserves a Soundtrack",
+      "tone_style": "Aspirational",
+      "score": {
+        "overall_score": 0.75,
+        "passed": true,
+        "verdicts": [
+          {
+            "dimension": "strategic_alignment",
+            "score": 7,
+            "verdict": "pass",
+            "rationale": "The copy aligns the guitar with an aspirational theme but misses the opportunity to explicitly connect this to the product's key selling point of tonal versatility."
+          },
+          {
+            "dimension": "trend_authenticity",
+            "score": 8,
+            "verdict": "pass",
+            "rationale": "The ad cleverly uses the universal theme of love, sparked by the trend, without being overly direct, making the connection feel authentic and tasteful."
+          },
+          {
+            "dimension": "platform_viability",
+            "score": 6,
+            "verdict": "fail",
+            "rationale": "While the copy is well-suited for Instagram's aesthetic, its thoughtful, aspirational tone may be too slow to capture attention effectively in a fast-scrolling TikTok feed."
+          },
+          {
+            "dimension": "copy_quality",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The copy is exceptionally well-written, with a compelling headline and evocative body text that is both polished and grammatically flawless."
+          },
+          {
+            "dimension": "audience_fit",
+            "score": 7,
+            "verdict": "pass",
+            "rationale": "The ad effectively taps into the nostalgic and emotional sensibilities of the audience but completely misses their described interest in surreal memes."
+          },
+          {
+            "dimension": "call_to_action_strength",
+            "score": 8,
+            "verdict": "pass",
+            "rationale": "The CTA is emotionally compelling and aligns perfectly with the ad's narrative, though it lacks urgency and uses a somewhat soft action verb."
+          }
+        ],
+        "strengths": [
+          "High-quality, evocative copywriting with a powerful headline.",
+          "Authentic and tasteful integration of a cultural trend.",
+          "Thematic CTA reinforces the ad's core narrative of life moments."
+        ],
+        "improvements": [
+          "More explicitly connect the emotional narrative to the product's key selling point of tonal versatility.",
+          "Adapt the format or hook for better performance on fast-paced platforms like TikTok.",
+          "Incorporate elements that appeal to the audience's stated interest in surreal humor, perhaps in the accompanying visual."
+        ]
+      }
+    },
+    {
+      "original_id": 12345,
+      "headline": "POV: Your Guitar is More Reliable Than Any Relationship",
+      "tone_style": "Relatable/Meme-based",
+      "score": {
+        "overall_score": 0.9,
+        "passed": true,
+        "verdicts": [
+          {
+            "dimension": "strategic_alignment",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The copy expertly integrates the product name (SE CE24) and key selling point (85/15 pickups) into the central creative theme, creating a cohesive and persuasive message."
+          },
+          {
+            "dimension": "trend_authenticity",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The ad cleverly references the 'engagement' news cycle trend without being overly direct, using it as a natural springboard for its core message of reliability."
+          },
+          {
+            "dimension": "platform_viability",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "The 'POV' meme format, short punchy text, and relatable humor are perfectly optimized for high engagement and shareability on Instagram and TikTok feeds."
+          },
+          {
+            "dimension": "copy_quality",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The writing is sharp, witty, and polished, with a compelling headline and clever parallelisms in the body text that make the message memorable."
+          },
+          {
+            "dimension": "audience_fit",
+            "score": 8,
+            "verdict": "pass",
+            "rationale": "This ad perfectly captures the meme-native, self-deprecating humor of the target millennial audience, though it could connect more directly to the 'jam band' sub-interest."
+          },
+          {
+            "dimension": "call_to_action_strength",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The CTA creatively extends the relationship metaphor ('Commit to great tone'), making it highly compelling, on-brand, and action-oriented."
+          }
+        ],
+        "strengths": [
+          "The use of the 'POV' meme format is perfectly suited for TikTok/Instagram, making the ad feel native and scroll-stopping.",
+          "The copy masterfully integrates the key selling point (85/15 pickups) into the central theme by personifying them as something that will 'never ghost you'.",
+          "The CTA 'Commit to great tone' is a brilliant continuation of the relationship metaphor, making it memorable and emotionally resonant."
+        ],
+        "improvements": [
+          "Strengthen the connection to the 'jam band' niche by referencing qualities like tonal versatility for improvisation or durability for long sets.",
+          "Consider A/B testing a slightly more surreal or absurd comparison to fully lean into the 'surreal memes' interest of the target audience."
+        ]
+      }
+    }
+  ],
+  "visual_concept_evaluations": [
+    {
+      "ad_copy_id": 12345,
+      "concept_name": "The Proposal Riff",
+      "score": {
+        "overall_score": 0.95,
+        "passed": true,
+        "verdicts": [
+          {
+            "dimension": "trend_visual_connection",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The concept creatively translates the 'engagement' trend into a clever visual pun that feels natural and humorous for the brand."
+          },
+          {
+            "dimension": "brand_product_representation",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "This concept makes the PRS guitar the absolute hero, using dramatic, desirable lighting to showcase its craftsmanship and beauty perfectly."
+          },
+          {
+            "dimension": "audience_appeal",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The surreal, meme-like humor of proposing with a guitar is perfectly aligned with the target audience's sensibilities and the musician trope of being 'married' to their instrument."
+          },
+          {
+            "dimension": "prompt_technical_quality",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "The prompt is exceptionally detailed, specifying composition, lighting, lens effects, and quality keywords, ensuring a high-fidelity, professional-grade visual output."
+          },
+          {
+            "dimension": "stopping_power",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The unusual and dramatic visual of a 'guitar proposal' is a strong scroll-stopper that immediately piques curiosity and creates visual impact."
+          },
+          {
+            "dimension": "concept_coherence",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "Every element, from the visual to the headline and CTA, flawlessly reinforces the central 'proposal' metaphor, creating a perfectly unified and clever creative."
+          }
+        ],
+        "strengths": [
+          "Exceptional concept coherence where all copy and visual elements reinforce the central 'proposal' metaphor.",
+          "The visual concept makes the product the hero, using dramatic lighting to showcase its craftsmanship and desirability.",
+          "The visual pun has high stopping power and strong appeal to the target audience's sense of humor."
+        ],
+        "improvements": [
+          "While the 'proposal' visual is strong on its own, ensure the connection to the specific 'tswift engaged' trend is clear enough for the audience.",
+          "Consider A/B testing the headline's humor, as it's a clever pun that could also be perceived as a 'dad joke' by some segments of the audience."
+        ]
+      }
+    },
+    {
+      "ad_copy_id": 1,
+      "concept_name": "The Ghost-Free Zone",
+      "score": {
+        "overall_score": 0.867,
+        "passed": true,
+        "verdicts": [
+          {
+            "dimension": "trend_visual_connection",
+            "score": 4,
+            "verdict": "fail",
+            "rationale": "The concept subverts the 'engagement' trend by focusing on relationship unreliability (ghosting), which is a weak and indirect connection to the positive news about commitment."
+          },
+          {
+            "dimension": "brand_product_representation",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "The concept and prompt are designed for premium product photography, ensuring the PRS SE CE24 is presented attractively and accurately as a high-quality instrument."
+          },
+          {
+            "dimension": "audience_appeal",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The split-screen meme format and ironic humor directly appeal to the target millennial audience's online culture and musician-centric priorities."
+          },
+          {
+            "dimension": "prompt_technical_quality",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "The prompt is technically superb, specifying aspect ratio, composition, lighting, emotional contrast, and high-fidelity keywords, leaving little room for misinterpretation by the AI."
+          },
+          {
+            "dimension": "stopping_power",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The strong visual dichotomy between the cold, blue phone screen and the warm, golden guitar creates immediate contrast and intrigue, effectively stopping a user's scroll."
+          },
+          {
+            "dimension": "concept_coherence",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "The visual, headline, caption, and CTA are perfectly aligned, creating a cohesive and clever message that reinforces the core concept from every angle."
+          }
+        ],
+        "strengths": [
+          "Excellent conceptual coherence, with all copy and visual elements working together seamlessly.",
+          "High audience appeal due to the native meme format and musician-centric humor.",
+          "Strong stopping power driven by the stark visual and emotional contrast in the split-screen layout."
+        ],
+        "improvements": [
+          "The connection to the 'tswift engaged' trend is tenuous and forced; the concept would be stronger standing on its own without this trend justification.",
+          "Consider leaning more into the 'surreal' aspect of the audience's meme preference for even greater distinction."
+        ]
+      }
+    }
+  ],
+  "summary": {
+    "total_ad_copies": 3,
+    "ad_copies_passed": 3,
+    "avg_ad_copy_score": 0.839,
+    "total_visual_concepts": 2,
+    "visual_concepts_passed": 2,
+    "avg_visual_score": 0.908,
+    "overall_pass_rate": 1.0,
+    "weakest_dimensions": [
+      "trend_visual_connection",
+      "audience_fit",
+      "strategic_alignment"
+    ]
+  }
+}

--- a/creative_eval_test_report.json
+++ b/creative_eval_test_report.json
@@ -8,119 +8,6 @@
       "headline": "She Said Yes, You Said Solo",
       "tone_style": "Humorous",
       "score": {
-        "overall_score": 0.867,
-        "passed": true,
-        "verdicts": [
-          {
-            "dimension": "strategic_alignment",
-            "score": 9,
-            "verdict": "pass",
-            "rationale": "The copy expertly connects the trend-based narrative to the product's key selling point, the versatile 85/15 S pickups, making the benefit clear and memorable."
-          },
-          {
-            "dimension": "trend_authenticity",
-            "score": 8,
-            "verdict": "pass",
-            "rationale": "The ad uses the trend as a clever parallel rather than a forced endorsement, making the connection feel authentic to the brand's witty voice."
-          },
-          {
-            "dimension": "platform_viability",
-            "score": 9,
-            "verdict": "pass",
-            "rationale": "With a punchy headline, concise body, and shareable caption, this ad is perfectly structured to stop scrolling and perform well on fast-paced social feeds."
-          },
-          {
-            "dimension": "copy_quality",
-            "score": 10,
-            "verdict": "pass",
-            "rationale": "The wordplay is exceptional, from the headline to the CTA, creating a cohesive and highly polished piece of copy that is both persuasive and entertaining."
-          },
-          {
-            "dimension": "audience_fit",
-            "score": 8,
-            "verdict": "pass",
-            "rationale": "The ad's humor and focus on 'commitment to tone' strongly resonates with the dedicated, gear-focused mindset of millennial jam band enthusiasts."
-          },
-          {
-            "dimension": "call_to_action_strength",
-            "score": 8,
-            "verdict": "pass",
-            "rationale": "The CTA cleverly continues the ad's central theme ('Find your perfect match'), making it compelling and highly relevant even without explicit urgency."
-          }
-        ],
-        "strengths": [
-          "The core wordplay ('She Said Yes, You Said Solo') is an exceptionally strong and memorable hook.",
-          "Seamlessly integrates the key selling point (pickup versatility) into the humorous, trend-based narrative.",
-          "The tone and format are perfectly suited for social media, making the ad feel native to platforms like Instagram."
-        ],
-        "improvements": [
-          "The reliance on a mainstream pop culture moment, while clever, carries a minor risk of alienating the most anti-pop segment of the jam band audience.",
-          "The CTA could be strengthened by adding a soft-urgency element to encourage immediate action."
-        ]
-      }
-    },
-    {
-      "original_id": 1,
-      "headline": "Every Love Story Deserves a Soundtrack",
-      "tone_style": "Aspirational",
-      "score": {
-        "overall_score": 0.75,
-        "passed": true,
-        "verdicts": [
-          {
-            "dimension": "strategic_alignment",
-            "score": 7,
-            "verdict": "pass",
-            "rationale": "The copy aligns the guitar with an aspirational theme but misses the opportunity to explicitly connect this to the product's key selling point of tonal versatility."
-          },
-          {
-            "dimension": "trend_authenticity",
-            "score": 8,
-            "verdict": "pass",
-            "rationale": "The ad cleverly uses the universal theme of love, sparked by the trend, without being overly direct, making the connection feel authentic and tasteful."
-          },
-          {
-            "dimension": "platform_viability",
-            "score": 6,
-            "verdict": "fail",
-            "rationale": "While the copy is well-suited for Instagram's aesthetic, its thoughtful, aspirational tone may be too slow to capture attention effectively in a fast-scrolling TikTok feed."
-          },
-          {
-            "dimension": "copy_quality",
-            "score": 9,
-            "verdict": "pass",
-            "rationale": "The copy is exceptionally well-written, with a compelling headline and evocative body text that is both polished and grammatically flawless."
-          },
-          {
-            "dimension": "audience_fit",
-            "score": 7,
-            "verdict": "pass",
-            "rationale": "The ad effectively taps into the nostalgic and emotional sensibilities of the audience but completely misses their described interest in surreal memes."
-          },
-          {
-            "dimension": "call_to_action_strength",
-            "score": 8,
-            "verdict": "pass",
-            "rationale": "The CTA is emotionally compelling and aligns perfectly with the ad's narrative, though it lacks urgency and uses a somewhat soft action verb."
-          }
-        ],
-        "strengths": [
-          "High-quality, evocative copywriting with a powerful headline.",
-          "Authentic and tasteful integration of a cultural trend.",
-          "Thematic CTA reinforces the ad's core narrative of life moments."
-        ],
-        "improvements": [
-          "More explicitly connect the emotional narrative to the product's key selling point of tonal versatility.",
-          "Adapt the format or hook for better performance on fast-paced platforms like TikTok.",
-          "Incorporate elements that appeal to the audience's stated interest in surreal humor, perhaps in the accompanying visual."
-        ]
-      }
-    },
-    {
-      "original_id": 12345,
-      "headline": "POV: Your Guitar is More Reliable Than Any Relationship",
-      "tone_style": "Relatable/Meme-based",
-      "score": {
         "overall_score": 0.9,
         "passed": true,
         "verdicts": [
@@ -128,54 +15,167 @@
             "dimension": "strategic_alignment",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The copy expertly integrates the product name (SE CE24) and key selling point (85/15 pickups) into the central creative theme, creating a cohesive and persuasive message."
+            "rationale": "The copy expertly connects the theme of 'commitment' to the musician's dedication to tone, directly integrating the key selling point of the versatile pickups."
           },
           {
             "dimension": "trend_authenticity",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The ad cleverly references the 'engagement' news cycle trend without being overly direct, using it as a natural springboard for its core message of reliability."
+            "rationale": "The ad uses the trend as a clever, humorous jumping-off point rather than a forced endorsement, making the connection feel witty and authentic."
           },
           {
             "dimension": "platform_viability",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The 'POV' meme format, short punchy text, and relatable humor are perfectly optimized for high engagement and shareability on Instagram and TikTok feeds."
+            "rationale": "The short, punchy headline, concise body, and shareable wordplay are perfectly optimized for a fast-scrolling social media feed like Instagram or TikTok."
           },
           {
             "dimension": "copy_quality",
-            "score": 9,
+            "score": 10,
             "verdict": "pass",
-            "rationale": "The writing is sharp, witty, and polished, with a compelling headline and clever parallelisms in the body text that make the message memorable."
+            "rationale": "The writing is exceptional, featuring clever parallel structures and wordplay that is both memorable and persuasive. The copy is polished and grammatically flawless."
           },
           {
             "dimension": "audience_fit",
             "score": 8,
             "verdict": "pass",
-            "rationale": "This ad perfectly captures the meme-native, self-deprecating humor of the target millennial audience, though it could connect more directly to the 'jam band' sub-interest."
+            "rationale": "The humorous, slightly detached take on a major pop culture event, combined with the focus on 'tone' and 'craft', strongly resonates with the musician-focused millennial audience."
           },
           {
             "dimension": "call_to_action_strength",
-            "score": 9,
+            "score": 8,
             "verdict": "pass",
-            "rationale": "The CTA creatively extends the relationship metaphor ('Commit to great tone'), making it highly compelling, on-brand, and action-oriented."
+            "rationale": "The CTA cleverly continues the 'commitment' theme with 'find your perfect match' and is both specific and action-oriented, creating strong desire."
           }
         ],
         "strengths": [
-          "The use of the 'POV' meme format is perfectly suited for TikTok/Instagram, making the ad feel native and scroll-stopping.",
-          "The copy masterfully integrates the key selling point (85/15 pickups) into the central theme by personifying them as something that will 'never ghost you'.",
-          "The CTA 'Commit to great tone' is a brilliant continuation of the relationship metaphor, making it memorable and emotionally resonant."
+          "Exceptional wordplay and humor ('She said yes, you said solo') make the copy highly memorable and shareable.",
+          "Seamlessly integrates a trending pop culture moment with a core product benefit (tonal versatility).",
+          "The copy is perfectly formatted for social media with a scroll-stopping headline and concise, impactful text."
         ],
         "improvements": [
-          "Strengthen the connection to the 'jam band' niche by referencing qualities like tonal versatility for improvisation or durability for long sets.",
-          "Consider A/B testing a slightly more surreal or absurd comparison to fully lean into the 'surreal memes' interest of the target audience."
+          "While the audience fit is strong, it could be even tighter by incorporating a subtle nod to jam band culture or aesthetics.",
+          "The CTA could be enhanced by adding a layer of urgency or a more direct benefit, such as 'Hear the versatility for yourself.'"
+        ]
+      }
+    },
+    {
+      "original_id": 12345,
+      "headline": "Every Love Story Deserves a Soundtrack",
+      "tone_style": "Aspirational",
+      "score": {
+        "overall_score": 0.567,
+        "passed": false,
+        "verdicts": [
+          {
+            "dimension": "strategic_alignment",
+            "score": 6,
+            "verdict": "fail",
+            "rationale": "The copy connects the product to an emotional benefit but fails to explicitly mention the key selling point of tonal versatility and only vaguely addresses the target audience."
+          },
+          {
+            "dimension": "trend_authenticity",
+            "score": 4,
+            "verdict": "fail",
+            "rationale": "The connection to the 'tswift engaged' trend is superficial, relying on a generic 'love' theme that feels opportunistic rather than genuine or clever."
+          },
+          {
+            "dimension": "platform_viability",
+            "score": 5,
+            "verdict": "fail",
+            "rationale": "The polished, earnest tone is not optimized for fast-scrolling, engagement-driven platforms like TikTok or Instagram, where it may fail to stop the scroll."
+          },
+          {
+            "dimension": "copy_quality",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The writing is grammatically flawless, professional, and emotionally evocative, with a strong, classic headline and persuasive body text."
+          },
+          {
+            "dimension": "audience_fit",
+            "score": 3,
+            "verdict": "fail",
+            "rationale": "The ad completely misses the specified audience of jam band fans who like surreal memes; the mainstream trend and earnest tone are a significant mismatch."
+          },
+          {
+            "dimension": "call_to_action_strength",
+            "score": 7,
+            "verdict": "pass",
+            "rationale": "The CTA is clear and thematically consistent with the ad's narrative, effectively framing the product as the start of a new journey."
+          }
+        ],
+        "strengths": [
+          "The copy quality is excellent, with polished, professional writing and an emotionally resonant headline.",
+          "The core concept of the guitar as the 'soundtrack to your life' is a strong, aspirational message for a musical instrument.",
+          "The CTA is thematically consistent with the overall narrative of the ad."
+        ],
+        "improvements": [
+          "Drastically improve audience fit by using language, humor, or references that resonate with jam band fans and their appreciation for surrealism.",
+          "Select a more authentic trend for this niche audience or abandon the trend-jacking approach for a more direct appeal.",
+          "Incorporate the key selling point (tonal versatility) more directly to add substance to the emotional appeal."
+        ]
+      }
+    },
+    {
+      "original_id": 1,
+      "headline": "POV: Your Guitar is More Reliable Than Any Relationship",
+      "tone_style": "Relatable/Meme-based",
+      "score": {
+        "overall_score": 0.917,
+        "passed": true,
+        "verdicts": [
+          {
+            "dimension": "strategic_alignment",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The copy masterfully weaves the product, a key feature (85/15 pickups), and the audience's meme-centric humor into a cohesive and compelling narrative."
+          },
+          {
+            "dimension": "trend_authenticity",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "It cleverly references the 'engagement' news cycle without being too direct, making the connection feel authentic and giving the ad a longer shelf-life."
+          },
+          {
+            "dimension": "platform_viability",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "The 'POV' format, short text, and meme-style humor are perfectly optimized for stopping the scroll on platforms like Instagram and TikTok."
+          },
+          {
+            "dimension": "copy_quality",
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The writing is sharp, witty, and concise, using clever wordplay ('pickups that never ghost you') to create a memorable and polished message."
+          },
+          {
+            "dimension": "audience_fit",
+            "score": 10,
+            "verdict": "pass",
+            "rationale": "This ad speaks the exact language of the target millennial audience, combining surreal meme culture with a relatable, slightly cynical musician's perspective."
+          },
+          {
+            "dimension": "call_to_action_strength",
+            "score": 8,
+            "verdict": "pass",
+            "rationale": "The CTA is strong and thematically consistent, framing the purchase as a 'commitment' to tone, which cleverly plays off the relationship theme."
+          }
+        ],
+        "strengths": [
+          "Exceptional audience and platform fit, perfectly leveraging meme culture and relatable humor.",
+          "Witty, high-quality copy that creatively integrates a product feature into the core message.",
+          "Authentic and clever use of a trending topic that avoids feeling forced or dated."
+        ],
+        "improvements": [
+          "The CTA, while good, could be slightly more urgent or provide a more concrete next step (e.g., 'Find a dealer').",
+          "Could more explicitly highlight the tonal *versatility* of the pickups, which was a key selling point, though the current focus on reliability is also very strong."
         ]
       }
     }
   ],
   "visual_concept_evaluations": [
     {
-      "ad_copy_id": 12345,
+      "ad_copy_id": 456,
       "concept_name": "The Proposal Riff",
       "score": {
         "overall_score": 0.95,
@@ -185,118 +185,119 @@
             "dimension": "trend_visual_connection",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The concept creatively translates the 'engagement' trend into a clever visual pun that feels natural and humorous for the brand."
+            "rationale": "The concept provides a clever, metaphorical interpretation of the 'engaged' trend rather than a literal one, making the connection creative and visually strong."
           },
           {
             "dimension": "brand_product_representation",
             "score": 10,
             "verdict": "pass",
-            "rationale": "This concept makes the PRS guitar the absolute hero, using dramatic, desirable lighting to showcase its craftsmanship and beauty perfectly."
+            "rationale": "The entire concept is built to hero the product, positioning the guitar as a precious, desirable object worthy of a proposal and ensuring it is the clear focal point."
           },
           {
             "dimension": "audience_appeal",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The surreal, meme-like humor of proposing with a guitar is perfectly aligned with the target audience's sensibilities and the musician trope of being 'married' to their instrument."
+            "rationale": "This concept perfectly taps into the 'inside joke' culture of dedicated musicians who view their instruments with deep affection, matching the audience's humor and passion."
           },
           {
             "dimension": "prompt_technical_quality",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The prompt is exceptionally detailed, specifying composition, lighting, lens effects, and quality keywords, ensuring a high-fidelity, professional-grade visual output."
+            "rationale": "The prompt is exceptionally detailed, specifying composition, professional lighting, lens choice, and high-fidelity details, leaving little room for error in generation."
           },
           {
             "dimension": "stopping_power",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The unusual and dramatic visual of a 'guitar proposal' is a strong scroll-stopper that immediately piques curiosity and creates visual impact."
+            "rationale": "The unusual, story-driven visual of a man proposing with a guitar is highly intriguing and combined with dramatic lighting, it has excellent potential to stop scrolling."
           },
           {
             "dimension": "concept_coherence",
             "score": 10,
             "verdict": "pass",
-            "rationale": "Every element, from the visual to the headline and CTA, flawlessly reinforces the central 'proposal' metaphor, creating a perfectly unified and clever creative."
+            "rationale": "The headline, caption, and CTA flawlessly extend the visual metaphor of the proposal, creating an exceptionally tight and clever creative package where all elements are in sync."
           }
         ],
         "strengths": [
-          "Exceptional concept coherence where all copy and visual elements reinforce the central 'proposal' metaphor.",
-          "The visual concept makes the product the hero, using dramatic lighting to showcase its craftsmanship and desirability.",
-          "The visual pun has high stopping power and strong appeal to the target audience's sense of humor."
+          "Perfectly coherent concept where the copy and visual work in harmony to execute a clever pun.",
+          "Excellent audience targeting that taps into the humor and passion of dedicated musicians.",
+          "The product is the undeniable hero of the visual, showcased in a dramatic and highly desirable way."
         ],
         "improvements": [
-          "While the 'proposal' visual is strong on its own, ensure the connection to the specific 'tswift engaged' trend is clear enough for the audience.",
-          "Consider A/B testing the headline's humor, as it's a clever pun that could also be perceived as a 'dad joke' by some segments of the audience."
+          "Consider creating a variant with a female musician to broaden the representation and appeal of the concept.",
+          "The core 'proposal' joke is strong, but ensure it lands even if the audience misses the timely 'tswift engaged' trend connection.",
+          "While the surrealism works for the target, a slightly more grounded version could be tested for broader appeal if needed."
         ]
       }
     },
     {
-      "ad_copy_id": 1,
+      "ad_copy_id": 12345,
       "concept_name": "The Ghost-Free Zone",
       "score": {
-        "overall_score": 0.867,
+        "overall_score": 0.833,
         "passed": true,
         "verdicts": [
           {
             "dimension": "trend_visual_connection",
             "score": 4,
             "verdict": "fail",
-            "rationale": "The concept subverts the 'engagement' trend by focusing on relationship unreliability (ghosting), which is a weak and indirect connection to the positive news about commitment."
+            "rationale": "The visual connection to 'tswift engaged' is extremely weak and indirect, relying on a thematic leap from 'commitment' to 'ghosting' that is not visually represented."
           },
           {
             "dimension": "brand_product_representation",
-            "score": 10,
+            "score": 9,
             "verdict": "pass",
-            "rationale": "The concept and prompt are designed for premium product photography, ensuring the PRS SE CE24 is presented attractively and accurately as a high-quality instrument."
+            "rationale": "The concept and prompt are designed to showcase the guitar in a highly desirable, premium light, ensuring the product is the hero and the brand is represented well."
           },
           {
             "dimension": "audience_appeal",
-            "score": 9,
+            "score": 8,
             "verdict": "pass",
-            "rationale": "The split-screen meme format and ironic humor directly appeal to the target millennial audience's online culture and musician-centric priorities."
+            "rationale": "The meme format and ironic humor about relationships vs. gear reliability are perfectly tailored to the millennial musician audience."
           },
           {
             "dimension": "prompt_technical_quality",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The prompt is technically superb, specifying aspect ratio, composition, lighting, emotional contrast, and high-fidelity keywords, leaving little room for misinterpretation by the AI."
+            "rationale": "The prompt is exceptionally detailed, specifying composition, lighting, aspect ratio, and high-fidelity keywords to ensure a high-quality, commercially viable image."
           },
           {
             "dimension": "stopping_power",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The strong visual dichotomy between the cold, blue phone screen and the warm, golden guitar creates immediate contrast and intrigue, effectively stopping a user's scroll."
+            "rationale": "The stark visual contrast between the cold/blue phone screen and the warm/golden guitar, combined with a familiar meme format, has excellent scroll-stopping potential."
           },
           {
             "dimension": "concept_coherence",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The visual, headline, caption, and CTA are perfectly aligned, creating a cohesive and clever message that reinforces the core concept from every angle."
+            "rationale": "All components—headline, visual, caption, and CTA—work in perfect harmony to deliver a single, clever, and consistent message."
           }
         ],
         "strengths": [
-          "Excellent conceptual coherence, with all copy and visual elements working together seamlessly.",
-          "High audience appeal due to the native meme format and musician-centric humor.",
-          "Strong stopping power driven by the stark visual and emotional contrast in the split-screen layout."
+          "Exceptional concept coherence where all elements (visual, headline, copy) work together perfectly.",
+          "Strong audience appeal through the use of a familiar and relevant meme format and ironic humor.",
+          "Technically superb image prompt that ensures high-quality, on-brand product representation."
         ],
         "improvements": [
-          "The connection to the 'tswift engaged' trend is tenuous and forced; the concept would be stronger standing on its own without this trend justification.",
-          "Consider leaning more into the 'surreal' aspect of the audience's meme preference for even greater distinction."
+          "The connection to the 'tswift engaged' trend is tenuous and feels forced; the concept is strong enough to stand on its own without it.",
+          "Find a trend that aligns more directly with the visual execution or drop the trend angle to improve authenticity."
         ]
       }
     }
   ],
   "summary": {
     "total_ad_copies": 3,
-    "ad_copies_passed": 3,
-    "avg_ad_copy_score": 0.839,
+    "ad_copies_passed": 2,
+    "avg_ad_copy_score": 0.795,
     "total_visual_concepts": 2,
     "visual_concepts_passed": 2,
-    "avg_visual_score": 0.908,
-    "overall_pass_rate": 1.0,
+    "avg_visual_score": 0.891,
+    "overall_pass_rate": 0.8,
     "weakest_dimensions": [
       "trend_visual_connection",
       "audience_fit",
-      "strategic_alignment"
+      "trend_authenticity"
     ]
   }
 }

--- a/creative_eval_test_report.json
+++ b/creative_eval_test_report.json
@@ -4,58 +4,58 @@
   "target_search_trend": "tswift engaged",
   "ad_copy_evaluations": [
     {
-      "original_id": 12345,
+      "original_id": 1,
       "headline": "She Said Yes, You Said Solo",
       "tone_style": "Humorous",
       "score": {
-        "overall_score": 0.9,
+        "overall_score": 0.867,
         "passed": true,
         "verdicts": [
           {
             "dimension": "strategic_alignment",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The copy expertly connects the theme of 'commitment' to the musician's dedication to tone, directly integrating the key selling point of the versatile pickups."
+            "rationale": "The copy effectively synthesizes the product's key selling point (pickup versatility) with a humorous narrative that aligns with the musician's mindset."
           },
           {
             "dimension": "trend_authenticity",
-            "score": 9,
+            "score": 8,
             "verdict": "pass",
-            "rationale": "The ad uses the trend as a clever, humorous jumping-off point rather than a forced endorsement, making the connection feel witty and authentic."
+            "rationale": "The ad cleverly pivots from the trending topic rather than just latching onto it, creating a relevant parallel between pop culture and a musician's dedication."
           },
           {
             "dimension": "platform_viability",
-            "score": 10,
+            "score": 9,
             "verdict": "pass",
-            "rationale": "The short, punchy headline, concise body, and shareable wordplay are perfectly optimized for a fast-scrolling social media feed like Instagram or TikTok."
+            "rationale": "The short, punchy headline and caption are perfectly suited for fast-scrolling social feeds, and the humorous angle is highly engaging."
           },
           {
             "dimension": "copy_quality",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The writing is exceptional, featuring clever parallel structures and wordplay that is both memorable and persuasive. The copy is polished and grammatically flawless."
+            "rationale": "The writing is exceptional, featuring clever, consistent wordplay and a polished, persuasive message from headline to body text."
           },
           {
             "dimension": "audience_fit",
-            "score": 8,
+            "score": 7,
             "verdict": "pass",
-            "rationale": "The humorous, slightly detached take on a major pop culture event, combined with the focus on 'tone' and 'craft', strongly resonates with the musician-focused millennial audience."
+            "rationale": "The humor and 'commitment to craft' theme will likely resonate, but using a mainstream pop culture figure is a slight gamble for this niche jam band audience."
           },
           {
             "dimension": "call_to_action_strength",
-            "score": 8,
+            "score": 9,
             "verdict": "pass",
-            "rationale": "The CTA cleverly continues the 'commitment' theme with 'find your perfect match' and is both specific and action-oriented, creating strong desire."
+            "rationale": "The CTA cleverly continues the ad's central theme ('perfect match') while being direct, specific, and action-oriented."
           }
         ],
         "strengths": [
-          "Exceptional wordplay and humor ('She said yes, you said solo') make the copy highly memorable and shareable.",
-          "Seamlessly integrates a trending pop culture moment with a core product benefit (tonal versatility).",
-          "The copy is perfectly formatted for social media with a scroll-stopping headline and concise, impactful text."
+          "Exceptional copy quality with clever, consistent wordplay throughout.",
+          "Strong thematic cohesion, tying the headline, body, and CTA together around the concept of 'commitment'.",
+          "Creative and authentic pivot from a mainstream trend to a niche product benefit."
         ],
         "improvements": [
-          "While the audience fit is strong, it could be even tighter by incorporating a subtle nod to jam band culture or aesthetics.",
-          "The CTA could be enhanced by adding a layer of urgency or a more direct benefit, such as 'Hear the versatility for yourself.'"
+          "Consider a cultural trend more endemic to the niche jam band audience to ensure maximum resonance and avoid potential disconnect.",
+          "Incorporate a more surreal or absurd element to better align with the target audience's stated appreciation for surreal memes."
         ]
       }
     },
@@ -64,60 +64,60 @@
       "headline": "Every Love Story Deserves a Soundtrack",
       "tone_style": "Aspirational",
       "score": {
-        "overall_score": 0.567,
-        "passed": false,
+        "overall_score": 0.767,
+        "passed": true,
         "verdicts": [
           {
             "dimension": "strategic_alignment",
-            "score": 6,
-            "verdict": "fail",
-            "rationale": "The copy connects the product to an emotional benefit but fails to explicitly mention the key selling point of tonal versatility and only vaguely addresses the target audience."
+            "score": 7,
+            "verdict": "pass",
+            "rationale": "The copy aligns well with the brand's aspirational image and the audience's emotional connection to music, but it misses the opportunity to directly mention the key selling point of tonal versatility."
           },
           {
             "dimension": "trend_authenticity",
-            "score": 4,
-            "verdict": "fail",
-            "rationale": "The connection to the 'tswift engaged' trend is superficial, relying on a generic 'love' theme that feels opportunistic rather than genuine or clever."
+            "score": 9,
+            "verdict": "pass",
+            "rationale": "The ad cleverly uses the universal theme of love sparked by the trend without being overly direct or gimmicky, making the connection feel authentic and broad."
           },
           {
             "dimension": "platform_viability",
-            "score": 5,
+            "score": 6,
             "verdict": "fail",
-            "rationale": "The polished, earnest tone is not optimized for fast-scrolling, engagement-driven platforms like TikTok or Instagram, where it may fail to stop the scroll."
+            "rationale": "While the copy is concise, its poetic and aspirational tone may be too slow to capture attention in a fast-scrolling feed without an exceptionally strong visual."
           },
           {
             "dimension": "copy_quality",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The writing is grammatically flawless, professional, and emotionally evocative, with a strong, classic headline and persuasive body text."
+            "rationale": "The copy is exceptionally well-written, with an evocative headline and persuasive body text that uses elevated language to create a strong emotional connection."
           },
           {
             "dimension": "audience_fit",
-            "score": 3,
-            "verdict": "fail",
-            "rationale": "The ad completely misses the specified audience of jam band fans who like surreal memes; the mainstream trend and earnest tone are a significant mismatch."
+            "score": 7,
+            "verdict": "pass",
+            "rationale": "The ad successfully taps into the nostalgic and emotional side of jam band fans, but it completely misses the described interest in surreal memes, making the fit good but not perfect."
           },
           {
             "dimension": "call_to_action_strength",
-            "score": 7,
+            "score": 8,
             "verdict": "pass",
-            "rationale": "The CTA is clear and thematically consistent with the ad's narrative, effectively framing the product as the start of a new journey."
+            "rationale": "The CTA is thematically consistent and emotionally compelling, effectively framing the product as part of the user's personal journey, even if it lacks hard urgency."
           }
         ],
         "strengths": [
-          "The copy quality is excellent, with polished, professional writing and an emotionally resonant headline.",
-          "The core concept of the guitar as the 'soundtrack to your life' is a strong, aspirational message for a musical instrument.",
-          "The CTA is thematically consistent with the overall narrative of the ad."
+          "Excellent copy quality and polished, emotional language.",
+          "Authentic and subtle integration of the cultural trend.",
+          "Strong thematic cohesion across headline, body, and CTA."
         ],
         "improvements": [
-          "Drastically improve audience fit by using language, humor, or references that resonate with jam band fans and their appreciation for surrealism.",
-          "Select a more authentic trend for this niche audience or abandon the trend-jacking approach for a more direct appeal.",
-          "Incorporate the key selling point (tonal versatility) more directly to add substance to the emotional appeal."
+          "Incorporate the key selling point of tonal versatility more explicitly.",
+          "Adapt the hook to be more attention-grabbing for fast-scrolling social feeds.",
+          "Address the target audience's interest in surreal humor/memes in an alternate version."
         ]
       }
     },
     {
-      "original_id": 1,
+      "original_id": 12345,
       "headline": "POV: Your Guitar is More Reliable Than Any Relationship",
       "tone_style": "Relatable/Meme-based",
       "score": {
@@ -128,105 +128,104 @@
             "dimension": "strategic_alignment",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The copy masterfully weaves the product, a key feature (85/15 pickups), and the audience's meme-centric humor into a cohesive and compelling narrative."
+            "rationale": "The copy expertly weaves the product name (SE CE24) and a key selling point (85/15 pickups) into a creative concept that is perfectly tailored to the target audience."
           },
           {
             "dimension": "trend_authenticity",
-            "score": 9,
+            "score": 8,
             "verdict": "pass",
-            "rationale": "It cleverly references the 'engagement' news cycle without being too direct, making the connection feel authentic and giving the ad a longer shelf-life."
+            "rationale": "The ad cleverly references the 'engagement' news cycle without being too direct, using it as a relevant and timely hook for its core message of reliability."
           },
           {
             "dimension": "platform_viability",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The 'POV' format, short text, and meme-style humor are perfectly optimized for stopping the scroll on platforms like Instagram and TikTok."
+            "rationale": "The 'POV' format, short punchy text, and relatable humor are perfectly optimized for high engagement and shareability on fast-scrolling platforms like TikTok and Instagram."
           },
           {
             "dimension": "copy_quality",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The writing is sharp, witty, and concise, using clever wordplay ('pickups that never ghost you') to create a memorable and polished message."
+            "rationale": "The writing is sharp, witty, and memorable, with clever lines like 'never ghost you' that reinforce the product benefit within the meme context."
           },
           {
             "dimension": "audience_fit",
             "score": 10,
             "verdict": "pass",
-            "rationale": "This ad speaks the exact language of the target millennial audience, combining surreal meme culture with a relatable, slightly cynical musician's perspective."
+            "rationale": "This ad is a bullseye for the target audience, perfectly capturing the self-deprecating and surreal meme-based humor that resonates with online millennials."
           },
           {
             "dimension": "call_to_action_strength",
-            "score": 8,
+            "score": 9,
             "verdict": "pass",
-            "rationale": "The CTA is strong and thematically consistent, framing the purchase as a 'commitment' to tone, which cleverly plays off the relationship theme."
+            "rationale": "The CTA 'Commit to great tone' is a brilliant thematic conclusion to the ad's relationship metaphor, making it both compelling and highly memorable."
           }
         ],
         "strengths": [
-          "Exceptional audience and platform fit, perfectly leveraging meme culture and relatable humor.",
-          "Witty, high-quality copy that creatively integrates a product feature into the core message.",
-          "Authentic and clever use of a trending topic that avoids feeling forced or dated."
+          "Exceptional audience and platform fit, using native meme formats and humor.",
+          "Clever thematic integration of product reliability with the cultural trend.",
+          "Sharp, witty copywriting that is both memorable and persuasive."
         ],
         "improvements": [
-          "The CTA, while good, could be slightly more urgent or provide a more concrete next step (e.g., 'Find a dealer').",
-          "Could more explicitly highlight the tonal *versatility* of the pickups, which was a key selling point, though the current focus on reliability is also very strong."
+          "Could add a subtle nod to the jam band scene to further connect with that specific audience segment.",
+          "Consider adding a single descriptive word for the pickups (e.g., 'versatile 85/15 pickups') to add a bit more product substance."
         ]
       }
     }
   ],
   "visual_concept_evaluations": [
     {
-      "ad_copy_id": 456,
+      "ad_copy_id": 12345,
       "concept_name": "The Proposal Riff",
       "score": {
-        "overall_score": 0.95,
+        "overall_score": 0.9,
         "passed": true,
         "verdicts": [
           {
             "dimension": "trend_visual_connection",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The concept provides a clever, metaphorical interpretation of the 'engaged' trend rather than a literal one, making the connection creative and visually strong."
+            "rationale": "The concept creatively reinterprets the 'engagement' trend as a musician's devotion to their instrument, creating a clear and humorous visual connection."
           },
           {
             "dimension": "brand_product_representation",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The entire concept is built to hero the product, positioning the guitar as a precious, desirable object worthy of a proposal and ensuring it is the clear focal point."
+            "rationale": "The concept makes the PRS SE CE24 the hero of the image, using dramatic lighting and composition to showcase its design and craftsmanship beautifully."
           },
           {
             "dimension": "audience_appeal",
             "score": 9,
             "verdict": "pass",
-            "rationale": "This concept perfectly taps into the 'inside joke' culture of dedicated musicians who view their instruments with deep affection, matching the audience's humor and passion."
+            "rationale": "The humorous and slightly surreal visual pun of 'marrying' a guitar directly appeals to the target audience's in-jokes and meme culture."
           },
           {
             "dimension": "prompt_technical_quality",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The prompt is exceptionally detailed, specifying composition, professional lighting, lens choice, and high-fidelity details, leaving little room for error in generation."
+            "rationale": "The prompt is exceptionally detailed, specifying aspect ratio, composition, lens choice, lighting, color grading, and high-fidelity keywords to ensure a premium result."
           },
           {
             "dimension": "stopping_power",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The unusual, story-driven visual of a man proposing with a guitar is highly intriguing and combined with dramatic lighting, it has excellent potential to stop scrolling."
+            "rationale": "The subversion of a familiar, emotionally charged scene (a proposal) with a guitar creates a visually arresting and humorous image that will immediately stop scrollers."
           },
           {
             "dimension": "concept_coherence",
-            "score": 10,
+            "score": 7,
             "verdict": "pass",
-            "rationale": "The headline, caption, and CTA flawlessly extend the visual metaphor of the proposal, creating an exceptionally tight and clever creative package where all elements are in sync."
+            "rationale": "While the 'perfect match' theme is consistent, the headline and caption introduce a parallel narrative that slightly conflicts with the direct visual of proposing to the instrument itself."
           }
         ],
         "strengths": [
-          "Perfectly coherent concept where the copy and visual work in harmony to execute a clever pun.",
-          "Excellent audience targeting that taps into the humor and passion of dedicated musicians.",
-          "The product is the undeniable hero of the visual, showcased in a dramatic and highly desirable way."
+          "The 'proposal' visual pun is a highly creative, memorable, and shareable concept that perfectly connects to the trend.",
+          "The prompt and concept are designed to showcase the product as the hero, highlighting its premium look and feel.",
+          "The humor and aesthetic are perfectly aligned with the target audience of dedicated musicians who personify their instruments."
         ],
         "improvements": [
-          "Consider creating a variant with a female musician to broaden the representation and appeal of the concept.",
-          "The core 'proposal' joke is strong, but ensure it lands even if the audience misses the timely 'tswift engaged' trend connection.",
-          "While the surrealism works for the target, a slightly more grounded version could be tested for broader appeal if needed."
+          "Refine the headline and copy for better coherence with the visual; the current copy creates a slightly conflicting narrative.",
+          "Incorporate the key selling point about the versatile 85/15 S pickups into the social caption to add a tangible product benefit."
         ]
       }
     },
@@ -234,70 +233,70 @@
       "ad_copy_id": 12345,
       "concept_name": "The Ghost-Free Zone",
       "score": {
-        "overall_score": 0.833,
+        "overall_score": 0.867,
         "passed": true,
         "verdicts": [
           {
             "dimension": "trend_visual_connection",
             "score": 4,
             "verdict": "fail",
-            "rationale": "The visual connection to 'tswift engaged' is extremely weak and indirect, relying on a thematic leap from 'commitment' to 'ghosting' that is not visually represented."
+            "rationale": "The concept's link to the 'tswift engaged' trend is abstract and indirect, relying on a thematic pivot to relationship unreliability rather than a clear visual connection."
           },
           {
             "dimension": "brand_product_representation",
-            "score": 9,
+            "score": 10,
             "verdict": "pass",
-            "rationale": "The concept and prompt are designed to showcase the guitar in a highly desirable, premium light, ensuring the product is the hero and the brand is represented well."
+            "rationale": "The concept and prompt ensure the PRS guitar is presented as a premium, highly desirable object, perfectly aligning with the brand's reputation for quality craftsmanship."
           },
           {
             "dimension": "audience_appeal",
-            "score": 8,
+            "score": 9,
             "verdict": "pass",
-            "rationale": "The meme format and ironic humor about relationships vs. gear reliability are perfectly tailored to the millennial musician audience."
+            "rationale": "The meme-native format and ironic humor about reliability speak directly to the target millennial audience's online culture and preferences."
           },
           {
             "dimension": "prompt_technical_quality",
             "score": 10,
             "verdict": "pass",
-            "rationale": "The prompt is exceptionally detailed, specifying composition, lighting, aspect ratio, and high-fidelity keywords to ensure a high-quality, commercially viable image."
+            "rationale": "The prompt is exceptionally detailed and technically strong, specifying composition, lighting, style, resolution, and aspect ratio to ensure a high-quality visual output."
           },
           {
             "dimension": "stopping_power",
             "score": 9,
             "verdict": "pass",
-            "rationale": "The stark visual contrast between the cold/blue phone screen and the warm/golden guitar, combined with a familiar meme format, has excellent scroll-stopping potential."
+            "rationale": "The strong color contrast, split-screen composition, and relatable meme format create immediate visual intrigue that is highly effective at stopping a user's scroll."
           },
           {
             "dimension": "concept_coherence",
             "score": 10,
             "verdict": "pass",
-            "rationale": "All components—headline, visual, caption, and CTA—work in perfect harmony to deliver a single, clever, and consistent message."
+            "rationale": "The headline, visual, caption, and CTA are perfectly aligned, creating a cohesive and clever message that reinforces the central theme of reliability."
           }
         ],
         "strengths": [
-          "Exceptional concept coherence where all elements (visual, headline, copy) work together perfectly.",
-          "Strong audience appeal through the use of a familiar and relevant meme format and ironic humor.",
-          "Technically superb image prompt that ensures high-quality, on-brand product representation."
+          "Strong audience appeal using a native meme format and ironic humor.",
+          "Excellent product representation that aligns with the brand's premium quality.",
+          "Highly coherent concept where the visual, headline, and copy work together seamlessly."
         ],
         "improvements": [
-          "The connection to the 'tswift engaged' trend is tenuous and feels forced; the concept is strong enough to stand on its own without it.",
-          "Find a trend that aligns more directly with the visual execution or drop the trend angle to improve authenticity."
+          "The connection to the 'tswift engaged' trend is weak and abstract; the concept would be better suited to a more general trend about relationships or reliability.",
+          "Consider reframing the concept to be less dependent on a specific, fleeting news event to improve its longevity."
         ]
       }
     }
   ],
   "summary": {
     "total_ad_copies": 3,
-    "ad_copies_passed": 2,
-    "avg_ad_copy_score": 0.795,
+    "ad_copies_passed": 3,
+    "avg_ad_copy_score": 0.85,
     "total_visual_concepts": 2,
     "visual_concepts_passed": 2,
-    "avg_visual_score": 0.891,
-    "overall_pass_rate": 0.8,
+    "avg_visual_score": 0.883,
+    "overall_pass_rate": 1.0,
     "weakest_dimensions": [
       "trend_visual_connection",
       "audience_fit",
-      "trend_authenticity"
+      "strategic_alignment"
     ]
   }
 }

--- a/deployment/headless_run.py
+++ b/deployment/headless_run.py
@@ -1,0 +1,167 @@
+"""Headless end-to-end runner for the creative_agent (creative-eval branch).
+
+Runs one full creative_agent invocation via a local ADK Runner, bypassing the
+api_server SSE/HTTP request timeout that kills UI runs during the ~5-min eval
+phase. Uses the same file artifact service directory (.adk/artifacts) the
+api_server uses so save_artifact calls persist identically. Verifies:
+
+  - each visual is rendered exactly once (visual_generator thinking_budget=0 fix)
+  - creative_evaluation_report is produced and eval_report_gcs_uri is set
+  - the HTML gallery is built
+  - a BigQuery row is written
+
+Run:  uv run python deployment/headless_run.py
+"""
+
+import os
+import sys
+import json
+import asyncio
+import logging
+import warnings
+from collections import Counter
+
+import dotenv
+
+# project root on path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+ENV_FILE_PATH = os.path.join(project_root, ".env")
+dotenv.load_dotenv(dotenv_path=ENV_FILE_PATH)
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+warnings.filterwarnings("ignore")
+
+from google.genai import types
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.artifacts.file_artifact_service import FileArtifactService
+
+from creative_agent.agent import root_agent
+
+APP_NAME = "creative_agent"
+USER_ID = "headless_user"
+ARTIFACT_DIR = os.path.join(project_root, ".adk", "artifacts")
+
+KICKOFF = f"""Brand: {os.getenv("BRAND")}
+Target Product: {os.getenv("TARGET_PRODUCT")}
+Key Selling Point(s): {os.getenv("KEY_SELLING_POINT")}
+Target Audience: {os.getenv("TARGET_AUDIENCE")}
+Target Search Trend: {os.getenv("TARGET_SEARCH_TREND")}
+"""
+
+# tool-call tallies keyed by tool name
+tool_calls: Counter = Counter()
+# last response payload per tool name (for the terminal persistence tools)
+tool_responses: dict = {}
+
+
+def _log_event(event):
+    author = getattr(event, "author", "?")
+    content = getattr(event, "content", None)
+    if not content or not getattr(content, "parts", None):
+        return
+    for part in content.parts:
+        fc = getattr(part, "function_call", None)
+        fr = getattr(part, "function_response", None)
+        txt = getattr(part, "text", None)
+        if fc:
+            tool_calls[fc.name] += 1
+            logging.info(f"[{author}] -> call: {fc.name}")
+        elif fr:
+            resp = fr.response
+            tool_responses[fr.name] = resp
+            status = resp.get("status") if isinstance(resp, dict) else None
+            logging.info(f"[{author}] <- resp: {fr.name} (status={status})")
+        elif txt and txt.strip():
+            snippet = txt.strip().replace("\n", " ")[:160]
+            logging.info(f"[{author}]: {snippet}")
+
+
+async def main():
+    session_service = InMemorySessionService()
+    artifact_service = FileArtifactService(root_dir=ARTIFACT_DIR)
+
+    session = await session_service.create_session(
+        app_name=APP_NAME, user_id=USER_ID, state={}
+    )
+    logging.info(f"session id: {session.id}")
+
+    runner = Runner(
+        app_name=APP_NAME,
+        agent=root_agent,
+        session_service=session_service,
+        artifact_service=artifact_service,
+    )
+
+    msg = types.Content(role="user", parts=[types.Part(text=KICKOFF)])
+    async for event in runner.run_async(
+        user_id=USER_ID, session_id=session.id, new_message=msg
+    ):
+        _log_event(event)
+
+    # ---- final state inspection ----
+    final = await session_service.get_session(
+        app_name=APP_NAME, user_id=USER_ID, session_id=session.id
+    )
+    state = dict(final.state)
+
+    print("\n" + "=" * 70)
+    print("TOOL CALL COUNTS")
+    print("=" * 70)
+    for name, n in sorted(tool_calls.items()):
+        print(f"  {name}: {n}")
+
+    print("\n" + "=" * 70)
+    print("KEY STATE VALUES")
+    print("=" * 70)
+    for k in [
+        "gcs_bucket",
+        "gcs_folder",
+        "agent_output_dir",
+        "_images_generated",
+        "_generated_artifact_keys",
+        "eval_report_gcs_uri",
+        "creative_gallery_gcs_uri",
+    ]:
+        v = state.get(k)
+        if isinstance(v, (dict, list)):
+            v = json.dumps(v)[:200]
+        print(f"  {k}: {v}")
+
+    report = state.get("creative_evaluation_report")
+    print(f"\n  creative_evaluation_report present: {report is not None}")
+    if isinstance(report, dict):
+        print(f"  report keys: {list(report.keys())}")
+
+    print("\n" + "=" * 70)
+    print("VALIDATION")
+    print("=" * 70)
+    gen_calls = tool_calls.get("generate_image", 0)
+    artifact_keys = state.get("_generated_artifact_keys") or []
+    if isinstance(artifact_keys, dict):
+        artifact_keys = list(artifact_keys.values())
+
+    def _ok(name):
+        r = tool_responses.get(name)
+        return isinstance(r, dict) and r.get("status") in ("success", "ok")
+
+    gallery = tool_responses.get("save_creative_gallery_html") or {}
+    bq = tool_responses.get("write_trends_to_bq") or {}
+    print(f"  generate_image tool calls: {gen_calls} (expected exactly 1)")
+    print(f"  generated artifact keys: {len(artifact_keys)}")
+    print(f"  eval report saved: {_ok('save_eval_report_to_gcs')} "
+          f"uri={state.get('eval_report_gcs_uri')}")
+    print(f"  gallery built: {_ok('save_creative_gallery_html')} "
+          f"uri={gallery.get('gcs_uri')}")
+    print(f"  bq row written: {_ok('write_trends_to_bq')} resp={json.dumps(bq)[:160]}")
+    print(f"\nsession id for reference: {session.id}")
+    print(f"gcs folder: {state.get('gcs_folder')}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -1,0 +1,17 @@
+# Session notes
+
+Durable notes captured across working sessions — non-obvious insights that
+outlive a single conversation and aren't recoverable from the repo, git history,
+`CLAUDE.md`, or existing docs. Update the relevant file rather than adding
+duplicates; delete notes that go stale. Each note is dated and states the branch
+it was written on, since some describe uncommitted working-tree state.
+
+- [local-testing.md](local-testing.md) — running/validating agents locally: the
+  ~12-min UI request timeout, the headless ADK Runner, where results land in
+  GCS/BQ/state, artifact/session services.
+- [creative-agent-image-generation.md](creative-agent-image-generation.md) —
+  `creative_agent` image-gen determinism fixes (skipped step + 2× duplicate
+  render) on the `creative-eval` branch, and why `interactive_creative` is left
+  separate.
+- [frontend.md](frontend.md) — React crash from nested session-state values and
+  its confusing backend cascade; the same-origin proxy.

--- a/docs/notes/creative-agent-image-generation.md
+++ b/docs/notes/creative-agent-image-generation.md
@@ -1,0 +1,79 @@
+# creative_agent image generation — determinism fixes
+
+Written 2026-07-12 on the `creative-eval` branch. These are **uncommitted
+working-tree changes** to `creative_agent/agent.py` (not yet on `main`).
+
+## Background: two related bugs on creative-eval
+
+The `creative-eval` branch inserted `creative_eval_agent` into the root workflow
+right after visual concepts. Two image-generation bugs surfaced:
+
+### 1. Images never generated (LLM skipped the step)
+
+Originally image rendering was a standalone `visual_generator` Agent exposed as
+a root `AgentTool`, invoked as its own WORKFLOW step. With eval inserted right
+after it, the orchestrator LLM **skipped `visual_generator`** and jumped from
+visual concepts straight to `creative_eval_agent` — `generate_image` never ran,
+no images saved.
+
+**Fix:** make image rendering deterministic by wrapping concepts + rendering in
+a `SequentialAgent` so the LLM can't skip a step:
+
+```python
+visual_production_pipeline = SequentialAgent(
+    name="visual_production_pipeline",
+    sub_agents=[visual_generation_pipeline, visual_generator],
+)
+```
+
+Root now calls `AgentTool(agent=visual_production_pipeline)` (one WORKFLOW step)
+and the standalone `visual_generator` AgentTool was removed from root tools.
+`visual_generation_pipeline` stays **concepts-only**
+(`SequentialAgent([drafter, critic, finalizer])`) because it is *shared* with
+`interactive_creative`.
+
+### 2. Every image rendered 2× (parallel duplicate tool calls)
+
+After the deterministic fix, each image rendered twice. `generate_image` has an
+idempotency guard (`if tool_context.state.get("_images_generated"): return`),
+but it only dedupes **sequential** re-calls. gemini-3 emitted **two parallel**
+`generate_image` calls in one turn; parallel function calls all read state
+*before* any of them commits its delta, so the guard can't catch them. Output
+was still correct (guard eventually True, 6 unique concepts → 6 PNGs) — it was a
+cost/waste bug only.
+
+**Fix:** give `visual_generator` a zero-budget planner + a "call exactly once"
+instruction so it emits a single deterministic tool call:
+
+```python
+planner=BuiltInPlanner(
+    thinking_config=types.ThinkingConfig(thinking_budget=0, include_thoughts=False)
+),
+instruction="""... Call the `generate_image` tool EXACTLY ONCE — a single
+    function call, never in parallel and never more than once. ..."""
+```
+
+`thinking_budget=0` is the same lever used on the `trend_trawler` root agent to
+stop gemini-3 MAX_TOKENS runaway and multiple/parallel tool calls in mechanical
+single-tool steps.
+
+## Do NOT touch interactive_creative for this
+
+`interactive_creative/agent.py` imports `visual_generation_pipeline` and
+`visual_generator` from `creative_agent.agent` and deliberately runs:
+concepts → CHECKPOINT 3 (`review_visual_concepts` LongRunningFunctionTool) →
+`visual_generator` images. Image gen MUST stay a separate step *after* the human
+review checkpoint there, so `interactive_creative` keeps them separate on
+purpose and was left unmodified. The `thinking_budget=0` fix on
+`visual_generator` propagates to it for free via the shared import.
+
+## The image client is Gemini, not Imagen
+
+`generate_image` (in `creative_agent/tools.py`) uses
+`client.models.generate_content(model=config.image_gen_model,
+contents=prompt, config=GenerateContentConfig(response_modalities=["IMAGE"]))`
+and reads bytes from `candidates[0].content.parts[].inline_data.data`. This is
+the Gemini image path (`gemini-3.1-flash-image`), NOT Imagen's
+`generate_images` / `generated_images`. `gemini-3.1-flash-image` needs
+`GOOGLE_CLOUD_LOCATION=global` (module-level `genai.Client(vertexai=True,
+location=config.LOCATION)` where LOCATION=global).

--- a/docs/notes/creative-agent-image-generation.md
+++ b/docs/notes/creative-agent-image-generation.md
@@ -57,6 +57,11 @@ instruction="""... Call the `generate_image` tool EXACTLY ONCE — a single
 stop gemini-3 MAX_TOKENS runaway and multiple/parallel tool calls in mechanical
 single-tool steps.
 
+**Verified fixed 2026-07-12** via headless run `a23fb408` (gcs_folder
+`2026_07_12_05_55_1a27`): exactly 6 `"Saved image artifact"` log lines and 6
+distinct PNGs in GCS — no duplicates. (Count `generate_image` via those log
+lines, not the event stream; see `local-testing.md` on AgentTool sub-events.)
+
 ## Do NOT touch interactive_creative for this
 
 `interactive_creative/agent.py` imports `visual_generation_pipeline` and

--- a/docs/notes/frontend.md
+++ b/docs/notes/frontend.md
@@ -28,6 +28,23 @@ but are downstream symptoms of the React crash. Fixing `formatStateValue` made
 both disappear. If you see multiple concurrent runs on one session or
 `raw_gtrends` KeyErrors, suspect a frontend render crash first.
 
+## Leaving the run page mid-run cancels the run (SSE abort)
+
+The run is driven by a long-lived `POST /run_sse` stream held open by the run
+page. If you **navigate away or refresh before the run completes** — e.g. click
+through to `/results` while the final leg is still working — the browser aborts
+that fetch, and the server logs `Root node ... was cancelled` and kills the
+in-flight agent. Observed 2026-07-12: an `interactive_creative` run that had
+already finished all 12 eval scores was cancelled ~4 s later when the results
+page loaded (the log shows the cancellation immediately followed by
+`GET .../results/.../artifacts/*` requests), so the eval report / gallery / BQ
+writes never ran. This is distinct from the ~12-min request timeout (that run was
+only ~6.5 min in). Interactive checkpoints split the run into separate requests,
+but the **final leg after checkpoint 3 has no checkpoint**, so it only survives
+while the run page stays open. Practical rule: don't leave the run page until it
+reports completion. (The concurrent-eval fix — see `local-testing.md` — shrinks
+this vulnerable window from ~5.5 min to ~30 s.)
+
 ## Same-origin proxy (why it exists)
 
 The browser talks to the ADK api_server through a same-origin Next.js proxy

--- a/docs/notes/frontend.md
+++ b/docs/notes/frontend.md
@@ -1,0 +1,38 @@
+# Frontend notes
+
+Written 2026-07-12 on the `creative-eval` branch.
+
+## React crash from nested session-state values (and its backend cascade)
+
+**Symptom:** `Objects are not valid as a React child (found: object with keys
+{target_search_trends})` on the run/results pages.
+
+**Root cause:** session-state values aren't all strings. Some keys (notably
+`target_search_trends`) are stored as nested objects/arrays, e.g.
+`{target_search_trends: [...]}`. The run/results pages rendered them via an
+`as string` cast, so React tried to render a raw object.
+
+**Fix:** `formatStateValue(value: unknown): string` in
+`frontend/src/lib/utils.ts` flattens any value (string / array / object) to a
+display string. Applied in both
+`frontend/src/app/run/[sessionId]/page.tsx` and
+`frontend/src/app/results/[sessionId]/page.tsx` where campaign/state fields are
+mapped for display. (This fix already existed on `main-baseline-fixes` but was
+missing on `creative-eval` — port it when moving between branches.)
+
+**Non-obvious cascade:** this frontend crash caused confusing *backend* errors.
+The crash remounted the run page, which re-fired **3 concurrent `POST /run_sse`**
+calls onto the same session. That produced `KeyError: raw_gtrends` and
+stale-session `ValueError`s in the api_server logs — which look like agent bugs
+but are downstream symptoms of the React crash. Fixing `formatStateValue` made
+both disappear. If you see multiple concurrent runs on one session or
+`raw_gtrends` KeyErrors, suspect a frontend render crash first.
+
+## Same-origin proxy (why it exists)
+
+The browser talks to the ADK api_server through a same-origin Next.js proxy
+(`frontend/src/app/api/adk/[...path]/route.ts`, base `/api/adk`), not directly.
+This bypasses the Cloud Workstations port-auth redirect + CORS and streams SSE
+through. `NEXT_PUBLIC_API_BASE` can override it to hit an api_server directly.
+Note this proxy does NOT bypass the ~12-min HTTP request timeout that kills long
+runs — see `local-testing.md`.

--- a/docs/notes/local-testing.md
+++ b/docs/notes/local-testing.md
@@ -17,6 +17,18 @@ the UI, even though the agent logic is correct.
 **Workaround: run headless.** `deployment/headless_run.py` drives the same
 `root_agent` through a local ADK `Runner` with no HTTP layer, so it completes.
 
+**Fix (2026-07-12): eval now runs concurrently.** The eval phase was the long
+silent stretch that blew the timeout. `evaluate_all_creatives`
+(`creative_eval/agent.py`) and `evaluate_creatives` (`creative_eval/evaluate.py`)
+now score all creatives in parallel via `evaluate_all_concurrently()` (a
+`ThreadPoolExecutor`, `EvalConfig.max_eval_workers=12`) instead of a sequential
+`for` loop. Measured: eval dropped from ~5.5 min (12 creatives sequential) to
+~26–30 s (bounded by the slowest single judge call, roughly constant regardless
+of creative count). This keeps the whole final leg well under the ~12-min
+timeout. Note the per-creative `evaluate_ad_copy`/`evaluate_visual_concept`
+signatures now take a shared `client` as a 4th positional arg (the pool creates
+one client and reuses it); test mocks must accept it.
+
 ## Headless runner details (`deployment/headless_run.py`)
 
 - Uses `Runner(app_name="creative_agent", agent=root_agent,

--- a/docs/notes/local-testing.md
+++ b/docs/notes/local-testing.md
@@ -1,0 +1,66 @@
+# Local testing notes
+
+Practical, non-obvious things about running/validating the agents locally.
+Written 2026-07-12 on the `creative-eval` branch (ADK 2.1.0).
+
+## The UI can't finish a full creative_agent run — HTTP request timeout
+
+A full `creative_agent` run takes ~10–12 min. When driven through the browser
+UI (`adk api_server` + Next.js frontend on Cloud Workstations), the run gets
+**cancelled ~12 min in, during the eval phase**. Root cause is the Cloud
+Workstations / proxy HTTP request timeout (~12 min) on the single long-lived
+`POST /run_sse` request. The eval phase (`creative_eval_agent`, 12 creatives ×
+~28s on `gemini-2.5-pro`) streams nothing for minutes, so it pushes the request
+past the timeout. Result: eval report / gallery / BigQuery steps never run via
+the UI, even though the agent logic is correct.
+
+**Workaround: run headless.** `deployment/headless_run.py` drives the same
+`root_agent` through a local ADK `Runner` with no HTTP layer, so it completes.
+
+## Headless runner details (`deployment/headless_run.py`)
+
+- Uses `Runner(app_name="creative_agent", agent=root_agent,
+  session_service=InMemorySessionService(),
+  artifact_service=FileArtifactService(root_dir=".adk/artifacts"))`.
+  `FileArtifactService` lives at
+  `google.adk.artifacts.file_artifact_service` and takes a single `root_dir`.
+  `.adk/artifacts` is the same dir `adk api_server` writes to
+  (`.adk/artifacts/users/<uid>/sessions/<sid>/...`).
+- **Do not pre-seed campaign state.** `load_session_state` only initializes
+  `gcs_bucket`/`gcs_folder`/`agent_output_dir` when `config.state_init` is
+  absent, and it overwrites `brand`/etc. with empty strings. The intended flow
+  is: start with empty state, let the callback set the `gcs_*` keys, and pass
+  campaign metadata in the **kickoff user message** — the root agent's
+  instructions call the `memorize` tool to store them. Seeding state with
+  `state_init` already set skips the `gcs_*` initialization and breaks the run.
+- Sessions are **in-memory per process**, so a headless run will NOT appear in
+  the running api_server's `/results/[sessionId]` UI (separate process, separate
+  memory). Verify via script stdout + GCS + BigQuery instead.
+
+## Where results actually land (state vs return value)
+
+Not all tools persist their output to session state — some only return it in the
+tool response. When validating, check the right place:
+
+- `save_eval_report_to_gcs` → sets `state["eval_report_gcs_uri"]`.
+- `generate_image` → sets `state["_images_generated"]` (bool guard) and
+  `state["_generated_artifact_keys"]` (list).
+- `save_creative_gallery_html` → **no state key**; returns `{status, gcs_uri}`.
+- `write_trends_to_bq` → **no state key**; returns `{status, ...}`.
+
+So the headless script captures function-response payloads for the terminal
+tools rather than reading state for them.
+
+## GCS / BigQuery layout for a run
+
+- GCS output: `gs://{GCS_BUCKET_NAME}/{gcs_folder}/{agent_output_dir}/` where
+  `agent_output_dir="creative_output"` and `gcs_folder` is
+  `YYYY_MM_DD_HH_MM_<4hex>` (set in `_set_initial_states`).
+- Bucket: `GCS_BUCKET_NAME=trend-trawler-deploy-ae`.
+
+## Gotcha: pkill/pgrep self-match
+
+Commands that contain the literal string `adk api_server` (or a script name)
+will be matched by `pkill -f` / `pgrep -f` against the very shell running them,
+killing your own command (seen as exit 143/144). Kill servers by explicit PID
+instead of pattern.

--- a/docs/notes/local-testing.md
+++ b/docs/notes/local-testing.md
@@ -36,6 +36,18 @@ the UI, even though the agent logic is correct.
 - Sessions are **in-memory per process**, so a headless run will NOT appear in
   the running api_server's `/results/[sessionId]` UI (separate process, separate
   memory). Verify via script stdout + GCS + BigQuery instead.
+- **Caveat: AgentTool sub-invocation events don't surface in the top-level
+  `runner.run_async` stream.** Tools invoked *inside* an `AgentTool` wrapper
+  (e.g. `generate_image` inside `visual_production_pipeline`) never appear as
+  function-call events at the top level, so counting them from the event stream
+  reads 0. To verify exactly-once image generation, count the tool's own
+  `"Saved image artifact"` log lines instead (one `generate_image` call saves
+  one line per concept — 6 concepts → 6 lines; the old duplicate bug gave 12).
+
+Verified 2026-07-12 (run `a23fb408`, gcs_folder `2026_07_12_05_55_1a27`): full
+end-to-end pass — 6 distinct PNGs, `creative_eval_report.json`,
+`creative_portfolio_gallery.html`, research PDF all in GCS; BQ row written;
+every top-level tool called exactly once.
 
 ## Where results actually land (state vs return value)
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,12 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  // Cloud Workstations serves the dev app from a forwarded *.cloudworkstations.dev
+  // host; Next.js 16 blocks cross-origin dev requests unless allow-listed here.
+  allowedDevOrigins: [
+    "3000-jtotts-cc-station.cluster-bg7xwomlpbbfku2lmsogqimkzi.cloudworkstations.dev",
+    "*.cluster-bg7xwomlpbbfku2lmsogqimkzi.cloudworkstations.dev",
+  ],
+};
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,8 @@
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "shadcn": "^4.1.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -2959,6 +2961,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2970,8 +2981,25 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2985,6 +3013,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3001,7 +3044,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3021,6 +3063,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -3323,6 +3371,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -4111,6 +4165,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4321,6 +4385,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4346,6 +4420,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/class-variance-authority": {
@@ -4507,6 +4621,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -4663,7 +4787,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4773,6 +4896,19 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -4893,9 +5029,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4908,6 +5042,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -5699,6 +5846,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5845,6 +6002,12 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6462,6 +6625,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/headers-polyfill": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
@@ -6505,6 +6708,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-errors": {
@@ -6616,6 +6829,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6647,6 +6866,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6813,6 +7056,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -6892,6 +7145,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-in-ssh": {
@@ -7814,6 +8077,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7866,6 +8139,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7873,6 +8156,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -7917,6 +8482,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -8621,6 +9749,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -8916,6 +10069,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -9026,6 +10189,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -9098,6 +10288,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -9777,6 +11033,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -9975,6 +11241,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stringify-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
@@ -10052,6 +11332,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {
@@ -10302,6 +11600,26 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -10574,6 +11892,93 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -10707,6 +12112,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -11326,6 +12759,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,8 @@
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"

--- a/frontend/src/__tests__/interactive-mode.test.ts
+++ b/frontend/src/__tests__/interactive-mode.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import type { AgentEvent } from "@/lib/types";
+
+// Test pause detection logic used in the run page
+
+function detectPause(event: AgentEvent): {
+  functionCallId: string;
+  functionName: string;
+  eventId: string;
+} | null {
+  if (!event.longRunningToolIds || event.longRunningToolIds.length === 0) {
+    return null;
+  }
+
+  const functionCalls =
+    event.content?.parts
+      ?.filter((p) => p.functionCall)
+      ?.map((p) => p.functionCall!) ?? [];
+
+  const pausedCall = functionCalls.find((fc) =>
+    event.longRunningToolIds!.includes(fc.id ?? "")
+  );
+
+  if (!pausedCall) return null;
+
+  return {
+    functionCallId: pausedCall.id ?? "",
+    functionName: pausedCall.name ?? "",
+    eventId: event.id,
+  };
+}
+
+describe("Interactive mode pause detection", () => {
+  it("detects a long-running tool pause event", () => {
+    const event: AgentEvent = {
+      id: "evt-1",
+      invocationId: "inv-1",
+      author: "root_agent",
+      content: {
+        role: "assistant",
+        parts: [
+          {
+            functionCall: {
+              id: "fc-123",
+              name: "review_research",
+              args: {},
+            },
+          },
+        ],
+      },
+      longRunningToolIds: ["fc-123"],
+      timestamp: Date.now(),
+    };
+
+    const result = detectPause(event);
+    expect(result).not.toBeNull();
+    expect(result!.functionCallId).toBe("fc-123");
+    expect(result!.functionName).toBe("review_research");
+    expect(result!.eventId).toBe("evt-1");
+  });
+
+  it("returns null for events without longRunningToolIds", () => {
+    const event: AgentEvent = {
+      id: "evt-2",
+      invocationId: "inv-1",
+      author: "root_agent",
+      content: {
+        role: "assistant",
+        parts: [{ text: "Processing..." }],
+      },
+      timestamp: Date.now(),
+    };
+
+    expect(detectPause(event)).toBeNull();
+  });
+
+  it("returns null for empty longRunningToolIds", () => {
+    const event: AgentEvent = {
+      id: "evt-3",
+      invocationId: "inv-1",
+      author: "root_agent",
+      longRunningToolIds: [],
+      timestamp: Date.now(),
+    };
+
+    expect(detectPause(event)).toBeNull();
+  });
+
+  it("returns null when function call ID does not match longRunningToolIds", () => {
+    const event: AgentEvent = {
+      id: "evt-4",
+      invocationId: "inv-1",
+      author: "root_agent",
+      content: {
+        role: "assistant",
+        parts: [
+          {
+            functionCall: {
+              id: "fc-999",
+              name: "some_tool",
+              args: {},
+            },
+          },
+        ],
+      },
+      longRunningToolIds: ["fc-other"],
+      timestamp: Date.now(),
+    };
+
+    expect(detectPause(event)).toBeNull();
+  });
+
+  it("handles events with no content", () => {
+    const event: AgentEvent = {
+      id: "evt-5",
+      invocationId: "inv-1",
+      author: "root_agent",
+      longRunningToolIds: ["fc-123"],
+      timestamp: Date.now(),
+    };
+
+    expect(detectPause(event)).toBeNull();
+  });
+
+  it("detects review_ad_copies pause", () => {
+    const event: AgentEvent = {
+      id: "evt-6",
+      invocationId: "inv-1",
+      author: "root_agent",
+      content: {
+        role: "assistant",
+        parts: [
+          {
+            functionCall: {
+              id: "fc-456",
+              name: "review_ad_copies",
+              args: {},
+            },
+          },
+        ],
+      },
+      longRunningToolIds: ["fc-456"],
+      timestamp: Date.now(),
+    };
+
+    const result = detectPause(event);
+    expect(result).not.toBeNull();
+    expect(result!.functionName).toBe("review_ad_copies");
+  });
+
+  it("detects review_visual_concepts pause", () => {
+    const event: AgentEvent = {
+      id: "evt-7",
+      invocationId: "inv-1",
+      author: "root_agent",
+      content: {
+        role: "assistant",
+        parts: [
+          {
+            functionCall: {
+              id: "fc-789",
+              name: "review_visual_concepts",
+              args: {},
+            },
+          },
+        ],
+      },
+      longRunningToolIds: ["fc-789"],
+      timestamp: Date.now(),
+    };
+
+    const result = detectPause(event);
+    expect(result).not.toBeNull();
+    expect(result!.functionName).toBe("review_visual_concepts");
+  });
+});
+
+// Test resumeRun request body construction
+
+describe("Resume run request body", () => {
+  it("constructs correct functionResponse message with functionCallEventId", () => {
+    const functionCallId = "fc-123";
+    const functionName = "review_research";
+    const functionCallEventId = "evt-1";
+    const response = { status: "approved", feedback: "Looks good" };
+
+    const body = {
+      appName: "interactive_creative",
+      userId: "user_1",
+      sessionId: "sess_1",
+      newMessage: {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              id: functionCallId,
+              name: functionName,
+              response: response,
+            },
+          },
+        ],
+      },
+      functionCallEventId,
+      streaming: true,
+    };
+
+    expect(body.newMessage.parts[0].functionResponse).toBeDefined();
+    expect(body.newMessage.parts[0].functionResponse!.id).toBe("fc-123");
+    expect(body.newMessage.parts[0].functionResponse!.name).toBe(
+      "review_research"
+    );
+    expect(body.newMessage.parts[0].functionResponse!.response).toEqual({
+      status: "approved",
+      feedback: "Looks good",
+    });
+    expect(body.functionCallEventId).toBe("evt-1");
+    expect(body.streaming).toBe(true);
+  });
+
+  it("handles empty feedback in response", () => {
+    const response = { status: "approved", feedback: "" };
+
+    const body = {
+      newMessage: {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              id: "fc-1",
+              name: "review_ad_copies",
+              response: response,
+            },
+          },
+        ],
+      },
+    };
+
+    expect(body.newMessage.parts[0].functionResponse!.response.status).toBe(
+      "approved"
+    );
+    expect(body.newMessage.parts[0].functionResponse!.response.feedback).toBe(
+      ""
+    );
+  });
+});

--- a/frontend/src/app/api/adk/[...path]/route.ts
+++ b/frontend/src/app/api/adk/[...path]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from "next/server";
+
+// Same-origin proxy to the ADK api_server. The browser calls /api/adk/* (same origin
+// as the app, so no CORS and no Cloud Workstations port-auth), and Next forwards
+// server-side to the api_server on localhost. The RESPONSE body is streamed through
+// untouched so SSE (/run_sse) keeps streaming; the request body is small JSON so it
+// is buffered.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BACKEND = process.env.ADK_API_BASE ?? "http://localhost:8000";
+
+async function proxy(
+  request: NextRequest,
+  ctx: { params: Promise<{ path: string[] }> }
+): Promise<Response> {
+  const { path } = await ctx.params;
+  const target = `${BACKEND}/${path.join("/")}${request.nextUrl.search}`;
+
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+  headers.delete("connection");
+  headers.delete("content-length");
+
+  const method = request.method;
+  const body =
+    method === "GET" || method === "HEAD" ? undefined : await request.text();
+
+  const upstream = await fetch(target, {
+    method,
+    headers,
+    body,
+    redirect: "manual",
+  });
+
+  // Strip hop-by-hop / length headers that would conflict with the streamed body.
+  const respHeaders = new Headers(upstream.headers);
+  respHeaders.delete("content-encoding");
+  respHeaders.delete("content-length");
+  respHeaders.delete("transfer-encoding");
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: respHeaders,
+  });
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;
+export const OPTIONS = proxy;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -78,7 +78,7 @@ function HomeContent() {
 
       // Build the user message with campaign metadata
       let message = `Brand Name: "${form.brand}"\nTarget Audience: "${form.targetAudience}"\nTarget Product: "${form.targetProduct}"\nKey Selling Points: "${form.keySellingPoints}"`;
-      if (form.agent === "creative_agent" && form.targetSearchTrend) {
+      if ((form.agent === "creative_agent" || form.agent === "interactive_creative") && form.targetSearchTrend) {
         message += `\ntarget_search_trend: "${form.targetSearchTrend}"`;
       }
 
@@ -102,7 +102,7 @@ function HomeContent() {
     form.targetAudience &&
     form.targetProduct &&
     form.keySellingPoints &&
-    (form.agent !== "creative_agent" || form.targetSearchTrend);
+    (form.agent === "trend_trawler" || form.targetSearchTrend);
 
   const isPreFilled = searchParams.get("targetSearchTrend");
 
@@ -147,7 +147,7 @@ function HomeContent() {
             <Select
               value={form.agent}
               onValueChange={(v) =>
-                setForm({ ...form, agent: v as CampaignInput["agent"] })
+                v && setForm({ ...form, agent: v as CampaignInput["agent"] })
               }
             >
               <SelectTrigger id="agent" className="w-full min-w-[400px] bg-background border-border hover:border-foreground/20 transition-colors">
@@ -160,6 +160,9 @@ function HomeContent() {
                 <SelectItem value="creative_agent">
                   Creative Agent &mdash; Generate ad creatives
                 </SelectItem>
+                <SelectItem value="interactive_creative">
+                  Interactive Creative &mdash; Generate with review checkpoints
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -170,7 +173,7 @@ function HomeContent() {
             </Label>
             <Select
               value=""
-              onValueChange={(v) => setForm({ ...form, brand: v })}
+              onValueChange={(v) => v && setForm({ ...form, brand: v })}
             >
               <SelectTrigger className="w-full bg-background border-border hover:border-foreground/20 transition-colors text-muted-foreground">
                 <SelectValue placeholder="Select a preset..." />
@@ -196,7 +199,7 @@ function HomeContent() {
             </Label>
             <Select
               value=""
-              onValueChange={(v) => setForm({ ...form, targetAudience: v })}
+              onValueChange={(v) => v && setForm({ ...form, targetAudience: v })}
             >
               <SelectTrigger className="w-full bg-background border-border hover:border-foreground/20 transition-colors text-muted-foreground">
                 <SelectValue placeholder="Select a preset..." />
@@ -227,7 +230,7 @@ function HomeContent() {
             </Label>
             <Select
               value=""
-              onValueChange={(v) => setForm({ ...form, targetProduct: v })}
+              onValueChange={(v) => v && setForm({ ...form, targetProduct: v })}
             >
               <SelectTrigger className="w-full bg-background border-border hover:border-foreground/20 transition-colors text-muted-foreground">
                 <SelectValue placeholder="Select a preset..." />
@@ -255,7 +258,7 @@ function HomeContent() {
             </Label>
             <Select
               value=""
-              onValueChange={(v) => setForm({ ...form, keySellingPoints: v })}
+              onValueChange={(v) => v && setForm({ ...form, keySellingPoints: v })}
             >
               <SelectTrigger className="w-full bg-background border-border hover:border-foreground/20 transition-colors text-muted-foreground">
                 <SelectValue placeholder="Select a preset..." />
@@ -280,7 +283,7 @@ function HomeContent() {
             />
           </div>
 
-          {form.agent === "creative_agent" && (
+          {(form.agent === "creative_agent" || form.agent === "interactive_creative") && (
             <div className="space-y-2 animate-fadeInUpSmooth">
               <Label htmlFor="trend" className="text-muted-foreground text-xs uppercase tracking-wider">
                 Target Search Trend

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,6 +16,12 @@ import {
 } from "@/components/ui/select";
 import { createSession } from "@/lib/api";
 import type { CampaignInput } from "@/lib/types";
+import {
+  BRAND_PRESETS,
+  AUDIENCE_PRESETS,
+  PRODUCT_PRESETS,
+  SELLING_POINTS_PRESETS,
+} from "@/lib/presets";
 
 export default function Home() {
   return (
@@ -162,6 +168,19 @@ function HomeContent() {
             <Label htmlFor="brand" className="text-muted-foreground text-xs uppercase tracking-wider">
               Brand Name
             </Label>
+            <Select
+              value=""
+              onValueChange={(v) => setForm({ ...form, brand: v })}
+            >
+              <SelectTrigger className="w-full bg-background border-border hover:border-foreground/20 transition-colors text-muted-foreground">
+                <SelectValue placeholder="Select a preset..." />
+              </SelectTrigger>
+              <SelectContent>
+                {BRAND_PRESETS.map((b) => (
+                  <SelectItem key={b} value={b}>{b}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <Input
               id="brand"
               placeholder='e.g., "Paul Reed Smith (PRS)"'
@@ -175,6 +194,21 @@ function HomeContent() {
             <Label htmlFor="audience" className="text-muted-foreground text-xs uppercase tracking-wider">
               Target Audience
             </Label>
+            <Select
+              value=""
+              onValueChange={(v) => setForm({ ...form, targetAudience: v })}
+            >
+              <SelectTrigger className="w-full bg-background border-border hover:border-foreground/20 transition-colors text-muted-foreground">
+                <SelectValue placeholder="Select a preset..." />
+              </SelectTrigger>
+              <SelectContent>
+                {AUDIENCE_PRESETS.map((a) => (
+                  <SelectItem key={a} value={a}>
+                    {a.length > 80 ? `${a.slice(0, 80)}...` : a}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <Textarea
               id="audience"
               placeholder="Who are they? Include psychographics, lifestyle, hobbies..."
@@ -191,6 +225,19 @@ function HomeContent() {
             <Label htmlFor="product" className="text-muted-foreground text-xs uppercase tracking-wider">
               Target Product
             </Label>
+            <Select
+              value=""
+              onValueChange={(v) => setForm({ ...form, targetProduct: v })}
+            >
+              <SelectTrigger className="w-full bg-background border-border hover:border-foreground/20 transition-colors text-muted-foreground">
+                <SelectValue placeholder="Select a preset..." />
+              </SelectTrigger>
+              <SelectContent>
+                {PRODUCT_PRESETS.map((p) => (
+                  <SelectItem key={p} value={p}>{p}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <Input
               id="product"
               placeholder='e.g., "PRS SE CE24 Electric Guitar"'
@@ -206,6 +253,21 @@ function HomeContent() {
             <Label htmlFor="selling-points" className="text-muted-foreground text-xs uppercase tracking-wider">
               Key Selling Points
             </Label>
+            <Select
+              value=""
+              onValueChange={(v) => setForm({ ...form, keySellingPoints: v })}
+            >
+              <SelectTrigger className="w-full bg-background border-border hover:border-foreground/20 transition-colors text-muted-foreground">
+                <SelectValue placeholder="Select a preset..." />
+              </SelectTrigger>
+              <SelectContent>
+                {SELLING_POINTS_PRESETS.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s.length > 80 ? `${s.slice(0, 80)}...` : s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <Textarea
               id="selling-points"
               placeholder="What's the core benefit? Why will the audience care?"

--- a/frontend/src/app/results/[sessionId]/page.tsx
+++ b/frontend/src/app/results/[sessionId]/page.tsx
@@ -289,7 +289,7 @@ export default function ResultsPage({
     .filter((f) => f.value);
 
   // Does this run have the creative asset + eval view?
-  const hasCreativeView = appName === "creative_agent" && visualConcepts.length > 0;
+  const hasCreativeView = (appName === "creative_agent" || appName === "interactive_creative") && visualConcepts.length > 0;
 
   return (
     <div className="mx-auto max-w-[1600px] px-6 py-8">
@@ -322,8 +322,8 @@ export default function ResultsPage({
         </div>
       </div>
 
-      {/* Campaign metadata bar — sticky, equal-width, centered */}
-      <div className="sticky top-0 z-30 -mx-6 px-6 pt-4 pb-3 mb-6 bg-background/90 backdrop-blur-xl border-b border-border/50 shadow-sm">
+      {/* Campaign metadata bar — equal-width, centered */}
+      <div className="-mx-6 px-6 pt-4 pb-3 mb-6 border-b border-border/50">
         <div className="grid gap-3 justify-center" style={{ gridTemplateColumns: `repeat(${campaignFields.length + (gcsUri ? 1 : 0)}, minmax(0, 240px))` }}>
           {campaignFields.map((f) => (
             <div key={f.key} className="glass rounded-xl px-4 py-2.5 text-center">

--- a/frontend/src/app/results/[sessionId]/page.tsx
+++ b/frontend/src/app/results/[sessionId]/page.tsx
@@ -12,13 +12,92 @@ import {
 } from "@/components/ui/collapsible";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { GcsWidget } from "@/components/gcs-widget";
-import { GalleryViewer } from "@/components/gallery-viewer";
 import { getSession, listArtifacts, getArtifact } from "@/lib/api";
 import type { Session } from "@/lib/types";
 
 interface ArtifactData {
   name: string;
   data: unknown;
+}
+
+interface EvalVerdict {
+  dimension: string;
+  score: number;
+  verdict: "pass" | "fail";
+  rationale: string;
+}
+
+interface CreativeScore {
+  overall_score: number;
+  passed: boolean;
+  verdicts: EvalVerdict[];
+  strengths: string[];
+  improvements: string[];
+}
+
+interface AdCopyEvaluation {
+  original_id: number;
+  headline: string;
+  tone_style: string;
+  score: CreativeScore;
+}
+
+interface VisualConceptEvaluation {
+  ad_copy_id: number;
+  concept_name: string;
+  score: CreativeScore;
+}
+
+interface EvalReport {
+  brand: string;
+  target_product: string;
+  target_search_trend: string;
+  ad_copy_evaluations: AdCopyEvaluation[];
+  visual_concept_evaluations: VisualConceptEvaluation[];
+  summary: {
+    total_ad_copies: number;
+    ad_copies_passed: number;
+    avg_ad_copy_score: number;
+    total_visual_concepts: number;
+    visual_concepts_passed: number;
+    avg_visual_score: number;
+    overall_pass_rate: number;
+    weakest_dimensions: string[];
+  };
+}
+
+// Visual concept data from session state (final_visual_concepts)
+interface VisualConcept {
+  ad_copy_id: number;
+  concept_name: string;
+  trend: string;
+  trend_reference: string;
+  markets_product: string;
+  audience_appeal: string;
+  selection_rationale: string;
+  headline: string;
+  social_caption: string;
+  call_to_action: string;
+  concept_summary: string;
+  image_generation_prompt: string;
+}
+
+// Ad copy data from session state (ad_copy_critique)
+interface AdCopy {
+  original_id: number;
+  headline: string;
+  body_text: string;
+  tone_style: string;
+  trend_connection: string;
+  audience_appeal_rationale: string;
+  social_caption: string;
+  call_to_action: string;
+  detailed_performance_rationale: string;
+}
+
+/** Replicate Python's REMOVE_PUNCTUATION + replace(" ", "_") for image filenames. */
+function conceptNameToFilename(name: string): string {
+  return name.replace(/[^\w\s]/g, "").replace(/ /g, "_") + ".png";
 }
 
 export default function ResultsPage({
@@ -35,6 +114,7 @@ export default function ResultsPage({
   const [artifacts, setArtifacts] = useState<ArtifactData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [evalReport, setEvalReport] = useState<EvalReport | null>(null);
   const [stateOpen, setStateOpen] = useState(false);
   const [artifactsOpen, setArtifactsOpen] = useState(false);
 
@@ -58,6 +138,26 @@ export default function ResultsPage({
           })
         );
         setArtifacts(loaded);
+
+        // Fetch eval report from GCS (optional — silently skip if missing)
+        const folder = sess.state?.gcs_folder as string;
+        const subdir = sess.state?.agent_output_dir as string;
+        const bucket =
+          (sess.state?.gcs_bucket_name as string) ||
+          (sess.state?.gcs_bucket as string)?.replace(/^gs:\/\//, "") ||
+          "";
+        if (bucket && folder && subdir) {
+          try {
+            const evalUrl = `/api/gcs?bucket=${encodeURIComponent(bucket)}&path=${encodeURIComponent(`${folder}/${subdir}/creative_eval_report.json`)}`;
+            const evalRes = await fetch(evalUrl);
+            if (evalRes.ok) {
+              const evalData = await evalRes.json();
+              setEvalReport(evalData);
+            }
+          } catch {
+            // eval report not available — skip
+          }
+        }
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "Failed to load results"
@@ -106,16 +206,63 @@ export default function ResultsPage({
     (state.gcs_bucket_name as string) ||
     (state.gcs_bucket as string)?.replace(/^gs:\/\//, "") ||
     "";
+  const folder = state.gcs_folder as string;
+  const subdir = state.agent_output_dir as string;
 
-  const galleryInfo = (() => {
-    const folder = state.gcs_folder as string;
-    const subdir = state.agent_output_dir as string;
+  const galleryUrl =
+    bucketName && folder && subdir
+      ? `/api/gcs?bucket=${encodeURIComponent(bucketName)}&path=${encodeURIComponent(`${folder}/${subdir}/creative_portfolio_gallery.html`)}`
+      : null;
+
+  // Extract visual concepts and ad copies from session state
+  const visualConceptsRaw = state.final_visual_concepts as { visual_concepts?: VisualConcept[] } | undefined;
+  const visualConcepts: VisualConcept[] = visualConceptsRaw?.visual_concepts || [];
+
+  const adCopyRaw = state.ad_copy_critique as { ad_copies?: AdCopy[] } | undefined;
+  const adCopies: AdCopy[] = adCopyRaw?.ad_copies || [];
+
+  // Build image URL for a visual concept
+  function getImageUrl(conceptName: string): string | null {
     if (!bucketName || !folder || !subdir) return null;
-    return {
-      bucket: bucketName,
-      objectPath: `${folder}/${subdir}/creative_portfolio_gallery.html`,
-    };
-  })();
+    const filename = conceptNameToFilename(conceptName);
+    return `/api/gcs?bucket=${encodeURIComponent(bucketName)}&path=${encodeURIComponent(`${folder}/${subdir}/${filename}`)}`;
+  }
+
+  // Find matching eval for a visual concept
+  function findVisualEval(conceptName: string): VisualConceptEvaluation | undefined {
+    return evalReport?.visual_concept_evaluations.find(
+      (ve) => ve.concept_name === conceptName
+    );
+  }
+
+  // Find matching ad copy eval for a visual concept.
+  // Try by ad_copy_id → original_id first, then by headline match, then by index.
+  function findAdCopyEvalForVisual(vc: VisualConcept, vcIndex: number): AdCopyEvaluation | undefined {
+    if (!evalReport) return undefined;
+    const evals = evalReport.ad_copy_evaluations;
+    // 1. Match by ID
+    const byId = evals.find((ae) => ae.original_id === vc.ad_copy_id);
+    if (byId) return byId;
+    // 2. Match by headline (visual concept carries the ad copy headline)
+    const byHeadline = evals.find((ae) => ae.headline === vc.headline);
+    if (byHeadline) return byHeadline;
+    // 3. Fall back to index position
+    if (vcIndex < evals.length) return evals[vcIndex];
+    return undefined;
+  }
+
+  // Find matching ad copy data from session state for a visual concept.
+  function findAdCopyForVisual(vc: VisualConcept, vcIndex: number): AdCopy | undefined {
+    // 1. Match by ID
+    const byId = adCopies.find((ac) => ac.original_id === vc.ad_copy_id);
+    if (byId) return byId;
+    // 2. Match by headline
+    const byHeadline = adCopies.find((ac) => ac.headline === vc.headline);
+    if (byHeadline) return byHeadline;
+    // 3. Fall back to index position
+    if (vcIndex < adCopies.length) return adCopies[vcIndex];
+    return undefined;
+  }
 
   const imageArtifacts = artifacts.filter(
     (a) => a.name.endsWith(".png") || a.name.endsWith(".jpg")
@@ -130,19 +277,23 @@ export default function ResultsPage({
       !a.name.endsWith(".html")
   );
 
-  // Campaign metadata fields for left sidebar
+  // Campaign metadata fields
   const campaignFields = [
     { label: "Brand", key: "brand" },
-    { label: "Target Audience", key: "target_audience" },
-    { label: "Target Product", key: "target_product" },
-    { label: "Key Selling Points", key: "key_selling_points" },
-    { label: "Search Trend", key: "target_search_trends" },
+    { label: "Audience", key: "target_audience" },
+    { label: "Product", key: "target_product" },
+    { label: "Selling Points", key: "key_selling_points" },
+    { label: "Trend", key: "target_search_trends" },
   ]
     .map((f) => ({ ...f, value: state[f.key] as string | undefined }))
     .filter((f) => f.value);
 
+  // Does this run have the creative asset + eval view?
+  const hasCreativeView = appName === "creative_agent" && visualConcepts.length > 0;
+
   return (
     <div className="mx-auto max-w-[1600px] px-6 py-8">
+      {/* Header row */}
       <div className="mb-6 flex items-center justify-between animate-fadeIn">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-foreground">
@@ -152,220 +303,458 @@ export default function ResultsPage({
             {appName} / {sessionId}
           </p>
         </div>
-        <Link href="/">
-          <Button variant="outline" size="sm" className="border-border bg-muted/50 hover:bg-muted">
-            New Run
-          </Button>
-        </Link>
+        <div className="flex items-center gap-2">
+          {galleryUrl && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-xs border-border bg-muted/50 hover:bg-muted"
+              onClick={() => window.open(galleryUrl, "_blank")}
+            >
+              Open Portfolio Gallery
+            </Button>
+          )}
+          <Link href="/">
+            <Button variant="outline" size="sm" className="border-border bg-muted/50 hover:bg-muted">
+              New Run
+            </Button>
+          </Link>
+        </div>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-[260px_1fr_260px]">
-        {/* Left sidebar — campaign metadata */}
-        <div className="space-y-3 animate-fadeInUp animation-delay-100 opacity-0" style={{ animationFillMode: "forwards" }}>
-          <h2 className="text-[10px] font-semibold text-muted-foreground tracking-wider uppercase pt-1">
-            Campaign Metadata
-          </h2>
-          {campaignFields.length === 0 ? (
-            <p className="text-xs text-muted-foreground italic">
-              No metadata available
-            </p>
-          ) : (
-            campaignFields.map((f) => (
-              <div key={f.key} className="glass rounded-xl px-4 py-3">
-                <dt className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                  {f.label}
-                </dt>
-                <dd className="mt-0.5 text-sm font-medium leading-snug break-words text-foreground">
-                  {f.value}
-                </dd>
-              </div>
-            ))
-          )}
-        </div>
-
-        {/* Center content area */}
-        <div className="animate-fadeInUp animation-delay-200 opacity-0" style={{ animationFillMode: "forwards" }}>
-          {/* Creative portfolio gallery */}
-          {appName === "creative_agent" && galleryInfo && (
-            <div className="mb-6">
-              <GalleryViewer
-                bucket={galleryInfo.bucket}
-                objectPath={galleryInfo.objectPath}
-              />
+      {/* Campaign metadata bar — sticky, equal-width, centered */}
+      <div className="sticky top-0 z-30 -mx-6 px-6 pt-4 pb-3 mb-6 bg-background/90 backdrop-blur-xl border-b border-border/50 shadow-sm">
+        <div className="grid gap-3 justify-center" style={{ gridTemplateColumns: `repeat(${campaignFields.length + (gcsUri ? 1 : 0)}, minmax(0, 240px))` }}>
+          {campaignFields.map((f) => (
+            <div key={f.key} className="glass rounded-xl px-4 py-2.5 text-center">
+              <dt className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                {f.label}
+              </dt>
+              <dd className="mt-0.5 text-sm font-medium leading-snug break-words text-foreground">
+                {f.value}
+              </dd>
             </div>
-          )}
-
-          {/* Artifacts */}
-          {artifacts.length > 0 && (
-            <Collapsible open={artifactsOpen} onOpenChange={setArtifactsOpen}>
-              <div className="glass rounded-2xl mb-6 overflow-hidden">
-                <CollapsibleTrigger className="w-full">
-                  <div className="cursor-pointer hover:bg-muted/30 transition-colors px-5 py-3 flex items-center justify-between">
-                    <span className="text-sm font-semibold text-foreground flex items-center gap-2">
-                      Artifacts
-                      <Badge
-                        variant="secondary"
-                        className="bg-primary/10 text-primary border-0 text-[10px]"
-                      >
-                        {artifacts.length}
-                      </Badge>
-                    </span>
-                    <span className="text-[10px] text-muted-foreground">
-                      {artifactsOpen ? "collapse" : "expand"}
-                    </span>
-                  </div>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  <div className="px-5 pb-5">
-                    <Tabs defaultValue="images">
-                      <TabsList className="bg-muted/50 border border-border">
-                        {imageArtifacts.length > 0 && (
-                          <TabsTrigger value="images">
-                            Images ({imageArtifacts.length})
-                          </TabsTrigger>
-                        )}
-                        {pdfArtifacts.length > 0 && (
-                          <TabsTrigger value="pdfs">
-                            PDFs ({pdfArtifacts.length})
-                          </TabsTrigger>
-                        )}
-                        {htmlArtifacts.length > 0 && (
-                          <TabsTrigger value="html">
-                            HTML ({htmlArtifacts.length})
-                          </TabsTrigger>
-                        )}
-                        {otherArtifacts.length > 0 && (
-                          <TabsTrigger value="other">
-                            Other ({otherArtifacts.length})
-                          </TabsTrigger>
-                        )}
-                      </TabsList>
-
-                      <TabsContent value="images">
-                        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
-                          {imageArtifacts.map((a) => {
-                            const folder = state.gcs_folder as string;
-                            const subdir = state.agent_output_dir as string;
-                            const src =
-                              bucketName && folder && subdir
-                                ? `/api/gcs?bucket=${encodeURIComponent(bucketName)}&path=${encodeURIComponent(`${folder}/${subdir}/${a.name}`)}`
-                                : null;
-                            return (
-                              <div
-                                key={a.name}
-                                className="overflow-hidden rounded-xl glass transition-all hover:shadow-md hover:shadow-black/5"
-                              >
-                                {src ? (
-                                  // eslint-disable-next-line @next/next/no-img-element
-                                  <img
-                                    src={src}
-                                    alt={a.name}
-                                    className="aspect-square w-full object-cover"
-                                  />
-                                ) : (
-                                  <div className="flex aspect-square items-center justify-center bg-muted/50 text-xs text-muted-foreground">
-                                    No preview
-                                  </div>
-                                )}
-                                <p className="truncate px-3 py-2 text-[10px] text-muted-foreground">
-                                  {a.name}
-                                </p>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </TabsContent>
-
-                      <TabsContent value="pdfs">
-                        <ul className="space-y-2">
-                          {pdfArtifacts.map((a) => (
-                            <li
-                              key={a.name}
-                              className="flex items-center justify-between rounded-lg glass px-4 py-3"
-                            >
-                              <span className="text-sm font-mono text-foreground/80">
-                                {a.name}
-                              </span>
-                              <Badge
-                                variant="outline"
-                                className="border-border"
-                              >
-                                PDF
-                              </Badge>
-                            </li>
-                          ))}
-                        </ul>
-                      </TabsContent>
-
-                      <TabsContent value="html">
-                        <ul className="space-y-2">
-                          {htmlArtifacts.map((a) => (
-                            <li
-                              key={a.name}
-                              className="flex items-center justify-between rounded-lg glass px-4 py-3"
-                            >
-                              <span className="text-sm font-mono text-foreground/80">
-                                {a.name}
-                              </span>
-                              <Badge
-                                variant="outline"
-                                className="border-border"
-                              >
-                                HTML
-                              </Badge>
-                            </li>
-                          ))}
-                        </ul>
-                      </TabsContent>
-
-                      <TabsContent value="other">
-                        <ul className="space-y-2">
-                          {otherArtifacts.map((a) => (
-                            <li
-                              key={a.name}
-                              className="rounded-lg glass px-4 py-3 text-sm font-mono text-foreground/80"
-                            >
-                              {a.name}
-                            </li>
-                          ))}
-                        </ul>
-                      </TabsContent>
-                    </Tabs>
-                  </div>
-                </CollapsibleContent>
-              </div>
-            </Collapsible>
-          )}
-
-          {/* Raw session state */}
-          <Collapsible open={stateOpen} onOpenChange={setStateOpen}>
-            <div className="glass rounded-2xl overflow-hidden">
-              <CollapsibleTrigger className="w-full">
-                <div className="cursor-pointer hover:bg-muted/30 transition-colors px-5 py-3 flex items-center justify-between">
-                  <span className="text-sm font-semibold text-foreground">
-                    Session State
-                  </span>
-                  <span className="text-[10px] text-muted-foreground">
-                    {stateOpen ? "collapse" : "expand"}
-                  </span>
-                </div>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <div className="px-5 pb-5">
-                  <pre className="max-h-96 overflow-auto rounded-lg bg-muted/50 p-4 text-xs font-mono text-foreground/70">
-                    {JSON.stringify(state, null, 2)}
-                  </pre>
-                </div>
-              </CollapsibleContent>
-            </div>
-          </Collapsible>
-        </div>
-
-        {/* Right sidebar — Cloud Storage Output */}
-        <div className="space-y-3 animate-fadeInUp animation-delay-300 opacity-0" style={{ animationFillMode: "forwards" }}>
+          ))}
           {gcsUri && <GcsWidget uri={gcsUri} />}
         </div>
       </div>
+
+      {/* Eval summary header */}
+      {evalReport && (
+        <div className="glass rounded-2xl mb-6 px-5 py-4 space-y-3 animate-fadeInUp animation-delay-200 opacity-0" style={{ animationFillMode: "forwards" }}>
+          <h2 className="text-sm font-semibold text-foreground">
+            Creative Evaluation
+          </h2>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="rounded-xl bg-muted/50 px-4 py-3 text-center">
+              <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Overall Pass Rate
+              </p>
+              <p className={`text-2xl font-bold ${evalReport.summary.overall_pass_rate >= 0.7 ? "text-emerald-600" : "text-red-500"}`}>
+                {(evalReport.summary.overall_pass_rate * 100).toFixed(0)}%
+              </p>
+            </div>
+            <div className="rounded-xl bg-muted/50 px-4 py-3 text-center">
+              <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Ad Copies
+              </p>
+              <p className="text-lg font-semibold text-foreground">
+                {evalReport.summary.ad_copies_passed}/{evalReport.summary.total_ad_copies} passed
+              </p>
+              <p className="text-xs text-muted-foreground">
+                avg {evalReport.summary.avg_ad_copy_score.toFixed(2)}
+              </p>
+            </div>
+            <div className="rounded-xl bg-muted/50 px-4 py-3 text-center">
+              <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Visual Concepts
+              </p>
+              <p className="text-lg font-semibold text-foreground">
+                {evalReport.summary.visual_concepts_passed}/{evalReport.summary.total_visual_concepts} passed
+              </p>
+              <p className="text-xs text-muted-foreground">
+                avg {evalReport.summary.avg_visual_score.toFixed(2)}
+              </p>
+            </div>
+          </div>
+          {evalReport.summary.weakest_dimensions.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Weakest:
+              </span>
+              {evalReport.summary.weakest_dimensions.map((d) => (
+                <Badge
+                  key={d}
+                  variant="secondary"
+                  className="bg-red-500/10 text-red-600 border-0 text-[10px]"
+                >
+                  {d.replace(/_/g, " ")}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Creative rows: image + eval per visual concept */}
+      {hasCreativeView && (
+        <div className="space-y-6 mb-6 animate-fadeInUp animation-delay-200 opacity-0" style={{ animationFillMode: "forwards" }}>
+          {visualConcepts.map((vc, i) => {
+            const imgUrl = getImageUrl(vc.concept_name);
+            const vcEval = findVisualEval(vc.concept_name);
+            const acEval = findAdCopyEvalForVisual(vc, i);
+            const ac = findAdCopyForVisual(vc, i);
+
+            return (
+              <div
+                key={i}
+                className="glass rounded-2xl overflow-hidden"
+              >
+                <div className="grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                  {/* Left: gallery-style image card */}
+                  <div className="flex flex-col">
+                    {/* Headline */}
+                    <div className="px-5 py-3 bg-muted/30 border-b border-border">
+                      <h3 className="text-lg font-semibold text-foreground">
+                        {vc.headline}
+                      </h3>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {vc.concept_name}
+                      </p>
+                    </div>
+
+                    {/* Image with hover overlay */}
+                    <div className="relative group overflow-hidden flex-1">
+                      {imgUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={imgUrl}
+                          alt={vc.concept_summary}
+                          className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
+                        />
+                      ) : (
+                        <div className="flex items-center justify-center h-64 bg-muted/50 text-sm text-muted-foreground">
+                          No image available
+                        </div>
+                      )}
+
+                      {/* Hover overlay — 4 corners like the gallery HTML */}
+                      <div className="absolute inset-0 bg-black/70 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none grid grid-cols-2 grid-rows-2 p-5 gap-3">
+                        <div className="self-start justify-self-start text-white text-sm leading-snug">
+                          <span className="block text-sky-300 font-semibold text-xs mb-1">Trend Reference:</span>
+                          {vc.trend_reference}
+                        </div>
+                        <div className="self-start justify-self-end text-right text-white text-sm leading-snug">
+                          <span className="block text-sky-300 font-semibold text-xs mb-1">Visual Concept:</span>
+                          {vc.concept_summary}
+                        </div>
+                        <div className="self-end justify-self-start text-white text-sm leading-snug">
+                          <span className="block text-sky-300 font-semibold text-xs mb-1">Markets Product:</span>
+                          {vc.markets_product}
+                        </div>
+                        <div className="self-end justify-self-end text-right text-white text-sm leading-snug">
+                          <span className="block text-sky-300 font-semibold text-xs mb-1">Audience Appeal:</span>
+                          {vc.audience_appeal}
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Caption */}
+                    <div className="px-5 py-3 border-t border-border">
+                      <p className="text-sm text-foreground/80">{vc.social_caption}</p>
+                    </div>
+                  </div>
+
+                  {/* Right: eval scores */}
+                  <div className="border-l border-border p-5 space-y-4 overflow-y-auto max-h-[700px]">
+                    {/* Ad copy details + eval */}
+                    {ac && (
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                          <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                            Ad Copy
+                          </h4>
+                          {acEval && (
+                            <Badge
+                              variant="secondary"
+                              className={`border-0 text-xs ${acEval.score.passed ? "bg-emerald-500/15 text-emerald-600" : "bg-red-500/15 text-red-600"}`}
+                            >
+                              {acEval.score.passed ? "PASS" : "FAIL"} &middot; {(acEval.score.overall_score * 100).toFixed(0)}%
+                            </Badge>
+                          )}
+                        </div>
+
+                        {/* Ad copy content */}
+                        <div className="rounded-xl bg-muted/30 p-3 space-y-2">
+                          <p className="font-semibold text-sm text-foreground">{ac.headline}</p>
+                          <p className="text-xs text-foreground/70 leading-relaxed">{ac.body_text}</p>
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <Badge variant="outline" className="border-border text-[10px]">{ac.tone_style}</Badge>
+                            <span className="text-[10px] text-muted-foreground">CTA: {ac.call_to_action}</span>
+                          </div>
+                        </div>
+
+                        {/* Ad copy eval verdicts */}
+                        {acEval && (
+                          <div className="grid grid-cols-2 gap-1.5">
+                            {acEval.score.verdicts.map((v) => (
+                              <div key={v.dimension} className="rounded-lg bg-muted/20 px-2.5 py-1.5">
+                                <div className="flex items-center justify-between mb-0.5">
+                                  <span className="text-[9px] font-medium uppercase tracking-wider text-muted-foreground">
+                                    {v.dimension.replace(/_/g, " ")}
+                                  </span>
+                                  <span className={`text-[10px] font-bold ${v.score >= 7 ? "text-emerald-600" : "text-red-500"}`}>
+                                    {v.score}/10
+                                  </span>
+                                </div>
+                                <p className="text-[10px] text-muted-foreground leading-snug">
+                                  {v.rationale}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Divider */}
+                    {ac && vcEval && <div className="border-t border-border" />}
+
+                    {/* Visual concept eval */}
+                    {vcEval && (
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                          <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                            Visual Concept
+                          </h4>
+                          <Badge
+                            variant="secondary"
+                            className={`border-0 text-xs ${vcEval.score.passed ? "bg-emerald-500/15 text-emerald-600" : "bg-red-500/15 text-red-600"}`}
+                          >
+                            {vcEval.score.passed ? "PASS" : "FAIL"} &middot; {(vcEval.score.overall_score * 100).toFixed(0)}%
+                          </Badge>
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-1.5">
+                          {vcEval.score.verdicts.map((v) => (
+                            <div key={v.dimension} className="rounded-lg bg-muted/20 px-2.5 py-1.5">
+                              <div className="flex items-center justify-between mb-0.5">
+                                <span className="text-[9px] font-medium uppercase tracking-wider text-muted-foreground">
+                                  {v.dimension.replace(/_/g, " ")}
+                                </span>
+                                <span className={`text-[10px] font-bold ${v.score >= 7 ? "text-emerald-600" : "text-red-500"}`}>
+                                  {v.score}/10
+                                </span>
+                              </div>
+                              <p className="text-[10px] text-muted-foreground leading-snug">
+                                {v.rationale}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+
+                        {/* Strengths & Improvements (combined from both evals) */}
+                        <div className="grid grid-cols-2 gap-3 text-xs">
+                          {vcEval.score.strengths.length > 0 && (
+                            <div>
+                              <p className="font-medium text-emerald-600 mb-1">Strengths</p>
+                              <ul className="space-y-1 text-muted-foreground">
+                                {vcEval.score.strengths.map((s, j) => (
+                                  <li key={j} className="leading-snug text-[10px]">&bull; {s}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                          {vcEval.score.improvements.length > 0 && (
+                            <div>
+                              <p className="font-medium text-amber-600 mb-1">Improvements</p>
+                              <ul className="space-y-1 text-muted-foreground">
+                                {vcEval.score.improvements.map((s, j) => (
+                                  <li key={j} className="leading-snug text-[10px]">&bull; {s}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Fallback when no eval data */}
+                    {!acEval && !vcEval && (
+                      <p className="text-xs text-muted-foreground italic">
+                        No evaluation data available for this creative.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Artifacts collapsible */}
+      {artifacts.length > 0 && (
+        <Collapsible open={artifactsOpen} onOpenChange={setArtifactsOpen}>
+          <div className="glass rounded-2xl mb-6 overflow-hidden">
+            <CollapsibleTrigger className="w-full">
+              <div className="cursor-pointer hover:bg-muted/30 transition-colors px-5 py-3 flex items-center justify-between">
+                <span className="text-sm font-semibold text-foreground flex items-center gap-2">
+                  Artifacts
+                  <Badge
+                    variant="secondary"
+                    className="bg-primary/10 text-primary border-0 text-[10px]"
+                  >
+                    {artifacts.length}
+                  </Badge>
+                </span>
+                <span className="text-[10px] text-muted-foreground">
+                  {artifactsOpen ? "collapse" : "expand"}
+                </span>
+              </div>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="px-5 pb-5">
+                <Tabs defaultValue="images">
+                  <TabsList className="bg-muted/50 border border-border">
+                    {imageArtifacts.length > 0 && (
+                      <TabsTrigger value="images">
+                        Images ({imageArtifacts.length})
+                      </TabsTrigger>
+                    )}
+                    {pdfArtifacts.length > 0 && (
+                      <TabsTrigger value="pdfs">
+                        PDFs ({pdfArtifacts.length})
+                      </TabsTrigger>
+                    )}
+                    {htmlArtifacts.length > 0 && (
+                      <TabsTrigger value="html">
+                        HTML ({htmlArtifacts.length})
+                      </TabsTrigger>
+                    )}
+                    {otherArtifacts.length > 0 && (
+                      <TabsTrigger value="other">
+                        Other ({otherArtifacts.length})
+                      </TabsTrigger>
+                    )}
+                  </TabsList>
+
+                  <TabsContent value="images">
+                    <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+                      {imageArtifacts.map((a) => {
+                        const src =
+                          bucketName && folder && subdir
+                            ? `/api/gcs?bucket=${encodeURIComponent(bucketName)}&path=${encodeURIComponent(`${folder}/${subdir}/${a.name}`)}`
+                            : null;
+                        return (
+                          <div
+                            key={a.name}
+                            className="overflow-hidden rounded-xl glass transition-all hover:shadow-md hover:shadow-black/5"
+                          >
+                            {src ? (
+                              // eslint-disable-next-line @next/next/no-img-element
+                              <img
+                                src={src}
+                                alt={a.name}
+                                className="aspect-square w-full object-cover"
+                              />
+                            ) : (
+                              <div className="flex aspect-square items-center justify-center bg-muted/50 text-xs text-muted-foreground">
+                                No preview
+                              </div>
+                            )}
+                            <p className="truncate px-3 py-2 text-[10px] text-muted-foreground">
+                              {a.name}
+                            </p>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </TabsContent>
+
+                  <TabsContent value="pdfs">
+                    <ul className="space-y-2">
+                      {pdfArtifacts.map((a) => (
+                        <li
+                          key={a.name}
+                          className="flex items-center justify-between rounded-lg glass px-4 py-3"
+                        >
+                          <span className="text-sm font-mono text-foreground/80">
+                            {a.name}
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className="border-border"
+                          >
+                            PDF
+                          </Badge>
+                        </li>
+                      ))}
+                    </ul>
+                  </TabsContent>
+
+                  <TabsContent value="html">
+                    <ul className="space-y-2">
+                      {htmlArtifacts.map((a) => (
+                        <li
+                          key={a.name}
+                          className="flex items-center justify-between rounded-lg glass px-4 py-3"
+                        >
+                          <span className="text-sm font-mono text-foreground/80">
+                            {a.name}
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className="border-border"
+                          >
+                            HTML
+                          </Badge>
+                        </li>
+                      ))}
+                    </ul>
+                  </TabsContent>
+
+                  <TabsContent value="other">
+                    <ul className="space-y-2">
+                      {otherArtifacts.map((a) => (
+                        <li
+                          key={a.name}
+                          className="rounded-lg glass px-4 py-3 text-sm font-mono text-foreground/80"
+                        >
+                          {a.name}
+                        </li>
+                      ))}
+                    </ul>
+                  </TabsContent>
+                </Tabs>
+              </div>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
+      )}
+
+      {/* Raw session state */}
+      <Collapsible open={stateOpen} onOpenChange={setStateOpen}>
+        <div className="glass rounded-2xl overflow-hidden">
+          <CollapsibleTrigger className="w-full">
+            <div className="cursor-pointer hover:bg-muted/30 transition-colors px-5 py-3 flex items-center justify-between">
+              <span className="text-sm font-semibold text-foreground">
+                Session State
+              </span>
+              <span className="text-[10px] text-muted-foreground">
+                {stateOpen ? "collapse" : "expand"}
+              </span>
+            </div>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="px-5 pb-5">
+              <pre className="max-h-96 overflow-auto rounded-lg bg-muted/50 p-4 text-xs font-mono text-foreground/70">
+                {JSON.stringify(state, null, 2)}
+              </pre>
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
     </div>
   );
 }

--- a/frontend/src/app/results/[sessionId]/page.tsx
+++ b/frontend/src/app/results/[sessionId]/page.tsx
@@ -13,6 +13,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { GcsWidget } from "@/components/gcs-widget";
 import { getSession, listArtifacts, getArtifact } from "@/lib/api";
+import { formatStateValue } from "@/lib/utils";
 import type { Session } from "@/lib/types";
 
 interface ArtifactData {
@@ -285,7 +286,7 @@ export default function ResultsPage({
     { label: "Selling Points", key: "key_selling_points" },
     { label: "Trend", key: "target_search_trends" },
   ]
-    .map((f) => ({ ...f, value: state[f.key] as string | undefined }))
+    .map((f) => ({ ...f, value: formatStateValue(state[f.key]) }))
     .filter((f) => f.value);
 
   // Does this run have the creative asset + eval view?

--- a/frontend/src/app/run/[sessionId]/page.tsx
+++ b/frontend/src/app/run/[sessionId]/page.tsx
@@ -1,16 +1,25 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo, use } from "react";
+import React, { useEffect, useState, useRef, useMemo, use } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EventLog } from "@/components/event-log";
 import { TrendCards, parseTrendsMarkdown } from "@/components/trend-cards";
 import { GcsWidget } from "@/components/gcs-widget";
-import { streamRun } from "@/lib/api";
+import { Textarea } from "@/components/ui/textarea";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { streamRun, resumeRun, getSession } from "@/lib/api";
 import type { AgentEvent } from "@/lib/types";
 
-type Status = "running" | "completed" | "error";
+type Status = "running" | "completed" | "error" | "paused";
+
+interface PauseContext {
+  functionCallId: string;
+  functionName: string;
+  eventId: string;
+}
 
 /** Pipeline state keys to surface as collapsible widgets, in display order (newest first). */
 const PIPELINE_STATE_KEYS = [
@@ -143,14 +152,15 @@ function ItemCard({
   item: Record<string, unknown>;
   index: number;
   widgetKey: string;
-}) {
+}): React.ReactNode {
   const title =
     (item.concept_name as string) ||
     (item.headline as string) ||
     `Item ${index + 1}`;
 
   const layout = WIDGET_LAYOUTS[widgetKey] || DEFAULT_LAYOUT;
-  const { pairs, fullWidth } = layout;
+  const pairs: [string, string][] = layout.pairs;
+  const fullWidth = layout.fullWidth;
 
   // Collect fields used in structured layout
   const structuredFields = new Set<string>();
@@ -181,7 +191,7 @@ function ItemCard({
       </div>
 
       {/* Side-by-side panels */}
-      {pairs.map(([leftKey, rightKey]) => {
+      {pairs.map(([leftKey, rightKey]): React.ReactNode => {
         const leftVal = item[leftKey];
         const rightVal = item[rightKey];
         if (!leftVal && !rightVal) return null;
@@ -206,7 +216,7 @@ function ItemCard({
       })}
 
       {/* Full-width panel */}
-      {fullWidth && item[fullWidth] && (
+      {fullWidth && !!item[fullWidth] && (
         <div className="rounded-md bg-cyan-50/60 border border-cyan-200/40 px-2.5 py-2">
           <FieldCell fieldKey={fullWidth} value={item[fullWidth]} />
         </div>
@@ -319,6 +329,249 @@ function PipelineWidget({
   );
 }
 
+/* ── Review panel components for interactive mode ── */
+
+function ReviewResearch({
+  state,
+  onResume,
+}: {
+  state: Record<string, unknown>;
+  onResume: (response: Record<string, unknown>) => void;
+}) {
+  const [feedback, setFeedback] = useState("");
+  const [editMode, setEditMode] = useState(false);
+  const report = state.combined_final_cited_report as string | undefined;
+  const [editedReport, setEditedReport] = useState(report ?? "");
+
+  return (
+    <div className="glass rounded-2xl p-6 space-y-4 animate-fadeInUp">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-amber-500" />
+          <h2 className="text-lg font-semibold">Review Research Report</h2>
+        </div>
+        {report && (
+          <button
+            onClick={() => setEditMode((v) => !v)}
+            className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+          >
+            {editMode ? "Preview" : "Edit"}
+          </button>
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Review the research findings below. Approve to continue to ad copy generation,
+        or provide feedback for revisions.
+      </p>
+      {report && !editMode && (
+        <div className="max-h-[28rem] overflow-y-auto rounded-lg bg-muted/30 p-5 border border-border prose prose-sm prose-neutral max-w-none
+          prose-headings:text-foreground prose-headings:font-bold
+          prose-h1:text-lg prose-h2:text-base prose-h3:text-sm
+          prose-p:text-foreground/85 prose-p:leading-relaxed
+          prose-a:text-primary prose-a:no-underline hover:prose-a:underline
+          prose-strong:text-foreground prose-strong:font-semibold
+          prose-li:text-foreground/85
+          prose-code:text-xs prose-code:bg-muted prose-code:rounded prose-code:px-1
+          prose-blockquote:border-l-primary/30 prose-blockquote:text-muted-foreground">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{report}</ReactMarkdown>
+        </div>
+      )}
+      {report && editMode && (
+        <Textarea
+          value={editedReport}
+          onChange={(e) => setEditedReport(e.target.value)}
+          rows={16}
+          className="bg-background border-border font-mono text-xs leading-relaxed max-h-[28rem]"
+        />
+      )}
+      <Textarea
+        placeholder="Optional feedback or revision requests..."
+        value={feedback}
+        onChange={(e) => setFeedback(e.target.value)}
+        rows={3}
+        className="bg-background border-border"
+      />
+      <div className="flex gap-3">
+        <Button onClick={() => onResume({ status: "approved", feedback, instruction: "User approved the research. Continue to the next step in the WORKFLOW." })}>
+          Approve &amp; Continue
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => onResume({ status: "revision_requested", feedback, instruction: "User requested changes to the research. Address their feedback, then continue the WORKFLOW." })}
+          disabled={!feedback}
+        >
+          Request Changes
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** Labeled field for review cards */
+function ReviewField({ label, value, color }: { label: string; value: string; color: string }) {
+  if (!value) return null;
+  return (
+    <div>
+      <dt className={`text-[10px] font-bold uppercase tracking-wider ${color}`}>{label}</dt>
+      <dd className="mt-0.5 text-sm leading-snug text-foreground/85">{value}</dd>
+    </div>
+  );
+}
+
+function ReviewAdCopies({
+  state,
+  onResume,
+}: {
+  state: Record<string, unknown>;
+  onResume: (response: Record<string, unknown>) => void;
+}) {
+  const [feedback, setFeedback] = useState("");
+  const adCopies = extractItems(state.ad_copy_critique);
+
+  return (
+    <div className="glass rounded-2xl p-6 space-y-4 animate-fadeInUp">
+      <div className="flex items-center gap-2">
+        <span className="inline-block h-2.5 w-2.5 rounded-full bg-amber-500" />
+        <h2 className="text-lg font-semibold">Review Ad Copies</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Review the generated ad copies. Approve to continue to visual concept generation.
+      </p>
+      {adCopies && (
+        <div className="space-y-3 max-h-[28rem] overflow-y-auto">
+          {adCopies.map((copy, i) => (
+            <div key={i} className="rounded-xl border border-border/60 bg-background/50 p-4 space-y-3">
+              {/* Title bar */}
+              <div className="flex items-center gap-2 pb-2 border-b border-border/40">
+                <Badge variant="secondary" className="text-[10px] px-1.5 py-0 bg-indigo-100 text-indigo-600 border-0 font-bold">
+                  {i + 1}
+                </Badge>
+                <span className="text-sm font-bold text-foreground">
+                  {String(copy.headline ?? `Ad Copy ${i + 1}`)}
+                </span>
+              </div>
+
+              {/* Two-column field grid */}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-md bg-muted/40 px-3 py-2">
+                  <ReviewField label="Body Text" value={String(copy.body_text ?? "")} color="text-indigo-500" />
+                </div>
+                <div className="rounded-md bg-muted/40 px-3 py-2">
+                  <ReviewField label="Tone / Style" value={String(copy.tone_style ?? "")} color="text-violet-500" />
+                </div>
+                <div className="rounded-md bg-muted/40 px-3 py-2">
+                  <ReviewField label="Call to Action" value={String(copy.call_to_action ?? "")} color="text-amber-600" />
+                </div>
+                <div className="rounded-md bg-muted/40 px-3 py-2">
+                  <ReviewField label="Trend Connection" value={String(copy.trend_connection ?? "")} color="text-emerald-600" />
+                </div>
+              </div>
+
+              {/* Full-width fields */}
+              {!!copy.audience_appeal_rationale && (
+                <div className="rounded-md bg-pink-50/60 border border-pink-200/40 px-3 py-2">
+                  <ReviewField label="Audience Appeal" value={String(copy.audience_appeal_rationale)} color="text-pink-600" />
+                </div>
+              )}
+              {!!copy.social_caption && (
+                <div className="rounded-md bg-amber-50/60 border border-amber-200/40 px-3 py-2">
+                  <ReviewField label="Social Caption" value={String(copy.social_caption)} color="text-amber-500" />
+                </div>
+              )}
+              {!!copy.detailed_performance_rationale && (
+                <div className="rounded-md bg-orange-50/60 border border-orange-200/40 px-3 py-2">
+                  <ReviewField label="Performance Rationale" value={String(copy.detailed_performance_rationale)} color="text-orange-500" />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      <Textarea
+        placeholder="Optional feedback..."
+        value={feedback}
+        onChange={(e) => setFeedback(e.target.value)}
+        rows={3}
+        className="bg-background border-border"
+      />
+      <div className="flex gap-3">
+        <Button onClick={() => onResume({ status: "approved", feedback, instruction: "User approved the ad copies. Continue to the next step in the WORKFLOW — generate visual concepts." })}>
+          Approve &amp; Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ReviewVisualConcepts({
+  state,
+  onResume,
+}: {
+  state: Record<string, unknown>;
+  onResume: (response: Record<string, unknown>) => void;
+}) {
+  const [feedback, setFeedback] = useState("");
+  const concepts = extractItems(state.final_visual_concepts);
+
+  return (
+    <div className="glass rounded-2xl p-6 space-y-4 animate-fadeInUp">
+      <div className="flex items-center gap-2">
+        <span className="inline-block h-2.5 w-2.5 rounded-full bg-amber-500" />
+        <h2 className="text-lg font-semibold">Review Visual Concepts</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Review the visual concepts and image prompts. Approve to generate images.
+      </p>
+      {concepts && (
+        <div className="space-y-3 max-h-96 overflow-y-auto">
+          {concepts.map((concept, i) => (
+            <div key={i} className="rounded-lg border p-4 space-y-2">
+              <div className="font-medium">{String(concept.concept_name ?? `Concept ${i + 1}`)}</div>
+              <div className="text-sm text-muted-foreground">{String(concept.concept_summary ?? "")}</div>
+              <div className="text-xs text-cyan-600 font-mono bg-muted/30 rounded p-2">
+                {String(concept.image_generation_prompt ?? "")}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <Textarea
+        placeholder="Optional feedback..."
+        value={feedback}
+        onChange={(e) => setFeedback(e.target.value)}
+        rows={3}
+        className="bg-background border-border"
+      />
+      <div className="flex gap-3">
+        <Button onClick={() => onResume({ status: "approved", feedback, instruction: "User approved the visual concepts. Continue to the next step in the WORKFLOW — generate images." })}>
+          Approve &amp; Generate Images
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ReviewPanel({
+  functionName,
+  sessionState,
+  onResume,
+}: {
+  functionName: string;
+  sessionState: Record<string, unknown>;
+  onResume: (response: Record<string, unknown>) => void;
+}) {
+  if (functionName === "review_research") {
+    return <ReviewResearch state={sessionState} onResume={onResume} />;
+  }
+  if (functionName === "review_ad_copies") {
+    return <ReviewAdCopies state={sessionState} onResume={onResume} />;
+  }
+  if (functionName === "review_visual_concepts") {
+    return <ReviewVisualConcepts state={sessionState} onResume={onResume} />;
+  }
+  return null;
+}
+
 export default function RunPage({
   params,
 }: {
@@ -332,7 +585,9 @@ export default function RunPage({
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [sessionState, setSessionState] = useState<Record<string, unknown>>({});
   const [toastDismissed, setToastDismissed] = useState(false);
+  const [pauseContext, setPauseContext] = useState<PauseContext | null>(null);
   const startedRef = useRef(false);
+  const seenEventIds = useRef(new Set<string>());
 
   const appName = searchParams.get("app") || "trend_trawler";
   const userId = searchParams.get("userId") || "default_user";
@@ -356,12 +611,17 @@ export default function RunPage({
 
     async function run() {
       try {
+        let paused = false;
         for await (const event of streamRun(
           appName,
           userId,
           sessionId,
           message
         )) {
+          // Deduplicate events by ID
+          if (event.id && seenEventIds.current.has(event.id)) continue;
+          if (event.id) seenEventIds.current.add(event.id);
+
           setEvents((prev) => [...prev, event]);
 
           if (event.actions?.stateDelta) {
@@ -370,8 +630,38 @@ export default function RunPage({
               ...event.actions!.stateDelta,
             }));
           }
+
+          // Detect long-running tool pause (interactive mode).
+          // IMPORTANT: Skip partial (streaming) events — their function call
+          // IDs are regenerated per chunk and won't match the session's final
+          // event. Only capture pause context from the non-partial event.
+          if (
+            !event.partial &&
+            event.longRunningToolIds &&
+            event.longRunningToolIds.length > 0
+          ) {
+            const functionCalls = event.content?.parts
+              ?.filter((p) => p.functionCall)
+              ?.map((p) => p.functionCall!) ?? [];
+
+            const pausedCall = functionCalls.find((fc) =>
+              event.longRunningToolIds!.includes(fc.id ?? "")
+            );
+
+            if (pausedCall) {
+              setPauseContext({
+                functionCallId: pausedCall.id ?? "",
+                functionName: pausedCall.name ?? "",
+                eventId: event.id,
+              });
+              setStatus("paused");
+              paused = true;
+              // Fetch full session state so campaign metadata is available
+              syncSessionState();
+            }
+          }
         }
-        setStatus("completed");
+        if (!paused) setStatus("completed");
       } catch (err) {
         setStatus("error");
         setErrorMsg(
@@ -382,6 +672,127 @@ export default function RunPage({
 
     run();
   }, [appName, userId, sessionId]);
+
+  // Resume from a paused long-running tool
+  async function handleResume(response: Record<string, unknown>) {
+    if (!pauseContext) return;
+    setStatus("running");
+    const ctx = pauseContext;
+    setPauseContext(null);
+
+    try {
+      let paused = false;
+      let eventCount = 0;
+      for await (const event of resumeRun(
+        appName,
+        userId,
+        sessionId,
+        ctx.functionCallId,
+        ctx.functionName,
+        ctx.eventId,
+        response
+      )) {
+        // Deduplicate events by ID
+        if (event.id && seenEventIds.current.has(event.id)) continue;
+        if (event.id) seenEventIds.current.add(event.id);
+        eventCount++;
+
+        setEvents((prev) => [...prev, event]);
+
+        if (event.actions?.stateDelta) {
+          setSessionState((prev) => ({
+            ...prev,
+            ...event.actions!.stateDelta,
+          }));
+        }
+
+        // Check for another pause (skip partial/streaming events)
+        if (!event.partial && event.longRunningToolIds && event.longRunningToolIds.length > 0) {
+          const functionCalls = event.content?.parts
+            ?.filter((p) => p.functionCall)
+            ?.map((p) => p.functionCall!) ?? [];
+
+          const pausedCall = functionCalls.find((fc) =>
+            event.longRunningToolIds!.includes(fc.id ?? "")
+          );
+
+          if (pausedCall) {
+            setPauseContext({
+              functionCallId: pausedCall.id ?? "",
+              functionName: pausedCall.name ?? "",
+              eventId: event.id,
+            });
+            setStatus("paused");
+            paused = true;
+            return;
+          }
+        }
+      }
+
+      // If no events came back, the backend may not have resumed properly.
+      // Fetch session state to check for active long-running tool calls.
+      if (eventCount === 0) {
+        console.warn("[resume] 0 events received — checking session for active pause");
+        try {
+          const session = await getSession(appName, userId, sessionId);
+          if (session.state) {
+            setSessionState((prev) => ({ ...prev, ...session.state }));
+          }
+          // Check if any event in the session has unresolved longRunningToolIds
+          for (let i = session.events.length - 1; i >= 0; i--) {
+            const evt = session.events[i];
+            if (evt.longRunningToolIds && evt.longRunningToolIds.length > 0) {
+              const functionCalls = evt.content?.parts
+                ?.filter((p) => p.functionCall)
+                ?.map((p) => p.functionCall!) ?? [];
+              const pausedCall = functionCalls.find((fc) =>
+                evt.longRunningToolIds!.includes(fc.id ?? "")
+              );
+              if (pausedCall) {
+                // Check if this pause has already been responded to
+                const hasResponse = session.events.slice(i + 1).some(
+                  (e) => e.content?.parts?.some(
+                    (p) => p.functionResponse?.id === pausedCall.id
+                  )
+                );
+                if (!hasResponse) {
+                  console.warn("[resume] Found unresolved pause:", pausedCall.name);
+                  setPauseContext({
+                    functionCallId: pausedCall.id ?? "",
+                    functionName: pausedCall.name ?? "",
+                    eventId: evt.id,
+                  });
+                  setStatus("paused");
+                  paused = true;
+                  break;
+                }
+              }
+            }
+          }
+        } catch {
+          // Session fetch failed, fall through to completed
+        }
+      }
+
+      if (!paused) setStatus("completed");
+    } catch (err) {
+      setStatus("error");
+      setErrorMsg(err instanceof Error ? err.message : "Resume failed");
+    }
+  }
+
+  // Fetch session state from backend to populate campaign metadata
+  // that was set during a prior run/resume phase
+  async function syncSessionState() {
+    try {
+      const session = await getSession(appName, userId, sessionId);
+      if (session.state) {
+        setSessionState((prev) => ({ ...prev, ...session.state }));
+      }
+    } catch {
+      // Ignore — session may not exist yet
+    }
+  }
 
   // Parse trend trawler output into clickable cards
   const trends = useMemo(() => {
@@ -419,15 +830,18 @@ export default function RunPage({
 
   // Campaign metadata fields for left sidebar
   const campaignFields = useMemo(() => {
-    const fields: { label: string; key: string }[] = [
+    const fields: { label: string; key: string; altKey?: string }[] = [
       { label: "Brand", key: "brand" },
       { label: "Target Audience", key: "target_audience" },
       { label: "Target Product", key: "target_product" },
       { label: "Key Selling Points", key: "key_selling_points" },
-      { label: "Search Trend", key: "target_search_trends" },
+      { label: "Search Trend", key: "target_search_trends", altKey: "target_search_trend" },
     ];
     return fields
-      .map((f) => ({ ...f, value: sessionState[f.key] as string | undefined }))
+      .map((f) => ({
+        ...f,
+        value: (sessionState[f.key] ?? (f.altKey ? sessionState[f.altKey] : undefined)) as string | undefined,
+      }))
       .filter((f) => f.value);
   }, [sessionState]);
 
@@ -438,6 +852,7 @@ export default function RunPage({
 
   const statusConfig: Record<Status, { color: string; glow: string }> = {
     running: { color: "bg-blue-500", glow: "shadow-blue-500/20" },
+    paused: { color: "bg-amber-500", glow: "shadow-amber-500/20" },
     completed: { color: "bg-emerald-500", glow: "shadow-emerald-500/20" },
     error: { color: "bg-red-500", glow: "shadow-red-500/20" },
   };
@@ -539,6 +954,11 @@ export default function RunPage({
                     </span>
                   </span>
                 )}
+                {status === "paused" && (
+                  <span className="text-sm text-amber-600 font-medium">
+                    Waiting for review
+                  </span>
+                )}
                 {status === "completed" && (
                   <span className="text-sm text-emerald-600 font-medium">
                     Run completed
@@ -551,6 +971,17 @@ export default function RunPage({
                 )}
               </div>
             </div>
+
+            {/* Review panel for interactive mode */}
+            {status === "paused" && pauseContext && (
+              <div className="lg:col-span-full">
+                <ReviewPanel
+                  functionName={pauseContext.functionName}
+                  sessionState={sessionState}
+                  onResume={handleResume}
+                />
+              </div>
+            )}
 
             {/* Right column: GCS output, research report, pipeline widgets, trend cards */}
             {hasRightColumn && (

--- a/frontend/src/app/run/[sessionId]/page.tsx
+++ b/frontend/src/app/run/[sessionId]/page.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { streamRun, resumeRun, getSession } from "@/lib/api";
+import { formatStateValue } from "@/lib/utils";
 import type { AgentEvent } from "@/lib/types";
 
 type Status = "running" | "completed" | "error" | "paused";
@@ -840,7 +841,7 @@ export default function RunPage({
     return fields
       .map((f) => ({
         ...f,
-        value: (sessionState[f.key] ?? (f.altKey ? sessionState[f.altKey] : undefined)) as string | undefined,
+        value: formatStateValue(sessionState[f.key] ?? (f.altKey ? sessionState[f.altKey] : undefined)),
       }))
       .filter((f) => f.value);
   }, [sessionState]);

--- a/frontend/src/components/event-log.tsx
+++ b/frontend/src/components/event-log.tsx
@@ -133,7 +133,7 @@ export function EventLog({
         )}
         {events.map((event, i) => (
           <EventItem
-            key={i}
+            key={event.id || `evt-${i}`}
             event={event}
             isLast={i === events.length - 1}
           />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -127,3 +127,69 @@ export async function* streamRun(
     }
   }
 }
+
+export async function* resumeRun(
+  appName: string,
+  userId: string,
+  sessionId: string,
+  functionCallId: string,
+  functionName: string,
+  functionCallEventId: string,
+  response: Record<string, unknown>
+): AsyncGenerator<AgentEvent> {
+  const res = await fetch(`${API_BASE}/run_sse`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      appName,
+      userId,
+      sessionId,
+      newMessage: {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              id: functionCallId,
+              name: functionName,
+              response: response,
+            },
+          },
+        ],
+      },
+      functionCallEventId,
+      streaming: true,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to resume run (${res.status}): ${body}`);
+  }
+  if (!res.body) throw new Error("No response body");
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        const data = line.slice(6).trim();
+        if (data) {
+          try {
+            yield JSON.parse(data) as AgentEvent;
+          } catch {
+            // skip malformed JSON
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,10 @@
 import type { Session, AgentEvent } from "./types";
 
-// Call api_server directly (not through Next.js proxy) so SSE streams properly
-const API_BASE = "http://localhost:8000";
+// Route through the same-origin Next.js proxy (src/app/api/adk/[...path]/route.ts) so
+// the browser never makes a cross-origin call — this avoids CORS and the Cloud
+// Workstations port-auth redirect, while the proxy streams SSE responses through.
+// Override with NEXT_PUBLIC_API_BASE to call an api_server directly if needed.
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "/api/adk";
 
 export async function listApps(): Promise<string[]> {
   const res = await fetch(`${API_BASE}/list-apps`);

--- a/frontend/src/lib/presets.ts
+++ b/frontend/src/lib/presets.ts
@@ -1,0 +1,29 @@
+/** Preset values for the campaign input form dropdowns. */
+
+export const BRAND_PRESETS = [
+  "Estee Lauder",
+  "Google",
+  "Paul Reed Smith (PRS)",
+  "Miller Coors",
+];
+
+export const AUDIENCE_PRESETS = [
+  "Men who are concerned with proactive age prevention, are overwhelmed with complex skin care routines, and love surreal memes",
+  "Millennials who respond positively to nostalgic messages",
+  "Millennials who follow jam bands (e.g., Widespread Panic and Phish), respond positively to nostalgic messages, and love surreal memes",
+  "Men who are nostalgic about 90's and 2000's wrestling and love surreal memes",
+];
+
+export const PRODUCT_PRESETS = [
+  "Advanced Night Repair",
+  "Pixel 10",
+  "SE CE24 Electric Guitar",
+  "Coors Light",
+];
+
+export const SELLING_POINTS_PRESETS = [
+  "Ideal for visible age prevention with double action to fight visible effects of free radical damage",
+  "Call Screen - Goodbye, spam calls. With Call Screen, Pixel can now detect and filter out even more spam calls. For other calls, it can tell you who's calling and why before you pick up. Detect and decline spam calls without distracting you.",
+  "The 85/15 S Humbucker pickups deliver a wide tonal range, from thick humbucker tones to clear single-coil sounds, making the guitar suitable for various genres.",
+  "Perfect for smashing with your friends",
+];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,10 +1,12 @@
 export interface Part {
   text?: string;
   functionCall?: {
+    id?: string;
     name: string;
     args: Record<string, unknown>;
   };
   functionResponse?: {
+    id?: string;
     name: string;
     response: Record<string, unknown>;
   };
@@ -28,6 +30,8 @@ export interface AgentEvent {
     stateDelta?: Record<string, unknown>;
     artifactDelta?: Record<string, string>;
   };
+  longRunningToolIds?: string[];
+  partial?: boolean;
   timestamp: number;
 }
 
@@ -40,7 +44,7 @@ export interface Session {
 }
 
 export interface CampaignInput {
-  agent: "trend_trawler" | "creative_agent";
+  agent: "trend_trawler" | "creative_agent" | "interactive_creative";
   brand: string;
   targetAudience: string;
   targetProduct: string;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Session-state values are not always strings. Some keys (e.g. `target_search_trends`)
+// are stored as nested objects/arrays; rendering those raw crashes React with
+// "Objects are not valid as a React child". Flatten any value to a display string.
+export function formatStateValue(value: unknown): string {
+  if (value == null) return ""
+  if (typeof value === "string") return value
+  if (Array.isArray(value)) return value.map(formatStateValue).filter(Boolean).join(", ")
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).map(formatStateValue).filter(Boolean).join(", ")
+  }
+  return String(value)
+}

--- a/interactive_creative/__init__.py
+++ b/interactive_creative/__init__.py
@@ -1,0 +1,1 @@
+# Interactive creative agent with human-in-the-loop review checkpoints.

--- a/interactive_creative/agent.py
+++ b/interactive_creative/agent.py
@@ -1,0 +1,112 @@
+from google.adk.agents import Agent
+from google.adk.apps import App, ResumabilityConfig
+from google.adk.tools.agent_tool import AgentTool
+from google.genai import types
+
+# Reuse existing sub-agents from creative_agent
+from creative_agent.agent import (
+    combined_research_pipeline,
+    ad_creative_pipeline,
+    visual_generation_pipeline,
+    visual_generator,
+)
+from creative_eval.agent import creative_eval_agent
+from creative_agent import tools, callbacks
+from creative_agent.config import config
+from interactive_creative.review_tools import (
+    review_research_tool,
+    review_ad_copies_tool,
+    review_visual_concepts_tool,
+)
+
+root_agent = Agent(
+    model=config.critic_model,
+    name="root_agent",
+    description="Interactive ad generation with human review checkpoints after research, ad copies, and visual concepts.",
+    instruction="""**Role:** You are the orchestrator for an interactive ad content generation workflow with human review checkpoints.
+
+    **Objective:** Generate ad creatives using campaign metadata, pausing at key checkpoints for human review and approval.
+
+    <AVAILABLE_TOOLS>
+    1. `memorize` — Store campaign metadata in session state.
+    2. `combined_research_pipeline` — Conduct web research.
+    3. `save_draft_report_artifact` — Save research PDF to GCS.
+    4. `review_research` — **CHECKPOINT** Pause for user to review research before proceeding.
+    5. `ad_creative_pipeline` — Generate ad copies.
+    6. `review_ad_copies` — **CHECKPOINT** Pause for user to review ad copies before proceeding.
+    7. `visual_generation_pipeline` — Generate visual concepts.
+    8. `review_visual_concepts` — **CHECKPOINT** Pause for user to review visual concepts before image generation.
+    9. `visual_generator` — Generate image creatives.
+    10. `creative_eval_agent` — Evaluate all creatives for quality.
+    11. `save_eval_report_to_gcs` — Save evaluation report JSON to GCS.
+    12. `save_creative_gallery_html` — Build HTML portfolio.
+    13. `write_trends_to_bq` — Log trend data to BigQuery.
+    </AVAILABLE_TOOLS>
+
+    <INPUT_PARAMETERS>
+    - brand: [string] The client's brand name.
+    - target_audience: [string] Target demographic.
+    - target_product: [string] Product/service name.
+    - key_selling_points: [string] Key benefits/features.
+    - target_search_trends: [string] Trending topics.
+    </INPUT_PARAMETERS>
+
+    <INSTRUCTIONS>
+    1. Receive and validate inputs. If critical inputs missing, respond with error.
+    2. Use `memorize` to store all campaign metadata into session state.
+    3. Follow the <WORKFLOW> steps strictly in order. **You MUST complete ALL 13 steps. Do NOT stop early.**
+    4. **CRITICAL:** When you receive a response from a checkpoint tool (review_research, review_ad_copies, or review_visual_concepts), that response contains the user's feedback. Read the `instruction` field in the response — it tells you to continue to the next step. You MUST immediately proceed to the next WORKFLOW step after each checkpoint. NEVER treat a checkpoint response as the end of the workflow.
+    </INSTRUCTIONS>
+
+    <WORKFLOW>
+    1. Use `combined_research_pipeline` to conduct web research.
+    2. Use `save_draft_report_artifact` to save research PDF to GCS.
+    3. **CHECKPOINT 1:** Call `review_research` to pause for user review. When you receive the response, read the user's feedback. If status is "approved", immediately proceed to step 4. If status is "revision_requested", address their feedback first, then proceed to step 4.
+    4. Use `ad_creative_pipeline` to generate ad copies. **Do NOT skip this step.**
+    5. **CHECKPOINT 2:** Call `review_ad_copies` to pause for user review. When you receive the response, read the user's feedback. If status is "approved", immediately proceed to step 6. **Do NOT end the workflow here.**
+    6. Use `visual_generation_pipeline` to generate visual concepts. **Do NOT skip this step.**
+    7. **CHECKPOINT 3:** Call `review_visual_concepts` to pause for user review. When you receive the response, immediately proceed to step 8. **Do NOT end the workflow here.**
+    8. Use `visual_generator` to generate image creatives. **Do NOT skip this step.**
+    9. Use `creative_eval_agent` to evaluate all creatives.
+    10. Use `save_eval_report_to_gcs` to save the evaluation report.
+    11. Use `save_creative_gallery_html` to create HTML portfolio.
+    12. Use `write_trends_to_bq` to log to BigQuery.
+    13. Display the Cloud Storage URI: {gcs_bucket}/{gcs_folder}/{agent_output_dir}
+
+    **REMINDER: The workflow is NOT complete until step 13 is done. Each checkpoint is a PAUSE, not an endpoint.**
+    </WORKFLOW>
+    """,
+    tools=[
+        AgentTool(agent=combined_research_pipeline),
+        AgentTool(agent=ad_creative_pipeline),
+        AgentTool(agent=visual_generation_pipeline),
+        AgentTool(agent=visual_generator),
+        AgentTool(agent=creative_eval_agent),
+        review_research_tool,
+        review_ad_copies_tool,
+        review_visual_concepts_tool,
+        tools.save_eval_report_to_gcs,
+        tools.save_draft_report_artifact,
+        tools.save_creative_gallery_html,
+        tools.write_trends_to_bq,
+        tools.memorize,
+    ],
+    generate_content_config=types.GenerateContentConfig(
+        temperature=1.0,
+        labels={
+            "agentic_wf": "trend_trawler",
+            "agent": "interactive_creative",
+            "subagent": "root_agent",
+        },
+    ),
+    before_agent_callback=callbacks.load_session_state,
+    before_model_callback=callbacks.rate_limit_callback,
+)
+
+# Wrap in App with resumability enabled — required for LongRunningFunctionTool
+# to properly pause and resume across multiple /run_sse calls.
+app = App(
+    name="interactive_creative",
+    root_agent=root_agent,
+    resumability_config=ResumabilityConfig(is_resumable=True),
+)

--- a/interactive_creative/review_tools.py
+++ b/interactive_creative/review_tools.py
@@ -1,0 +1,25 @@
+from google.adk.tools.long_running_tool import LongRunningFunctionTool
+from google.adk.tools.tool_context import ToolContext
+
+
+def review_research(tool_context: ToolContext) -> None:
+    """Pause for user to review the research report. When this tool returns a response, you MUST continue to the next workflow step (ad_creative_pipeline). The response contains 'status' and 'instruction' fields — follow the instruction."""
+    tool_context.actions.skip_summarization = True
+    return None
+
+
+def review_ad_copies(tool_context: ToolContext) -> None:
+    """Pause for user to review ad copies. When this tool returns a response, you MUST continue to the next workflow step (visual_generation_pipeline). The response contains 'status' and 'instruction' fields — follow the instruction."""
+    tool_context.actions.skip_summarization = True
+    return None
+
+
+def review_visual_concepts(tool_context: ToolContext) -> None:
+    """Pause for user to review visual concepts. When this tool returns a response, you MUST continue to the next workflow step (visual_generator). The response contains 'status' and 'instruction' fields — follow the instruction."""
+    tool_context.actions.skip_summarization = True
+    return None
+
+
+review_research_tool = LongRunningFunctionTool(review_research)
+review_ad_copies_tool = LongRunningFunctionTool(review_ad_copies)
+review_visual_concepts_tool = LongRunningFunctionTool(review_visual_concepts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.13, <4.0"
 dependencies = [
     "google-genai>=1.19.0,<2.0.0",
     "google-cloud-aiplatform[agent-engines]>=1.125.0,<2.0.0",
-    "google-adk[eval]>=1.27.3,<2.0.0",
+    "google-adk[eval]>=1.31.1",
     "pandas>=2.3.2,<3.0.0",
     "google-cloud-bigquery>=3.36.0,<4.0.0",
     "db-dtypes>=1.4.3,<2.0.0",
@@ -25,6 +25,7 @@ dependencies = [
     "functions-framework==3.9.2",
     "cloudevents==1.11.0",
     "google-cloud-pubsub>=2.31.1,<3.0.0",
+    "litellm>=1.83.7",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.13, <4.0"
 dependencies = [
     "google-genai>=1.19.0,<2.0.0",
     "google-cloud-aiplatform[agent-engines]>=1.125.0,<2.0.0",
-    "google-adk>=1.27.3,<2.0.0",
+    "google-adk[eval]>=1.27.3,<2.0.0",
     "pandas>=2.3.2,<3.0.0",
     "google-cloud-bigquery>=3.36.0,<4.0.0",
     "db-dtypes>=1.4.3,<2.0.0",

--- a/tests/eval/eval_config.json
+++ b/tests/eval/eval_config.json
@@ -1,0 +1,52 @@
+{
+  "criteria": {
+    "rubric_based_final_response_quality_v1": {
+      "threshold": 0.8,
+      "rubrics": [
+        {
+          "rubric_id": "cloud_storage_uri",
+          "rubric_content": {
+            "text_property": "The final response MUST include a Cloud Storage location path (containing 'gs://' or a GCS bucket reference)."
+          }
+        },
+        {
+          "rubric_id": "selected_trends",
+          "rubric_content": {
+            "text_property": "The final response MUST include a 'Selected Strategy' section with at least 2 trending search terms, each with a marketing angle or strategic bridge explanation."
+          }
+        },
+        {
+          "rubric_id": "brand_relevance",
+          "rubric_content": {
+            "text_property": "The selected trends and strategic bridges MUST reference or relate to the brand, product, or target audience provided in the campaign metadata. Each trend should have an explicit explanation of how it connects to the campaign."
+          }
+        }
+      ],
+      "judge_model_options": {
+        "judge_model": "gemini-2.5-flash",
+        "num_samples": 3
+      }
+    },
+    "rubric_based_tool_use_quality_v1": {
+      "threshold": 0.8,
+      "rubrics": [
+        {
+          "rubric_id": "pipeline_execution",
+          "rubric_content": {
+            "text_property": "The agent MUST execute the pipeline in the correct logical order: first memorize campaign metadata, then gather trends, then research/understand trends, then pick/select trends, then persist results (save to state, BigQuery, file, and GCS)."
+          }
+        },
+        {
+          "rubric_id": "all_tools_used",
+          "rubric_content": {
+            "text_property": "The agent MUST call all of these tools at least once: memorize, gather_trends_agent, understand_trends_agent, pick_trends_agent, save_search_trends_to_session_state, write_trends_to_bq, write_to_file, save_session_state_to_gcs."
+          }
+        }
+      ],
+      "judge_model_options": {
+        "judge_model": "gemini-2.5-flash",
+        "num_samples": 3
+      }
+    }
+  }
+}

--- a/tests/eval/evalsets/trend_trawler_evalset.json
+++ b/tests/eval/evalsets/trend_trawler_evalset.json
@@ -1,0 +1,81 @@
+{
+  "eval_set_id": "trend_trawler_eval",
+  "name": "Trend Trawler Pipeline Evaluation",
+  "description": "End-to-end eval for the trend_trawler agent. Verifies tool trajectory (memorize → gather → understand → pick → persist) and final response quality.",
+  "eval_cases": [
+    {
+      "eval_id": "prs_guitars_campaign",
+      "conversation": [
+        {
+          "invocation_id": "inv_1",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Brand Name: \"Paul Reed Smith (PRS)\"\nTarget Audience: \"millennials who follow jam bands (e.g., Widespread Panic and Phish), respond positively to nostalgic messages, and love surreal memes\"\nTarget Product: \"PRS SE CE24 Electric Guitar\"\nKey Selling Points: \"The 85/15 S Humbucker pickups deliver a wide tonal range, from thick humbucker tones to clear single-coil sounds, making the guitar suitable for various genres.\""
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              { "name": "memorize", "args": {} },
+              { "name": "memorize", "args": {} },
+              { "name": "memorize", "args": {} },
+              { "name": "memorize", "args": {} },
+              { "name": "gather_trends_agent", "args": {} },
+              { "name": "understand_trends_agent", "args": {} },
+              { "name": "pick_trends_agent", "args": {} },
+              { "name": "save_search_trends_to_session_state", "args": {} },
+              { "name": "save_search_trends_to_session_state", "args": {} },
+              { "name": "save_search_trends_to_session_state", "args": {} },
+              { "name": "write_trends_to_bq", "args": {} },
+              { "name": "write_to_file", "args": {} },
+              { "name": "save_session_state_to_gcs", "args": {} }
+            ]
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "trend_trawler",
+        "user_id": "eval_user",
+        "state": {}
+      }
+    },
+    {
+      "eval_id": "anr_skincare_campaign",
+      "conversation": [
+        {
+          "invocation_id": "inv_1",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Brand Name: \"Estee Lauder\"\nTarget Audience: \"Gen-Z gamers (18-25) who spend 4+ hours daily gaming, care about skin health but find traditional skincare messaging boring and irrelevant to their lifestyle\"\nTarget Product: \"Advanced Night Repair Serum\"\nKey Selling Points: \"Repairs visible signs of damage from blue light exposure and late nights. 7-in-1 serum powered by Chronolux Power Signal Technology for visibly reduced lines, wrinkles, and even skin tone.\""
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              { "name": "memorize", "args": {} },
+              { "name": "memorize", "args": {} },
+              { "name": "memorize", "args": {} },
+              { "name": "memorize", "args": {} },
+              { "name": "gather_trends_agent", "args": {} },
+              { "name": "understand_trends_agent", "args": {} },
+              { "name": "pick_trends_agent", "args": {} },
+              { "name": "save_search_trends_to_session_state", "args": {} },
+              { "name": "save_search_trends_to_session_state", "args": {} },
+              { "name": "save_search_trends_to_session_state", "args": {} },
+              { "name": "write_trends_to_bq", "args": {} },
+              { "name": "write_to_file", "args": {} },
+              { "name": "save_session_state_to_gcs", "args": {} }
+            ]
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "trend_trawler",
+        "user_id": "eval_user",
+        "state": {}
+      }
+    }
+  ]
+}

--- a/tests/test_creative_eval.py
+++ b/tests/test_creative_eval.py
@@ -287,3 +287,328 @@ class TestEvalConfig:
 
         config = EvalConfig(eval_model="gemini-2.5-flash")
         assert config.eval_model == "gemini-2.5-flash"
+
+
+# =====================================================================
+# Tests for evaluate_all_creatives (agent tool input/output contract)
+# =====================================================================
+
+# --- Sample fixtures ---
+
+SAMPLE_CAMPAIGN_STATE = {
+    "brand": "PRS Guitars",
+    "target_product": "SE CE24",
+    "target_audience": "Millennial jam band guitarists",
+    "key_selling_points": "Versatile 85/15 S pickups",
+    "target_search_trends": "tswift engaged",
+}
+
+SAMPLE_AD_COPIES = {
+    "ad_copies": [
+        {
+            "original_id": 1,
+            "headline": "She Said Yes, You Said Solo",
+            "body_text": "While the world celebrates love, your PRS SE CE24 celebrates tone.",
+            "tone_style": "Humorous",
+            "trend_connection": "Riffs on engagement trend",
+            "audience_appeal_rationale": "Speaks to gear-obsessed musicians",
+            "social_caption": "Commitment issues? Not with this guitar.",
+            "call_to_action": "Find your perfect match",
+            "detailed_performance_rationale": "Humor + product focus = engagement",
+        },
+        {
+            "original_id": 2,
+            "headline": "Every Love Story Deserves a Soundtrack",
+            "body_text": "The SE CE24 delivers the tone for every moment.",
+            "tone_style": "Aspirational",
+            "trend_connection": "Universal love theme from trend",
+            "audience_appeal_rationale": "Emotional resonance with musicians",
+            "social_caption": "Write the soundtrack to your story.",
+            "call_to_action": "Start your story",
+            "detailed_performance_rationale": "Aspirational tone drives brand affinity",
+        },
+    ]
+}
+
+SAMPLE_VISUAL_CONCEPTS = {
+    "visual_concepts": [
+        {
+            "ad_copy_id": 1,
+            "concept_name": "The Proposal Riff",
+            "trend": "tswift engaged",
+            "trend_reference": "Visual pun on guitar proposal",
+            "markets_product": "Guitar as hero shot in ring box",
+            "audience_appeal": "Surreal humor for meme-native audience",
+            "selection_rationale": "High stopping power + product focus",
+            "headline": "She Said Yes, You Said Solo",
+            "social_caption": "The only proposal that matters.",
+            "call_to_action": "Find your perfect match",
+            "concept_summary": "Guitar in a ring box under dramatic lighting",
+            "image_generation_prompt": "A PRS SE CE24 guitar resting in a velvet ring box...",
+        },
+    ]
+}
+
+
+class _FakeToolContext:
+    """Minimal mock of ADK ToolContext for testing evaluate_all_creatives."""
+
+    def __init__(self, state: dict):
+        self.state = dict(state)
+
+
+class TestEvaluateAllCreativesInputs:
+    """Test that evaluate_all_creatives correctly reads inputs from session state."""
+
+    def test_returns_error_when_no_creatives_in_state(self):
+        from creative_eval.agent import evaluate_all_creatives
+
+        ctx = _FakeToolContext({**SAMPLE_CAMPAIGN_STATE})
+        result = evaluate_all_creatives(ctx)
+        assert result["status"] == "error"
+        assert "No ad copies or visual concepts" in result["message"]
+
+    def test_returns_error_with_empty_lists(self):
+        from creative_eval.agent import evaluate_all_creatives
+
+        ctx = _FakeToolContext({
+            **SAMPLE_CAMPAIGN_STATE,
+            "ad_copy_critique": {"ad_copies": []},
+            "final_visual_concepts": {"visual_concepts": []},
+        })
+        result = evaluate_all_creatives(ctx)
+        assert result["status"] == "error"
+
+    def test_parses_string_state_values(self):
+        """State values may arrive as JSON strings — verify they're handled."""
+        import json
+        from creative_eval.agent import evaluate_all_creatives
+        from unittest.mock import patch, MagicMock
+
+        ctx = _FakeToolContext({
+            **SAMPLE_CAMPAIGN_STATE,
+            "ad_copy_critique": json.dumps(SAMPLE_AD_COPIES),
+            "final_visual_concepts": json.dumps(SAMPLE_VISUAL_CONCEPTS),
+        })
+
+        # Mock the actual LLM calls to avoid hitting the API
+        mock_ad_eval = MagicMock()
+        mock_vis_eval = MagicMock()
+        with patch("creative_eval.agent.evaluate_ad_copy", mock_ad_eval), \
+             patch("creative_eval.agent.evaluate_visual_concept", mock_vis_eval), \
+             patch("creative_eval.agent._build_summary") as mock_summary:
+
+            # Setup return values
+            from creative_eval.schemas import (
+                AdCopyEvaluation, VisualConceptEvaluation, CreativeScore, EvaluationSummary,
+            )
+            mock_score = CreativeScore(
+                overall_score=0.8, passed=True, verdicts=[], strengths=[], improvements=[],
+            )
+            mock_ad_eval.return_value = AdCopyEvaluation(
+                original_id=1, headline="Test", tone_style="Humorous", score=mock_score,
+            )
+            mock_vis_eval.return_value = VisualConceptEvaluation(
+                ad_copy_id=1, concept_name="Test", score=mock_score,
+            )
+            mock_summary.return_value = EvaluationSummary(
+                total_ad_copies=2, ad_copies_passed=2, avg_ad_copy_score=0.8,
+                total_visual_concepts=1, visual_concepts_passed=1, avg_visual_score=0.8,
+                overall_pass_rate=1.0, weakest_dimensions=[],
+            )
+
+            result = evaluate_all_creatives(ctx)
+
+        assert result["status"] == "success"
+        # Should have been called once per ad copy (2) and once per visual concept (1)
+        assert mock_ad_eval.call_count == 2
+        assert mock_vis_eval.call_count == 1
+
+    def test_extracts_campaign_context_keys(self):
+        """Verify the campaign context dict passed to evaluators has the right keys."""
+        import json
+        from creative_eval.agent import evaluate_all_creatives
+        from unittest.mock import patch, MagicMock
+
+        ctx = _FakeToolContext({
+            **SAMPLE_CAMPAIGN_STATE,
+            "ad_copy_critique": SAMPLE_AD_COPIES,
+            "final_visual_concepts": {"visual_concepts": []},
+        })
+
+        captured_contexts = []
+
+        def capture_ad_eval(ad_copy, campaign_context, config):
+            captured_contexts.append(campaign_context)
+            from creative_eval.schemas import AdCopyEvaluation, CreativeScore
+            return AdCopyEvaluation(
+                original_id=1, headline="T", tone_style="H",
+                score=CreativeScore(
+                    overall_score=0.8, passed=True, verdicts=[], strengths=[], improvements=[],
+                ),
+            )
+
+        with patch("creative_eval.agent.evaluate_ad_copy", side_effect=capture_ad_eval), \
+             patch("creative_eval.agent._build_summary") as mock_summary:
+            from creative_eval.schemas import EvaluationSummary
+            mock_summary.return_value = EvaluationSummary(
+                total_ad_copies=2, ad_copies_passed=2, avg_ad_copy_score=0.8,
+                total_visual_concepts=0, visual_concepts_passed=0, avg_visual_score=0.0,
+                overall_pass_rate=1.0, weakest_dimensions=[],
+            )
+            evaluate_all_creatives(ctx)
+
+        assert len(captured_contexts) == 2
+        cc = captured_contexts[0]
+        assert cc["brand"] == "PRS Guitars"
+        assert cc["target_product"] == "SE CE24"
+        assert cc["target_audience"] == "Millennial jam band guitarists"
+        assert cc["key_selling_points"] == "Versatile 85/15 S pickups"
+        assert cc["target_search_trend"] == "tswift engaged"
+
+
+class TestEvaluateAllCreativesOutputs:
+    """Test that evaluate_all_creatives produces correct outputs."""
+
+    def _run_with_mocks(self, ad_scores, vis_scores, threshold=0.7):
+        """Helper: run evaluate_all_creatives with mocked evaluators returning given scores."""
+        from creative_eval.agent import evaluate_all_creatives
+        from creative_eval.schemas import (
+            AdCopyEvaluation, VisualConceptEvaluation, CreativeScore,
+            EvalVerdict, EvaluationSummary,
+        )
+        from unittest.mock import patch
+
+        ad_copies = [
+            {**SAMPLE_AD_COPIES["ad_copies"][0], "original_id": i}
+            for i in range(len(ad_scores))
+        ]
+        vis_concepts = [
+            {**SAMPLE_VISUAL_CONCEPTS["visual_concepts"][0], "ad_copy_id": i}
+            for i in range(len(vis_scores))
+        ]
+
+        ctx = _FakeToolContext({
+            **SAMPLE_CAMPAIGN_STATE,
+            "ad_copy_critique": {"ad_copies": ad_copies},
+            "final_visual_concepts": {"visual_concepts": vis_concepts},
+        })
+
+        ad_iter = iter(ad_scores)
+        vis_iter = iter(vis_scores)
+
+        def mock_ad_eval(ad_copy, campaign_context, config):
+            score = next(ad_iter)
+            return AdCopyEvaluation(
+                original_id=ad_copy.get("original_id", 0),
+                headline=ad_copy.get("headline", ""),
+                tone_style=ad_copy.get("tone_style", ""),
+                score=CreativeScore(
+                    overall_score=score,
+                    passed=score >= threshold,
+                    verdicts=[
+                        EvalVerdict(dimension="d1", score=int(score * 10),
+                                    verdict="pass" if score >= threshold else "fail",
+                                    rationale="test"),
+                    ],
+                    strengths=["d1"] if score >= threshold else [],
+                    improvements=[] if score >= threshold else ["d1"],
+                ),
+            )
+
+        def mock_vis_eval(vc, campaign_context, config):
+            score = next(vis_iter)
+            return VisualConceptEvaluation(
+                ad_copy_id=vc.get("ad_copy_id", 0),
+                concept_name=vc.get("concept_name", ""),
+                score=CreativeScore(
+                    overall_score=score,
+                    passed=score >= threshold,
+                    verdicts=[
+                        EvalVerdict(dimension="d1", score=int(score * 10),
+                                    verdict="pass" if score >= threshold else "fail",
+                                    rationale="test"),
+                    ],
+                    strengths=["d1"] if score >= threshold else [],
+                    improvements=[] if score >= threshold else ["d1"],
+                ),
+            )
+
+        with patch("creative_eval.agent.evaluate_ad_copy", side_effect=mock_ad_eval), \
+             patch("creative_eval.agent.evaluate_visual_concept", side_effect=mock_vis_eval):
+            result = evaluate_all_creatives(ctx)
+
+        return result, ctx
+
+    def test_success_result_keys(self):
+        result, _ = self._run_with_mocks(ad_scores=[0.8, 0.9], vis_scores=[0.75])
+        assert result["status"] == "success"
+        expected_keys = {
+            "status", "total_ad_copies", "ad_copies_passed", "avg_ad_copy_score",
+            "total_visual_concepts", "visual_concepts_passed", "avg_visual_score",
+            "overall_pass_rate", "weakest_dimensions",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_counts_match_inputs(self):
+        result, _ = self._run_with_mocks(ad_scores=[0.8, 0.9, 0.6], vis_scores=[0.75, 0.5])
+        assert result["total_ad_copies"] == 3
+        assert result["total_visual_concepts"] == 2
+
+    def test_pass_counts_correct(self):
+        result, _ = self._run_with_mocks(
+            ad_scores=[0.8, 0.5, 0.9],   # 2 pass, 1 fail
+            vis_scores=[0.75, 0.3],        # 1 pass, 1 fail
+        )
+        assert result["ad_copies_passed"] == 2
+        assert result["visual_concepts_passed"] == 1
+
+    def test_report_stored_in_session_state(self):
+        _, ctx = self._run_with_mocks(ad_scores=[0.8], vis_scores=[0.75])
+        report = ctx.state.get("creative_evaluation_report")
+        assert report is not None
+        assert isinstance(report, dict)
+
+    def test_stored_report_has_correct_structure(self):
+        _, ctx = self._run_with_mocks(ad_scores=[0.8, 0.9], vis_scores=[0.75])
+        report = ctx.state["creative_evaluation_report"]
+
+        # Top-level keys
+        assert report["brand"] == "PRS Guitars"
+        assert report["target_product"] == "SE CE24"
+        assert report["target_search_trend"] == "tswift engaged"
+
+        # Evaluation lists
+        assert len(report["ad_copy_evaluations"]) == 2
+        assert len(report["visual_concept_evaluations"]) == 1
+
+        # Summary
+        summary = report["summary"]
+        assert summary["total_ad_copies"] == 2
+        assert summary["total_visual_concepts"] == 1
+        assert 0.0 <= summary["overall_pass_rate"] <= 1.0
+
+    def test_stored_report_validates_as_schema(self):
+        """The dict stored in state should round-trip through the Pydantic schema."""
+        from creative_eval.schemas import CreativeEvaluationReport
+
+        _, ctx = self._run_with_mocks(ad_scores=[0.8], vis_scores=[0.75])
+        report_dict = ctx.state["creative_evaluation_report"]
+        restored = CreativeEvaluationReport.model_validate(report_dict)
+        assert restored.brand == "PRS Guitars"
+
+    def test_all_fail_produces_zero_pass_rate(self):
+        result, _ = self._run_with_mocks(ad_scores=[0.3, 0.4], vis_scores=[0.2])
+        assert result["ad_copies_passed"] == 0
+        assert result["visual_concepts_passed"] == 0
+        assert result["overall_pass_rate"] == 0.0
+
+    def test_all_pass_produces_full_pass_rate(self):
+        result, _ = self._run_with_mocks(ad_scores=[0.8, 0.9], vis_scores=[0.85])
+        assert result["ad_copies_passed"] == 2
+        assert result["visual_concepts_passed"] == 1
+        assert result["overall_pass_rate"] == 1.0
+
+    def test_weakest_dimensions_populated(self):
+        result, _ = self._run_with_mocks(ad_scores=[0.5], vis_scores=[0.4])
+        assert isinstance(result["weakest_dimensions"], list)

--- a/tests/test_creative_eval.py
+++ b/tests/test_creative_eval.py
@@ -1,0 +1,289 @@
+"""Tests for the creative evaluation module (schemas, scoring logic, config)."""
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestEvalVerdict:
+    def test_valid_pass_verdict(self):
+        from creative_eval.schemas import EvalVerdict
+
+        v = EvalVerdict(
+            dimension="trend_authenticity",
+            score=8,
+            verdict="pass",
+            rationale="Strong natural connection to the trend.",
+        )
+        assert v.score == 8
+        assert v.verdict == "pass"
+
+    def test_valid_fail_verdict(self):
+        from creative_eval.schemas import EvalVerdict
+
+        v = EvalVerdict(
+            dimension="copy_quality",
+            score=4,
+            verdict="fail",
+            rationale="Grammar issues and unclear messaging.",
+        )
+        assert v.verdict == "fail"
+
+    def test_score_bounds(self):
+        from creative_eval.schemas import EvalVerdict
+
+        with pytest.raises(ValidationError):
+            EvalVerdict(dimension="x", score=0, verdict="fail", rationale="too low")
+
+        with pytest.raises(ValidationError):
+            EvalVerdict(dimension="x", score=11, verdict="pass", rationale="too high")
+
+    def test_invalid_verdict_value(self):
+        from creative_eval.schemas import EvalVerdict
+
+        with pytest.raises(ValidationError):
+            EvalVerdict(dimension="x", score=5, verdict="maybe", rationale="invalid")
+
+
+class TestCreativeScore:
+    def test_valid_score(self):
+        from creative_eval.schemas import CreativeScore, EvalVerdict
+
+        verdicts = [
+            EvalVerdict(dimension="d1", score=8, verdict="pass", rationale="good"),
+            EvalVerdict(dimension="d2", score=5, verdict="fail", rationale="needs work"),
+        ]
+        score = CreativeScore(
+            overall_score=0.65,
+            passed=False,
+            verdicts=verdicts,
+            strengths=["d1"],
+            improvements=["d2"],
+        )
+        assert score.overall_score == 0.65
+        assert not score.passed
+        assert len(score.verdicts) == 2
+
+    def test_score_bounds(self):
+        from creative_eval.schemas import CreativeScore
+
+        with pytest.raises(ValidationError):
+            CreativeScore(
+                overall_score=1.5,
+                passed=True,
+                verdicts=[],
+                strengths=[],
+                improvements=[],
+            )
+
+
+class TestAdCopyEvaluation:
+    def test_valid_evaluation(self):
+        from creative_eval.schemas import AdCopyEvaluation, CreativeScore
+
+        eval_result = AdCopyEvaluation(
+            original_id=1,
+            headline="Rock Your World",
+            tone_style="Humorous",
+            score=CreativeScore(
+                overall_score=0.8,
+                passed=True,
+                verdicts=[],
+                strengths=["copy_quality"],
+                improvements=[],
+            ),
+        )
+        assert eval_result.original_id == 1
+        assert eval_result.score.passed
+
+
+class TestVisualConceptEvaluation:
+    def test_valid_evaluation(self):
+        from creative_eval.schemas import VisualConceptEvaluation, CreativeScore
+
+        eval_result = VisualConceptEvaluation(
+            ad_copy_id=3,
+            concept_name="Sunset Serenade",
+            score=CreativeScore(
+                overall_score=0.72,
+                passed=True,
+                verdicts=[],
+                strengths=["stopping_power"],
+                improvements=[],
+            ),
+        )
+        assert eval_result.concept_name == "Sunset Serenade"
+
+
+class TestEvaluationSummary:
+    def test_valid_summary(self):
+        from creative_eval.schemas import EvaluationSummary
+
+        summary = EvaluationSummary(
+            total_ad_copies=6,
+            ad_copies_passed=5,
+            avg_ad_copy_score=0.78,
+            total_visual_concepts=6,
+            visual_concepts_passed=4,
+            avg_visual_score=0.71,
+            overall_pass_rate=0.75,
+            weakest_dimensions=["prompt_technical_quality", "trend_visual_connection"],
+        )
+        assert summary.overall_pass_rate == 0.75
+        assert len(summary.weakest_dimensions) == 2
+
+
+class TestCreativeEvaluationReport:
+    def test_valid_report(self):
+        from creative_eval.schemas import (
+            CreativeEvaluationReport,
+            AdCopyEvaluation,
+            VisualConceptEvaluation,
+            CreativeScore,
+            EvaluationSummary,
+        )
+
+        report = CreativeEvaluationReport(
+            brand="PRS Guitars",
+            target_product="SE CE24",
+            target_search_trend="tswift engaged",
+            ad_copy_evaluations=[
+                AdCopyEvaluation(
+                    original_id=1,
+                    headline="Test",
+                    tone_style="Humorous",
+                    score=CreativeScore(
+                        overall_score=0.8,
+                        passed=True,
+                        verdicts=[],
+                        strengths=[],
+                        improvements=[],
+                    ),
+                )
+            ],
+            visual_concept_evaluations=[
+                VisualConceptEvaluation(
+                    ad_copy_id=1,
+                    concept_name="Test Concept",
+                    score=CreativeScore(
+                        overall_score=0.65,
+                        passed=False,
+                        verdicts=[],
+                        strengths=[],
+                        improvements=["stopping_power"],
+                    ),
+                )
+            ],
+            summary=EvaluationSummary(
+                total_ad_copies=1,
+                ad_copies_passed=1,
+                avg_ad_copy_score=0.8,
+                total_visual_concepts=1,
+                visual_concepts_passed=0,
+                avg_visual_score=0.65,
+                overall_pass_rate=0.5,
+                weakest_dimensions=["stopping_power"],
+            ),
+        )
+        assert report.brand == "PRS Guitars"
+        assert report.summary.overall_pass_rate == 0.5
+
+    def test_report_serialization(self):
+        from creative_eval.schemas import (
+            CreativeEvaluationReport,
+            EvaluationSummary,
+        )
+
+        report = CreativeEvaluationReport(
+            brand="Test",
+            target_product="Product",
+            target_search_trend="trend",
+            ad_copy_evaluations=[],
+            visual_concept_evaluations=[],
+            summary=EvaluationSummary(
+                total_ad_copies=0,
+                ad_copies_passed=0,
+                avg_ad_copy_score=0.0,
+                total_visual_concepts=0,
+                visual_concepts_passed=0,
+                avg_visual_score=0.0,
+                overall_pass_rate=0.0,
+                weakest_dimensions=[],
+            ),
+        )
+        # Should serialize to JSON and back without error
+        json_str = report.model_dump_json()
+        restored = CreativeEvaluationReport.model_validate_json(json_str)
+        assert restored.brand == "Test"
+
+
+class TestScoreFromVerdicts:
+    def test_computes_average(self):
+        from creative_eval.evaluate import _score_from_verdicts
+        from creative_eval.schemas import EvalVerdict
+
+        verdicts = [
+            EvalVerdict(dimension="d1", score=8, verdict="pass", rationale="good"),
+            EvalVerdict(dimension="d2", score=6, verdict="fail", rationale="ok"),
+            EvalVerdict(dimension="d3", score=10, verdict="pass", rationale="great"),
+        ]
+        result = _score_from_verdicts(verdicts, threshold=0.7)
+        # avg = (8+6+10) / 30 = 0.8
+        assert result.overall_score == 0.8
+        assert result.passed
+
+    def test_empty_verdicts(self):
+        from creative_eval.evaluate import _score_from_verdicts
+
+        result = _score_from_verdicts([], threshold=0.7)
+        assert result.overall_score == 0.0
+        assert not result.passed
+
+    def test_below_threshold(self):
+        from creative_eval.evaluate import _score_from_verdicts
+        from creative_eval.schemas import EvalVerdict
+
+        verdicts = [
+            EvalVerdict(dimension="d1", score=3, verdict="fail", rationale="bad"),
+            EvalVerdict(dimension="d2", score=4, verdict="fail", rationale="weak"),
+        ]
+        result = _score_from_verdicts(verdicts, threshold=0.7)
+        # avg = (3+4) / 20 = 0.35
+        assert result.overall_score == 0.35
+        assert not result.passed
+
+    def test_identifies_strengths_and_improvements(self):
+        from creative_eval.evaluate import _score_from_verdicts
+        from creative_eval.schemas import EvalVerdict
+
+        verdicts = [
+            EvalVerdict(dimension="strong_dim", score=9, verdict="pass", rationale="excellent"),
+            EvalVerdict(dimension="weak_dim", score=3, verdict="fail", rationale="poor"),
+            EvalVerdict(dimension="ok_dim", score=7, verdict="pass", rationale="decent"),
+        ]
+        result = _score_from_verdicts(verdicts, threshold=0.7)
+        assert "strong_dim" in result.strengths
+        assert "weak_dim" in result.improvements
+
+
+class TestEvalConfig:
+    def test_default_config(self):
+        from creative_eval.config import EvalConfig
+
+        config = EvalConfig()
+        assert config.eval_model == "gemini-2.5-pro"
+        assert config.passing_threshold == 0.7
+        assert config.max_retries == 3
+        assert len(config.ad_copy_dimensions) == 6
+        assert len(config.visual_dimensions) == 6
+
+    def test_custom_threshold(self):
+        from creative_eval.config import EvalConfig
+
+        config = EvalConfig(passing_threshold=0.8)
+        assert config.passing_threshold == 0.8
+
+    def test_custom_model(self):
+        from creative_eval.config import EvalConfig
+
+        config = EvalConfig(eval_model="gemini-2.5-flash")
+        assert config.eval_model == "gemini-2.5-flash"

--- a/tests/test_creative_eval.py
+++ b/tests/test_creative_eval.py
@@ -394,8 +394,8 @@ class TestEvaluateAllCreativesInputs:
         # Mock the actual LLM calls to avoid hitting the API
         mock_ad_eval = MagicMock()
         mock_vis_eval = MagicMock()
-        with patch("creative_eval.agent.evaluate_ad_copy", mock_ad_eval), \
-             patch("creative_eval.agent.evaluate_visual_concept", mock_vis_eval), \
+        with patch("creative_eval.evaluate.evaluate_ad_copy", mock_ad_eval), \
+             patch("creative_eval.evaluate.evaluate_visual_concept", mock_vis_eval), \
              patch("creative_eval.agent._build_summary") as mock_summary:
 
             # Setup return values
@@ -438,7 +438,7 @@ class TestEvaluateAllCreativesInputs:
 
         captured_contexts = []
 
-        def capture_ad_eval(ad_copy, campaign_context, config):
+        def capture_ad_eval(ad_copy, campaign_context, config, client=None):
             captured_contexts.append(campaign_context)
             from creative_eval.schemas import AdCopyEvaluation, CreativeScore
             return AdCopyEvaluation(
@@ -448,7 +448,7 @@ class TestEvaluateAllCreativesInputs:
                 ),
             )
 
-        with patch("creative_eval.agent.evaluate_ad_copy", side_effect=capture_ad_eval), \
+        with patch("creative_eval.evaluate.evaluate_ad_copy", side_effect=capture_ad_eval), \
              patch("creative_eval.agent._build_summary") as mock_summary:
             from creative_eval.schemas import EvaluationSummary
             mock_summary.return_value = EvaluationSummary(
@@ -497,7 +497,7 @@ class TestEvaluateAllCreativesOutputs:
         ad_iter = iter(ad_scores)
         vis_iter = iter(vis_scores)
 
-        def mock_ad_eval(ad_copy, campaign_context, config):
+        def mock_ad_eval(ad_copy, campaign_context, config, client=None):
             score = next(ad_iter)
             return AdCopyEvaluation(
                 original_id=ad_copy.get("original_id", 0),
@@ -516,7 +516,7 @@ class TestEvaluateAllCreativesOutputs:
                 ),
             )
 
-        def mock_vis_eval(vc, campaign_context, config):
+        def mock_vis_eval(vc, campaign_context, config, client=None):
             score = next(vis_iter)
             return VisualConceptEvaluation(
                 ad_copy_id=vc.get("ad_copy_id", 0),
@@ -534,8 +534,8 @@ class TestEvaluateAllCreativesOutputs:
                 ),
             )
 
-        with patch("creative_eval.agent.evaluate_ad_copy", side_effect=mock_ad_eval), \
-             patch("creative_eval.agent.evaluate_visual_concept", side_effect=mock_vis_eval):
+        with patch("creative_eval.evaluate.evaluate_ad_copy", side_effect=mock_ad_eval), \
+             patch("creative_eval.evaluate.evaluate_visual_concept", side_effect=mock_vis_eval):
             result = evaluate_all_creatives(ctx)
 
         return result, ctx

--- a/trend_trawler/agent.py
+++ b/trend_trawler/agent.py
@@ -169,6 +169,13 @@ trend_trawler = Agent(
     model=config.worker_model,
     name="trend_trawler",
     description="Determines culturally relevant Search trends to use for ad creatives.",
+    # Minimal thinking: the orchestrator's job is mechanical tool sequencing, not deep
+    # reasoning. On gemini-3 models, unbounded default thinking caused the orchestrator
+    # to burn its entire output budget "thinking" and hit MAX_TOKENS before emitting a
+    # tool call. thinking_budget=0 disables thinking here.
+    planner=BuiltInPlanner(
+        thinking_config=types.ThinkingConfig(thinking_budget=0, include_thoughts=False)
+    ),
     instruction="""You are the Lead Campaign Orchestrator.
     Your goal is to manage the end-to-end execution of the Trend Research Pipeline.
 

--- a/trend_trawler/config.py
+++ b/trend_trawler/config.py
@@ -34,12 +34,12 @@ class ResearchConfiguration:
     """
 
     state_init = "_state_init"
-    critic_model: str = "gemini-2.5-pro"
-    worker_model: str = "gemini-2.5-flash"
-    video_analysis_model: str = "gemini-2.5-pro"
-    lite_planner_model: str = "gemini-2.5-flash-lite"
-    image_gen_model: str = "imagen-4.0-generate-001" # "gemini-2.5-flash-image"
-    video_gen_model: str = "veo-3.0-generate-001" # "veo-3.1-generate-preview"
+    critic_model: str = "gemini-2.5-pro" # gemini-3-pro-preview
+    worker_model: str = "gemini-2.5-flash" # gemini-3-flash-preview
+    video_analysis_model: str = "gemini-2.5-pro" # gemini-3-pro-preview
+    lite_planner_model: str = "gemini-2.5-flash-lite" # gemini-3-flash-preview
+    image_gen_model: str = "imagen-4.0-generate-001" # "imagen-4.0-ultra-generate-001
+    video_gen_model: str = "veo-3.1-generate-001" # "veo-3.0-generate-001"
     max_results_yt_trends: int = 45
 
     # Adjust these values to limit the rate at which the agent queries the LLM API.

--- a/trend_trawler/config.py
+++ b/trend_trawler/config.py
@@ -34,11 +34,11 @@ class ResearchConfiguration:
     """
 
     state_init = "_state_init"
-    critic_model: str = "gemini-2.5-pro" # gemini-3-pro-preview
-    worker_model: str = "gemini-2.5-flash" # gemini-3-flash-preview
-    video_analysis_model: str = "gemini-2.5-pro" # gemini-3-pro-preview
-    lite_planner_model: str = "gemini-2.5-flash-lite" # gemini-3-flash-preview
-    image_gen_model: str = "imagen-4.0-generate-001" # "imagen-4.0-ultra-generate-001
+    critic_model: str = "gemini-3.1-pro-preview" # gemini-3-pro-preview
+    worker_model: str = "gemini-3.5-flash" # gemini-3-flash-preview
+    video_analysis_model: str = "gemini-3.1-pro-preview" # gemini-3-pro-preview
+    lite_planner_model: str = "gemini-3.1-flash-lite" # gemini-3-flash-preview
+    image_gen_model: str = "gemini-3.1-flash-image"
     video_gen_model: str = "veo-3.1-generate-001" # "veo-3.0-generate-001"
     max_results_yt_trends: int = 45
 

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,7 @@ dependencies = [
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-pubsub" },
     { name = "google-genai" },
+    { name = "litellm" },
     { name = "markdown" },
     { name = "markdown-pdf" },
     { name = "pandas" },
@@ -50,11 +51,12 @@ requires-dist = [
     { name = "db-dtypes", specifier = ">=1.4.3,<2.0.0" },
     { name = "fastapi", specifier = ">=0.124.1" },
     { name = "functions-framework", specifier = "==3.9.2" },
-    { name = "google-adk", extras = ["eval"], specifier = ">=1.27.3,<2.0.0" },
+    { name = "google-adk", extras = ["eval"], specifier = ">=1.31.1" },
     { name = "google-cloud-aiplatform", extras = ["agent-engines"], specifier = ">=1.125.0,<2.0.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.36.0,<4.0.0" },
     { name = "google-cloud-pubsub", specifier = ">=2.31.1,<3.0.0" },
     { name = "google-genai", specifier = ">=1.19.0,<2.0.0" },
+    { name = "litellm", specifier = ">=1.83.7" },
     { name = "markdown", specifier = ">=3.8.2,<4.0.0" },
     { name = "markdown-pdf", specifier = ">=1.9,<2.0" },
     { name = "pandas", specifier = ">=2.3.2,<3.0.0" },
@@ -77,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.3"
+version = "3.13.4"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -88,59 +90,59 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5dff64413671b0d3e7d5918ea490bdccb97a4ad29b3f311ed423200b2203e01c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:87b9aab6d6ed88235aa2970294f496ff1a1f9adcd724d800e9b952395a80ffd9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:425c126c0dc43861e22cb1c14ba4c8e45d09516d0a3ae0a3f7494b79f5f233a3" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f9120f7093c2a32d9647abcaf21e6ad275b4fbec5b55969f978b1a97c7c86bf" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:697753042d57f4bf7122cab985bf15d0cef23c770864580f5af4f52023a56bd6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6de499a1a44e7de70735d0b39f67c8f25eb3d91eb3103be99ca0fa882cdd987d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37239e9f9a7ea9ac5bf6b92b0260b01f8a22281996da609206a84df860bc1261" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f76c1e3fe7d7c8afad7ed193f89a292e1999608170dcc9751a7462a87dfd5bc0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fc290605db2a917f6e81b0e1e0796469871f5af381ce15c604a3c5c7e51cb730" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4021b51936308aeea0367b8f006dc999ca02bc118a0cc78c303f50a2ff6afb91" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:49a03727c1bba9a97d3e93c9f93ca03a57300f484b6e935463099841261195d3" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3d9908a48eb7416dc1f4524e69f1d32e5d90e3981e4e37eb0aa1cd18f9cfa2a4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2712039939ec963c237286113c68dbad80a82a4281543f3abf766d9d73228998" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:7bfdc049127717581866fa4708791220970ce291c23e28ccf3922c700740fdc0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8057c98e0c8472d8846b9c79f56766bcc57e3e8ac7bfd510482332366c56c591" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-win32.whl", hash = "sha256:1449ceddcdbcf2e0446957863af03ebaaa03f94c090f945411b61269e2cb5daf" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp313-cp313-win_amd64.whl", hash = "sha256:693781c45a4033d31d4187d2436f5ac701e7bbfe5df40d917736108c1cc7436e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:ea37047c6b367fd4bd632bff8077449b8fa034b69e812a18e0132a00fae6e808" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6fc0e2337d1a4c3e6acafda6a78a39d4c14caea625124817420abceed36e2415" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c685f2d80bb67ca8c3837823ad76196b3694b0159d232206d1e461d3d434666f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48e377758516d262bde50c2584fc6c578af272559c409eecbdd2bae1601184d6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:34749271508078b261c4abb1767d42b8d0c0cc9449c73a4df494777dc55f0687" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82611aeec80eb144416956ec85b6ca45a64d76429c1ed46ae1b5f86c6e0c9a26" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2fff83cfc93f18f215896e3a190e8e5cb413ce01553901aca925176e7568963a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbe7d4cecacb439e2e2a8a1a7b935c25b812af7a5fd26503a66dadf428e79ec1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b928f30fe49574253644b1ca44b1b8adbd903aa0da4b9054a6c20fc7f4092a25" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5e8fe4de30df199155baaf64f2fcd604f4c678ed20910db8e2c66dc4b11603" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:8542f41a62bcc58fc7f11cf7c90e0ec324ce44950003feb70640fc2a9092c32a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5e1d8c8b8f1d91cd08d8f4a3c2b067bfca6ec043d3ff36de0f3a715feeedf926" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:90455115e5da1c3c51ab619ac57f877da8fd6d73c05aacd125c5ae9819582aba" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:042e9e0bcb5fba81886c8b4fbb9a09d6b8a00245fd8d88e4d989c1f96c74164c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2eb752b102b12a76ca02dff751a801f028b4ffbbc478840b473597fc91a9ed43" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-win32.whl", hash = "sha256:b556c85915d8efaed322bf1bdae9486aa0f3f764195a0fb6ee962e5c71ef5ce1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9bf9f7a65e7aa20dd764151fb3d616c81088f91f8df39c3893a536e279b4b984" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:05861afbbec40650d8a07ea324367cb93e9e8cc7762e04dd4405df99fa65159c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2fc82186fadc4a8316768d61f3722c230e2c1dcab4200d52d2ebdf2482e47592" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0add0900ff220d1d5c5ebbf99ed88b0c1bbf87aa7e4262300ed1376a6b13414f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:568f416a4072fbfae453dcf9a99194bbb8bdeab718e08ee13dfa2ba0e4bebf29" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:add1da70de90a2569c5e15249ff76a631ccacfe198375eead4aadf3b8dc849dc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b47b7ba335d2e9b1239fa571131a87e2d8ec96b333e68b2a305e7a98b0bae2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4dce1c718e38081c8f35f323209d4c1df7d4db4bab1b5c88a6b4d12b74587" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34bac00a67a812570d4a460447e1e9e06fae622946955f939051e7cc895cfab8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a19884d2ee70b06d9204b2727a7b9f983d0c684c650254679e716b0b77920632" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ca7f2bb6ba8348a3614c7918cc4bb73268c5ac2a207576b7afea19d3d9f64" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b0d95340658b9d2f11d9697f59b3814a9d3bb4b7a7c20b131df4bcef464037c0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1e53262fd202e4b40b70c3aff944a8155059beedc8a89bba9dc1f9ef06a1b56" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d60ac9663f44168038586cab2157e122e46bdef09e9368b37f2d82d354c23f72" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:90751b8eed69435bac9ff4e3d2f6b3af1f57e37ecb0fbeee59c0174c9e2d41df" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fc353029f176fd2b3ec6cfc71be166aba1936fe5d73dd1992ce289ca6647a9aa" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-win32.whl", hash = "sha256:2e41b18a58da1e474a057b3d35248d8320029f61d70a37629535b16a0c8f3767" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:44531a36aa2264a1860089ffd4dce7baf875ee5a6079d5fb42e261c704ef7344" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:63dd5e5b1e43b8fb1e91b79b7ceba1feba588b317d1edff385084fcc7a0a4538" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:746ac3cc00b5baea424dacddea3ec2c2702f9590de27d837aa67004db1eebc6e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bda8f16ea99d6a6705e5946732e48487a448be874e54a4f73d514660ff7c05d3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b061e7b5f840391e3f64d0ddf672973e45c4cfff7a0feea425ea24e51530fc2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b252e8d5cd66184b570d0d010de742736e8a4fab22c58299772b0c5a466d4b21" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20af8aad61d1803ff11152a26146d8d81c266aa8c5aa9b4504432abb965c36a0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:13a5cc924b59859ad2adb1478e31f410a7ed46e92a2a619d6d1dd1a63c1a855e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:534913dfb0a644d537aebb4123e7d466d94e3be5549205e6a31f72368980a81a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:320e40192a2dcc1cf4b5576936e9652981ab596bf81eb309535db7e2f5b5672f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9e587fcfce2bcf06526a43cb705bdee21ac089096f2e271d75de9c339db3100c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9eb9c2eea7278206b5c6c1441fdd9dc420c278ead3f3b2cc87f9b693698cc500" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:29be00c51972b04bf9d5c8f2d7f7314f48f96070ca40a873a53056e652e805f7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90c06228a6c3a7c9f776fe4fc0b7ff647fffd3bed93779a6913c804ae00c1073" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a533ec132f05fd9a1d959e7f34184cd7d5e8511584848dab85faefbaac573069" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1c946f10f413836f82ea4cfb90200d2a59578c549f00857e03111cf45ad01ca5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-win32.whl", hash = "sha256:48708e2706106da6967eff5908c78ca3943f005ed6bcb75da2a7e4da94ef8c70" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:74a2eb058da44fa3a877a49e2095b591d4913308bb424c418b77beb160c55ce3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:e0a2c961fc92abeff61d6444f2ce6ad35bb982db9fc8ff8a47455beacf454a57" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:153274535985a0ff2bff1fb6c104ed547cec898a09213d21b0f791a44b14d933" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:351f3171e2458da3d731ce83f9e6b9619e325c45cbd534c7759750cabf453ad7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f989ac8bc5595ff761a5ccd32bdb0768a117f36dd1504b1c2c074ed5d3f4df9c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d36fc1709110ec1e87a229b201dd3ddc32aa01e98e7868083a794609b081c349" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42adaeea83cbdf069ab94f5103ce0787c21fb1a0153270da76b59d5578302329" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:92deb95469928cc41fd4b42a95d8012fa6df93f6b1c0a83af0ffbc4a5e218cde" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c0c7c07c4257ef3a1df355f840bc62d133bcdef5c1c5ba75add3c08553e2eed" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f062c45de8a1098cb137a1898819796a2491aec4e637a06b03f149315dff4d8f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:76093107c531517001114f0ebdb4f46858ce818590363e3e99a4a2280334454a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:6f6ec32162d293b82f8b63a16edc80769662fbd5ae6fbd4936d3206a2c2cc63b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5903e2db3d202a00ad9f0ec35a122c005e85d90c9836ab4cda628f01edf425e2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2d5bea57be7aca98dbbac8da046d99b5557c5cf4e28538c4c786313078aca09e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:bcf0c9902085976edc0232b75006ef38f89686901249ce14226b6877f88464fb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3295f98bfeed2e867cab588f2a146a9db37a85e3ae9062abf46ba062bd29165" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-win32.whl", hash = "sha256:a598a5c5767e1369d8f5b08695cab1d8160040f796c4416af76fd773d229b3c9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:c555db4bc7a264bead5a7d63d92d41a1122fcd39cc62a4db815f45ad46f9c2c8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:45abbbf09a129825d13c18c7d3182fecd46d9da3cfc383756145394013604ac1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:74c80b2bc2c2adb7b3d1941b2b60701ee2af8296fc8aad8b8bc48bc25767266c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c97989ae40a9746650fa196894f317dafc12227c808c774929dda0ff873a5954" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dae86be9811493f9990ef44fff1685f5c1a3192e9061a71a109d527944eed551" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1db491abe852ca2fa6cc48a3341985b0174b3741838e1341b82ac82c8bd9e871" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e5d701c0aad02a7dce72eef6b93226cf3734330f1a31d69ebbf69f33b86666e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ac32a189081ae0a10ba18993f10f338ec94341f0d5df8fff348043962f3c6f8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98e968cdaba43e45c73c3f306fca418c8009a957733bac85937c9f9cf3f4de27" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca114790c9144c335d538852612d3e43ea0f075288f4849cf4b05d6cd2238ce7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ea2e071661ba9cfe11eabbc81ac5376eaeb3061f6e72ec4cc86d7cdd1ffbdbbb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:34e89912b6c20e0fd80e07fa401fd218a410aa1ce9f1c2f1dad6db1bd0ce0927" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0e217cf9f6a42908c52b46e42c568bd57adc39c9286ced31aaace614b6087965" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:0c296f1221e21ba979f5ac1964c3b78cfde15c5c5f855ffd2caab337e9cd9182" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d99a9d168ebaffb74f36d011750e490085ac418f4db926cce3989c8fe6cb6b1b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cb19177205d93b881f3f89e6081593676043a6828f59c78c17a0fd6c1fbed2ba" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-win32.whl", hash = "sha256:c606aa5656dab6552e52ca368e43869c916338346bfaf6304e15c58fb113ea30" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/aiohttp/aiohttp-3.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:014dcc10ec8ab8db681f0d68e939d1e9286a5aa2b993cbbdb0db130853e02144" },
 ]
 
 [[package]]
@@ -198,14 +200,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/anyio/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/anyio/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/anyio/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/anyio/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708" },
 ]
 
 [[package]]
@@ -219,14 +221,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.2"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/authlib/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/authlib/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/authlib/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/authlib/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f" },
 ]
 
 [[package]]
@@ -240,11 +243,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/certifi/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/certifi/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/certifi/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/certifi/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a" },
 ]
 
 [[package]]
@@ -294,71 +297,71 @@ wheels = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.6"
+version = "3.4.7"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-win32.whl", hash = "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/charset-normalizer/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d" },
 ]
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.1.8"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/click/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/click/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/click/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/click/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2" },
 ]
 
 [[package]]
@@ -393,60 +396,60 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.5"
+version = "48.0.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/cryptography/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8" },
 ]
 
 [[package]]
 name = "db-dtypes"
-version = "1.5.0"
+version = "1.5.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "numpy" },
@@ -454,9 +457,9 @@ dependencies = [
     { name = "pandas" },
     { name = "pyarrow" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/db-dtypes/db_dtypes-1.5.0.tar.gz", hash = "sha256:ad9e94243f53e104bc77dbf9ae44b580d83a770d3694483aba59c9767966daa5" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/db-dtypes/db_dtypes-1.5.1.tar.gz", hash = "sha256:901099b807c9312bc61a5bddbfb07512884e6c6d5a9edacf24d50bcf303aa5f7" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/db-dtypes/db_dtypes-1.5.0-py3-none-any.whl", hash = "sha256:abdbb2e4eb965800ed6f98af0c5c1cafff9063ace09114be2d26a7f046be2c8a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/db-dtypes/db_dtypes-1.5.1-py3-none-any.whl", hash = "sha256:ad71a6645e3c1f06d4d32023940576648f43119822f825f0d22587c6ef8afe15" },
 ]
 
 [[package]]
@@ -482,16 +485,16 @@ wheels = [
 
 [[package]]
 name = "docstring-parser"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/docstring-parser/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/docstring-parser/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/docstring-parser/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/docstring-parser/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b" },
 ]
 
 [[package]]
 name = "fastapi"
-version = "0.135.2"
+version = "0.136.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "annotated-doc" },
@@ -500,9 +503,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastapi/fastapi-0.135.2.tar.gz", hash = "sha256:88a832095359755527b7f63bb4c6bc9edb8329a026189eed83d6c1afcf419d56" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastapi/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastapi/fastapi-0.135.2-py3-none-any.whl", hash = "sha256:0af0447d541867e8db2a6a25c23a8c4bd80e2394ac5529bd87501bbb9e240ca5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastapi/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f" },
 ]
 
 [[package]]
@@ -537,11 +540,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.2"
+version = "3.29.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/filelock/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/filelock/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/filelock/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/filelock/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258" },
 ]
 
 [[package]]
@@ -636,11 +639,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.3.0"
+version = "2026.4.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fsspec/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fsspec/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fsspec/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fsspec/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2" },
 ]
 
 [[package]]
@@ -674,7 +677,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.28.0"
+version = "1.32.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "aiosqlite" },
@@ -723,9 +726,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.28.0.tar.gz", hash = "sha256:3c7ef1a518296641b992cc68ae4795987da48765f9788af37da1acc39db0f362" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.32.0.tar.gz", hash = "sha256:539df330a695d8ae5dc1bc3f1155ef03c6c620620cd0b690b8d47865e722e51c" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.28.0-py3-none-any.whl", hash = "sha256:8470c2e5a97bcef9a54283148be9f4ffaa88b3eefe3f55f269183f715d8830b6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.32.0-py3-none-any.whl", hash = "sha256:cee8e8bd1d869f7e01ba3e5aac44b255f70ee3f9bb78cb50b3253ce605703b0d" },
 ]
 
 [package.optional-dependencies]
@@ -740,7 +743,7 @@ eval = [
 
 [[package]]
 name = "google-api-core"
-version = "2.30.0"
+version = "2.30.3"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-auth" },
@@ -749,9 +752,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-api-core/google_api_core-2.30.0.tar.gz", hash = "sha256:02edfa9fab31e17fc0befb5f161b3bf93c9096d99aed584625f38065c511ad9b" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-api-core/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-api-core/google_api_core-2.30.0-py3-none-any.whl", hash = "sha256:80be49ee937ff9aba0fd79a6eddfde35fe658b9953ab9b79c57dd7061afa8df5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-api-core/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8" },
 ]
 
 [package.optional-dependencies]
@@ -762,7 +765,7 @@ grpc = [
 
 [[package]]
 name = "google-api-python-client"
-version = "2.193.0"
+version = "2.195.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core" },
@@ -771,22 +774,22 @@ dependencies = [
     { name = "httplib2" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-api-python-client/google_api_python_client-2.193.0.tar.gz", hash = "sha256:8f88d16e89d11341e0a8b199cafde0fb7e6b44260dffb88d451577cbd1bb5d33" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-api-python-client/google_api_python_client-2.195.0.tar.gz", hash = "sha256:c72cf2661c3addf01c880ce60541e83e1df354644b874f7f9d8d5ed2070446ae" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-api-python-client/google_api_python_client-2.193.0-py3-none-any.whl", hash = "sha256:c42aa324b822109901cfecab5dc4fc3915d35a7b376835233c916c70610322db" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-api-python-client/google_api_python_client-2.195.0-py3-none-any.whl", hash = "sha256:753e62057f23049a89534bea0162b60fe391b85fb86d80bcdf884d05ec91c5bf" },
 ]
 
 [[package]]
 name = "google-auth"
-version = "2.49.1"
+version = "2.50.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-auth/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-auth/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-auth/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-auth/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15" },
 ]
 
 [package.optional-dependencies]
@@ -799,20 +802,20 @@ requests = [
 
 [[package]]
 name = "google-auth-httplib2"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-auth" },
     { name = "httplib2" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-auth-httplib2/google_auth_httplib2-0.3.0.tar.gz", hash = "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-auth-httplib2/google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-auth-httplib2/google_auth_httplib2-0.3.0-py3-none-any.whl", hash = "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-auth-httplib2/google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c" },
 ]
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.143.0"
+version = "1.150.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "docstring-parser" },
@@ -828,9 +831,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-aiplatform/google_cloud_aiplatform-1.143.0.tar.gz", hash = "sha256:1f0124a89795a6b473deb28724dd37d95334205df3a9c9c48d0b8d7a3d5d5cc4" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-aiplatform/google_cloud_aiplatform-1.150.0.tar.gz", hash = "sha256:ff413e527cb753257957985acdcfebef697faf20a72587b59848d8208aaea0a2" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-aiplatform/google_cloud_aiplatform-1.143.0-py2.py3-none-any.whl", hash = "sha256:78df97d044859f743a9cc48b89a260d33579b0d548b1589bb3ae9f4c2afc0c5a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-aiplatform/google_cloud_aiplatform-1.150.0-py2.py3-none-any.whl", hash = "sha256:cdddf054712820048d14e2084fc2a86e58937332f2ac44ce73eb06af1ee8f5b2" },
 ]
 
 [package.optional-dependencies]
@@ -860,7 +863,7 @@ evaluation = [
 
 [[package]]
 name = "google-cloud-appengine-logging"
-version = "1.8.0"
+version = "1.9.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -869,27 +872,27 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-appengine-logging/google_cloud_appengine_logging-1.8.0.tar.gz", hash = "sha256:84b705a69e4109fc2f68dfe36ce3df6a34d5c3d989eee6d0ac1b024dda0ba6f5" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-appengine-logging/google_cloud_appengine_logging-1.9.0.tar.gz", hash = "sha256:ff397f0bbc1485f979ab45767c38e0f676c9598c97c384f7412216e6ea22f805" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-appengine-logging/google_cloud_appengine_logging-1.8.0-py3-none-any.whl", hash = "sha256:a4ce9ce94a9fd8c89ed07fa0b06fcf9ea3642f9532a1be1a8c7b5f82c0a70ec6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-appengine-logging/google_cloud_appengine_logging-1.9.0-py3-none-any.whl", hash = "sha256:bbf3a7e4dc171678f7f481259d1f68c3ae7d337530f1f2361f8a0b214dbcfe36" },
 ]
 
 [[package]]
 name = "google-cloud-audit-log"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-audit-log/google_cloud_audit_log-0.4.0.tar.gz", hash = "sha256:8467d4dcca9f3e6160520c24d71592e49e874838f174762272ec10e7950b6feb" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-audit-log/google_cloud_audit_log-0.5.0.tar.gz", hash = "sha256:3b32d5e77db634c46fbd6c5e01f5bda836f420dfbb21d730501c75e9fab4e4a4" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-audit-log/google_cloud_audit_log-0.4.0-py3-none-any.whl", hash = "sha256:6b88e2349df45f8f4cc0993b687109b1388da1571c502dc1417efa4b66ec55e0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-audit-log/google_cloud_audit_log-0.5.0-py3-none-any.whl", hash = "sha256:3f4632f25bf67446fa9085c52868f3cb42fb1afbab9489ba8978e30991afc79f" },
 ]
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "3.40.1"
+version = "3.41.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -900,14 +903,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "requests" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery/google_cloud_bigquery-3.40.1.tar.gz", hash = "sha256:75afcfb6e007238fe1deefb2182105249321145ff921784fe7b1de2b4ba24506" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery/google_cloud_bigquery-3.41.0.tar.gz", hash = "sha256:2217e488b47ed576360c9b2cc07d59d883a54b83167c0ef37f915c26b01a06fe" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery/google_cloud_bigquery-3.40.1-py3-none-any.whl", hash = "sha256:9082a6b8193aba87bed6a2c79cf1152b524c99bb7e7ac33a785e333c09eac868" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery/google_cloud_bigquery-3.41.0-py3-none-any.whl", hash = "sha256:2a5b5a737b401cbd824a6e5eac7554100b878668d908e6548836b5d8aaa4dcaa" },
 ]
 
 [[package]]
 name = "google-cloud-bigquery-storage"
-version = "2.36.2"
+version = "2.37.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -916,14 +919,14 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery-storage/google_cloud_bigquery_storage-2.36.2.tar.gz", hash = "sha256:ad49d8c09ad6cd82da4efe596fcfcdbc1458bf05b93915e3c5c00f1e700ae128" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery-storage/google_cloud_bigquery_storage-2.37.0.tar.gz", hash = "sha256:f88ee7f1e49db1e639da3d9a8b79835ca4bc47afbb514fb2adfc0ccb41a7fd97" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery-storage/google_cloud_bigquery_storage-2.36.2-py3-none-any.whl", hash = "sha256:823a73db0c4564e8ad3eedcfd5049f3d5aa41775267863b5627211ec36be2dbf" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery-storage/google_cloud_bigquery_storage-2.37.0-py3-none-any.whl", hash = "sha256:1e319c27ef60fc31030f6e0b52e5e891e1cdd50551effe8c6f673a4c3c56fcb6" },
 ]
 
 [[package]]
 name = "google-cloud-bigtable"
-version = "2.35.0"
+version = "2.37.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -931,30 +934,31 @@ dependencies = [
     { name = "google-cloud-core" },
     { name = "google-crc32c" },
     { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigtable/google_cloud_bigtable-2.35.0.tar.gz", hash = "sha256:f5699012c5fea4bd4bdf7e80e5e3a812a847eb8f41bf8dc2f43095d6d876b83b" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigtable/google_cloud_bigtable-2.37.0.tar.gz", hash = "sha256:dda8b1972b0499238459b6e8a1bc38fb232fe70fab218607850149ed47c93933" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigtable/google_cloud_bigtable-2.35.0-py3-none-any.whl", hash = "sha256:f355bfce1f239453ec2bb3839b0f4f9937cf34ef06ef29e1ca63d58fd38d0c50" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigtable/google_cloud_bigtable-2.37.0-py3-none-any.whl", hash = "sha256:364f4cac65c9d205524a0a9105ba65a1fe6606e7db10ec630b945134f996210c" },
 ]
 
 [[package]]
 name = "google-cloud-core"
-version = "2.5.0"
+version = "2.5.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-core/google_cloud_core-2.5.0.tar.gz", hash = "sha256:7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-core/google_cloud_core-2.5.1.tar.gz", hash = "sha256:3dc94bdec9d05a31d9f355045ed0f369fbc0d8c665076c734f065d729800f811" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-core/google_cloud_core-2.5.0-py3-none-any.whl", hash = "sha256:67d977b41ae6c7211ee830c7912e41003ea8194bff15ae7d72fd6f51e57acabc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-core/google_cloud_core-2.5.1-py3-none-any.whl", hash = "sha256:ea62cdf502c20e3e14be8a32c05ed02113d7bef454e40ff3fab6fe1ec9f1f4e7" },
 ]
 
 [[package]]
 name = "google-cloud-dataplex"
-version = "2.17.0"
+version = "2.18.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -964,9 +968,9 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-dataplex/google_cloud_dataplex-2.17.0.tar.gz", hash = "sha256:321ad2abb9faecda60136d197bd2348c1dd73885fb67707db0d8f828d774fb65" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-dataplex/google_cloud_dataplex-2.18.0.tar.gz", hash = "sha256:ae3f7f1b5c64675e8a4b66725d404eec864e12d29051323a2232bdb05797016d" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-dataplex/google_cloud_dataplex-2.17.0-py3-none-any.whl", hash = "sha256:6f04a772f68564979cdf5fadb517960b961792921e117043ed1b1ef44694853c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-dataplex/google_cloud_dataplex-2.18.0-py3-none-any.whl", hash = "sha256:6e4ec95b24f64e95cec5f3753fbe7419f78ddb8b1ba90f8d955bc7613bb90764" },
 ]
 
 [[package]]
@@ -986,7 +990,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-iam"
-version = "2.21.0"
+version = "2.22.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -996,14 +1000,14 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-iam/google_cloud_iam-2.21.0.tar.gz", hash = "sha256:fc560527e22b97c6cbfba0797d867cf956c727ba687b586b9aa44d78e92281a3" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-iam/google_cloud_iam-2.22.0.tar.gz", hash = "sha256:203ddfece17e014ee4fbc5c3244daa14a88b7ee57c8e3a7622d0f2a1a3b8d7f3" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-iam/google_cloud_iam-2.21.0-py3-none-any.whl", hash = "sha256:1b4a21302b186a31f3a516ccff303779638308b7c801fb61a2406b6a0c6293c4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-iam/google_cloud_iam-2.22.0-py3-none-any.whl", hash = "sha256:c443b34b5a6a9e51d32cee397879bb781b900af68937c67a275def23bbc025f3" },
 ]
 
 [[package]]
 name = "google-cloud-logging"
-version = "3.14.0"
+version = "3.15.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -1017,14 +1021,14 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-logging/google_cloud_logging-3.14.0.tar.gz", hash = "sha256:361e83cd692fecc7da10351f641c474591f586f234fc49394db4ba5c8c5994a7" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-logging/google_cloud_logging-3.15.0.tar.gz", hash = "sha256:72168a1e98bbfc27c75f0b8f630a7f5d786065f3f1f7e9e53d2d787a03693a4a" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-logging/google_cloud_logging-3.14.0-py3-none-any.whl", hash = "sha256:4767ebdb3b46a3052d5185a7d5cf02829d33ea12a0aab1d57221110d581b9e1a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-logging/google_cloud_logging-3.15.0-py3-none-any.whl", hash = "sha256:7dcc67434c4e7181510c133d5ac8fd4ce60c23fa4158661f67e54bf440c32450" },
 ]
 
 [[package]]
 name = "google-cloud-monitoring"
-version = "2.29.1"
+version = "2.30.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -1033,14 +1037,14 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-monitoring/google_cloud_monitoring-2.29.1.tar.gz", hash = "sha256:86cac55cdd2608561819d19544fb3c129bbb7dcecc445d8de426e34cd6fa8e49" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-monitoring/google_cloud_monitoring-2.30.0.tar.gz", hash = "sha256:a9530aa9aa246c490810dfa7be32d67e8340d19108acc99cbc02d1ed494fba76" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-monitoring/google_cloud_monitoring-2.29.1-py3-none-any.whl", hash = "sha256:944a57031f20da38617d184d5658c1f938e019e8061f27fd944584831a1b9d5a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-monitoring/google_cloud_monitoring-2.30.0-py3-none-any.whl", hash = "sha256:2729f3b88a4798b7757b1d9d31b6cb562bb3544e8173765e4e5cd44d8685b1ed" },
 ]
 
 [[package]]
 name = "google-cloud-pubsub"
-version = "2.36.0"
+version = "2.37.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -1053,14 +1057,14 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-pubsub/google_cloud_pubsub-2.36.0.tar.gz", hash = "sha256:96e057e5f83433ce428852095d652c2f7fc193f0f77db1f27cc39186fe69c1f4" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-pubsub/google_cloud_pubsub-2.37.0.tar.gz", hash = "sha256:7c5ba9beb5236e2b83c091dd6171423dc7d6d0e989391bd09f60dbd242b29f10" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-pubsub/google_cloud_pubsub-2.36.0-py3-none-any.whl", hash = "sha256:d6726ccf9373924e0746338dadf8244b9aa1a97a24130b59a2106c926ea37598" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-pubsub/google_cloud_pubsub-2.37.0-py3-none-any.whl", hash = "sha256:dd912422cf66e4ffb423b0d5391ca81bdfa408eb0f21f57adecdb6fb3b1e0bb1" },
 ]
 
 [[package]]
 name = "google-cloud-resource-manager"
-version = "1.16.0"
+version = "1.17.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -1070,14 +1074,14 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-resource-manager/google_cloud_resource_manager-1.16.0.tar.gz", hash = "sha256:cc938f87cc36c2672f062b1e541650629e0d954c405a4dac35ceedee70c267c3" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-resource-manager/google_cloud_resource_manager-1.17.0.tar.gz", hash = "sha256:0f486b62e2c58ff992a3a50fa0f4a96eef7750aa6c971bb373398ccb91828660" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-resource-manager/google_cloud_resource_manager-1.16.0-py3-none-any.whl", hash = "sha256:fb9a2ad2b5053c508e1c407ac31abfd1a22e91c32876c1892830724195819a28" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-resource-manager/google_cloud_resource_manager-1.17.0-py3-none-any.whl", hash = "sha256:e479baf4b014a57f298e01b8279e3290b032e3476d69c8e5e1427af8f82739a5" },
 ]
 
 [[package]]
 name = "google-cloud-secret-manager"
-version = "2.26.0"
+version = "2.27.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -1087,14 +1091,14 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-secret-manager/google_cloud_secret_manager-2.26.0.tar.gz", hash = "sha256:0d1d6f76327685a0ed78a4cf50f289e1bfbbe56026ed0affa98663b86d6d50d6" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-secret-manager/google_cloud_secret_manager-2.27.0.tar.gz", hash = "sha256:6af864c252bd3c11db7bb02b80cb0b14a8c9a33fc7ec4d6f245f33d8ce1f7cd1" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-secret-manager/google_cloud_secret_manager-2.26.0-py3-none-any.whl", hash = "sha256:940a5447a6ec9951446fd1a0f22c81a4303fde164cd747aae152c5f5c8e6723e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-secret-manager/google_cloud_secret_manager-2.27.0-py3-none-any.whl", hash = "sha256:e5540bece65a3ad720146f3b438973faf9315109b3ffa012a58711843047a3dc" },
 ]
 
 [[package]]
 name = "google-cloud-spanner"
-version = "3.63.0"
+version = "3.65.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -1111,14 +1115,14 @@ dependencies = [
     { name = "protobuf" },
     { name = "sqlparse" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-spanner/google_cloud_spanner-3.63.0.tar.gz", hash = "sha256:e2a4fb3bdbad4688645f455d498705d3f935b7c9011f5c94c137b77569b47a62" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-spanner/google_cloud_spanner-3.65.0.tar.gz", hash = "sha256:434139bd1439528398cd2a96e390a57182420747c214a33f317bbac64afd9c5c" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-spanner/google_cloud_spanner-3.63.0-py3-none-any.whl", hash = "sha256:6ffae0ed589bbbd2d8831495e266198f3d069005cfe65c664448c9a727c88e7b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-spanner/google_cloud_spanner-3.65.0-py3-none-any.whl", hash = "sha256:67ca892698d9530d10c682be7c38265089088b57272af3e57f1ea7afb9e88eff" },
 ]
 
 [[package]]
 name = "google-cloud-speech"
-version = "2.37.0"
+version = "2.38.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -1127,9 +1131,9 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-speech/google_cloud_speech-2.37.0.tar.gz", hash = "sha256:1b2debf721954f1157fb2631d19b29fbeeba5736e58b71aaf10734d6365add59" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-speech/google_cloud_speech-2.38.0.tar.gz", hash = "sha256:1854b51cbb7957273b6ba61f4a6cf49dec8d09ec450991587897e50267eaca51" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-speech/google_cloud_speech-2.37.0-py3-none-any.whl", hash = "sha256:370abd51244ffc68062d655d3063e083fad525416e0cb31737f4804e3cd8588c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-speech/google_cloud_speech-2.38.0-py3-none-any.whl", hash = "sha256:dbccb340a750a409b0e70c48c16c8d7d5d48a87c70cce2add50f3d571f5375a0" },
 ]
 
 [[package]]
@@ -1151,7 +1155,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-trace"
-version = "1.18.0"
+version = "1.19.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -1160,9 +1164,9 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-trace/google_cloud_trace-1.18.0.tar.gz", hash = "sha256:46d42b90273da3bc4850bb0d6b9a205eb826a54561ff1b30ca33cc92174c3f37" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-trace/google_cloud_trace-1.19.0.tar.gz", hash = "sha256:58293c6efcee6c74bb854ff01b008823bef66845c14f15ffa5209d545098a65d" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-trace/google_cloud_trace-1.18.0-py3-none-any.whl", hash = "sha256:52c002d8d3da802e031fee62cd49a1baf899932d4f548a150f685af6815b5554" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-trace/google_cloud_trace-1.19.0-py3-none-any.whl", hash = "sha256:59604c4c775c40af31b367df6bada0af34518cc35ac8cfedecd43898a120c51d" },
 ]
 
 [[package]]
@@ -1185,7 +1189,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.68.0"
+version = "1.75.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "anyio" },
@@ -1199,33 +1203,33 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-genai/google_genai-1.68.0.tar.gz", hash = "sha256:ac30c0b8bc630f9372993a97e4a11dae0e36f2e10d7c55eacdca95a9fa14ca96" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-genai/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-genai/google_genai-1.68.0-py3-none-any.whl", hash = "sha256:a1bc9919c0e2ea2907d1e319b65471d3d6d58c54822039a249fe1323e4178d15" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-genai/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c" },
 ]
 
 [[package]]
 name = "google-resumable-media"
-version = "2.8.0"
+version = "2.8.2"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-crc32c" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-resumable-media/google_resumable_media-2.8.0.tar.gz", hash = "sha256:f1157ed8b46994d60a1bc432544db62352043113684d4e030ee02e77ebe9a1ae" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-resumable-media/google_resumable_media-2.8.2.tar.gz", hash = "sha256:f3354a182ebd193ae3f42e3ef95e6c9b10f128320de23ac7637236713b1acd70" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-resumable-media/google_resumable_media-2.8.0-py3-none-any.whl", hash = "sha256:dd14a116af303845a8d932ddae161a26e86cc229645bc98b39f026f9b1717582" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-resumable-media/google_resumable_media-2.8.2-py3-none-any.whl", hash = "sha256:82b6d8ccd11765268cdd2a2123f417ec806b8eef3000a9a38dfe3033da5fb220" },
 ]
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.73.0"
+version = "1.74.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/googleapis-common-protos/googleapis_common_protos-1.73.0.tar.gz", hash = "sha256:778d07cd4fbeff84c6f7c72102f0daf98fa2bfd3fa8bea426edc545588da0b5a" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/googleapis-common-protos/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/googleapis-common-protos/googleapis_common_protos-1.73.0-py3-none-any.whl", hash = "sha256:dfdaaa2e860f242046be561e6d6cb5c5f1541ae02cfbcb034371aadb2942b4e8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/googleapis-common-protos/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5" },
 ]
 
 [package.optional-dependencies]
@@ -1244,50 +1248,53 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.3.2"
+version = "3.5.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/greenlet/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86" },
 ]
 
 [[package]]
 name = "grpc-google-iam-v1"
-version = "0.14.3"
+version = "0.14.4"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "googleapis-common-protos", extra = ["grpc"] },
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpc-google-iam-v1/grpc_google_iam_v1-0.14.3.tar.gz", hash = "sha256:879ac4ef33136c5491a6300e27575a9ec760f6cdf9a2518798c1b8977a5dc389" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpc-google-iam-v1/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpc-google-iam-v1/grpc_google_iam_v1-0.14.3-py3-none-any.whl", hash = "sha256:7a7f697e017a067206a3dfef44e4c634a34d3dee135fe7d7a4613fe3e59217e6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpc-google-iam-v1/grpc_google_iam_v1-0.14.4-py3-none-any.whl", hash = "sha256:412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964" },
 ]
 
 [[package]]
@@ -1304,59 +1311,59 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.78.1"
+version = "1.80.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1.tar.gz", hash = "sha256:27c625532d33ace45d57e775edf1982e183ff8641c72e4e91ef7ba667a149d72" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:2b7ad2981550ce999e25ce3f10c8863f718a352a2fd655068d29ea3fd37b4907" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:409bfe22220889b9906739910a0ee4c197a967c21b8dd14b4b06dd477f8819ce" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:34b6cb16f4b67eeb5206250dc5b4d5e8e3db939535e58efc330e4c61341554bd" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:39d21fd30d38a5afb93f0e2e71e2ec2bd894605fb75d41d5a40060c2f98f8d11" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09fbd4bcaadb6d8604ed1504b0bdf7ac18e48467e83a9d930a70a7fefa27e862" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:db681513a1bdd879c0b24a5a6a70398da5eaaba0e077a306410dc6008426847a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f81816faa426da461e9a597a178832a351d6f1078102590a4b32c77d251b71eb" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffbb760df1cd49e0989f9826b2fd48930700db6846ac171eaff404f3cfbe5c28" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-win32.whl", hash = "sha256:1a56bf3ee99af5cf32d469de91bf5de79bdac2e18082b495fc1063ea33f4f2d0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp313-cp313-win_amd64.whl", hash = "sha256:8991c2add0d8505178ff6c3ae54bd9386279e712be82fa3733c54067aae9eda1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:d101fe49b1e0fb4a7aa36ed0c3821a0f67a5956ef572745452d2cd790d723a3f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:5ce1855e8cfc217cdf6bcfe0cf046d7cf81ddcc3e6894d6cfd075f87a2d8f460" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd26048d066b51f39fe9206e2bcc2cea869a5e5b2d13c8d523f4179193047ebd" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4b8d7fda614cf2af0f73bbb042f3b7fee2ecd4aea69ec98dbd903590a1083529" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:656a5bd142caeb8b1efe1fe0b4434ecc7781f44c97cfc7927f6608627cf178c0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:99550e344482e3c21950c034f74668fccf8a546d50c1ecb4f717543bbdc071ba" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:8f27683ca68359bd3f0eb4925824d71e538f84338b3ae337ead2ae43977d7541" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a40515b69ac50792f9b8ead260f194ba2bb3285375b6c40c7ff938f14c3df17d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-win32.whl", hash = "sha256:2c473b54ef1618f4fb85e82ff4994de18143b74efc088b91b5a935a3a45042ba" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.78.1-cp314-cp314-win_amd64.whl", hash = "sha256:e2a6b33d1050dce2c6f563c5caf7f7cbeebf7fba8cde37ffe3803d50526900d1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f" },
 ]
 
 [[package]]
 name = "grpcio-status"
-version = "1.78.1"
+version = "1.80.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio-status/grpcio_status-1.78.1.tar.gz", hash = "sha256:47e7fa903549c5881344f1cba23c814b5f69d09233541036eb25642d32497c8e" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio-status/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio-status/grpcio_status-1.78.1-py3-none-any.whl", hash = "sha256:5f6660b99063f918b7f84d99cab68084aeb0dd09949e1224a6073026cea6820c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/grpcio-status/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe" },
 ]
 
 [[package]]
 name = "gunicorn"
-version = "25.1.0"
+version = "26.0.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/gunicorn/gunicorn-25.1.0.tar.gz", hash = "sha256:1426611d959fa77e7de89f8c0f32eed6aa03ee735f98c01efba3e281b1c47616" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/gunicorn/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/gunicorn/gunicorn-25.1.0-py3-none-any.whl", hash = "sha256:d0b1236ccf27f72cfe14bce7caadf467186f19e865094ca84221424e839b8b8b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/gunicorn/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc" },
 ]
 
 [[package]]
@@ -1370,34 +1377,34 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.4.2"
+version = "1.5.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ac8202ae1e664b2c15cdfc7298cbb25e80301ae596d602ef7870099a126fcad4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6d2f8ee39fa9fba9af929f8c0d0482f8ee6e209179ad14a909b6ad78ffcb7c81" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4642a6cf249c09da8c1f87fe50b24b2a3450b235bf8adb55700b52f0ea6e2eb6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:769431385e746c92dc05492dde6f687d304584b89c33d79def8367ace06cb555" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c9dd1c1bc4cc56168f81939b0e05b4c36dd2d28c13dc1364b17af89aa0082496" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fca58a2ae4e6f6755cc971ac6fcdf777ea9284d7e540e350bb000813b9a3008d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:163aab46854ccae0ab6a786f8edecbbfbaa38fcaa0184db6feceebf7000c93c0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:09b138422ecbe50fd0c84d4da5ff537d27d487d3607183cd10e3e53f05188e82" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:949dcf88b484bb9d9276ca83f6599e4aa03d493c08fc168c124ad10b2e6f75d7" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:41659966020d59eb9559c57de2cde8128b706a26a64c60f0531fa2318f409418" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c588e21d80010119458dd5d02a69093f0d115d84e3467efe71ffb2c67c19146" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a296744d771a8621ad1d50c098d7ab975d599800dae6d48528ba3944e5001ba0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f563f7efe49588b7d0629d18d36f46d1658fe7e08dce3fa3d6526e1c98315e2d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5b2e0132c56d7ee1bf55bdb638c4b62e7106f6ac74f0b786fed499d5548c5570" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:2f45c712c2fa1215713db10df6ac84b49d0e1c393465440e9cb1de73ecf7bbf6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6d53df40616f7168abfccff100d232e9d460583b9d86fa4912c24845f192f2b8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be" },
 ]
 
 [[package]]
@@ -1451,7 +1458,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.8.0"
+version = "1.14.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "filelock" },
@@ -1464,30 +1471,30 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/huggingface-hub/huggingface_hub-1.8.0.tar.gz", hash = "sha256:c5627b2fd521e00caf8eff4ac965ba988ea75167fad7ee72e17f9b7183ec63f3" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/huggingface-hub/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/huggingface-hub/huggingface_hub-1.8.0-py3-none-any.whl", hash = "sha256:d3eb5047bd4e33c987429de6020d4810d38a5bef95b3b40df9b17346b7f353f2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/huggingface-hub/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.13"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/idna/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/idna/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/idna/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/idna/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3" },
 ]
 
 [[package]]
 name = "importlib-metadata"
-version = "8.7.1"
+version = "8.5.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/importlib-metadata/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/importlib-metadata/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/importlib-metadata/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/importlib-metadata/importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b" },
 ]
 
 [[package]]
@@ -1522,53 +1529,56 @@ wheels = [
 
 [[package]]
 name = "jiter"
-version = "0.13.0"
+version = "0.14.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff" },
 ]
 
 [[package]]
@@ -1581,8 +1591,20 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.6.5"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/joserfc/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/joserfc/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e" },
+]
+
+[[package]]
 name = "jsonschema"
-version = "4.26.0"
+version = "4.23.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "attrs" },
@@ -1590,9 +1612,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jsonschema/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jsonschema/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jsonschema/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jsonschema/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566" },
 ]
 
 [[package]]
@@ -1609,7 +1631,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.82.6"
+version = "1.83.14"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "aiohttp" },
@@ -1625,21 +1647,21 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/litellm/litellm-1.82.6.tar.gz", hash = "sha256:2aa1c2da21fe940c33613aa447119674a3ad4d2ad5eb064e4d5ce5ee42420136" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/litellm/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/litellm/litellm-1.82.6-py3-none-any.whl", hash = "sha256:164a3ef3e19f309e3cabc199bef3d2045212712fefdfa25fc7f75884a5b5b205" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/litellm/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb" },
 ]
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.12"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/mako/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/mako/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/mako/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/mako/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9" },
 ]
 
 [[package]]
@@ -1733,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.27.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "anyio" },
@@ -1751,9 +1773,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/mcp/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/mcp/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/mcp/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/mcp/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741" },
 ]
 
 [[package]]
@@ -1929,57 +1951,57 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.4.3"
+version = "2.4.4"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b346845443716c8e542d54112966383b448f4a3ba5c66409771b8c0889485dd3" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2629289168f4897a3c4e23dc98d6f1731f0fc0fe52fb9db19f974041e4cc12b9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bb2e3cf95854233799013779216c57e153c1ee67a0bf92138acca0e429aefaee" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:7f3408ff897f8ab07a07fbe2823d7aee6ff644c097cc1f90382511fe982f647f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:decb0eb8a53c3b009b0962378065589685d66b23467ef5dac16cbe818afde27f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5f51900414fc9204a0e0da158ba2ac52b75656e7dce7e77fb9f84bfa343b4cc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6bd06731541f89cdc01b261ba2c9e037f1543df7472517836b78dfb15bd6e476" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22654fe6be0e5206f553a9250762c653d3698e46686eee53b399ab90da59bd92" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-win32.whl", hash = "sha256:d71e379452a2f670ccb689ec801b1218cd3983e253105d6e83780967e899d687" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:0a60e17a14d640f49146cb38e3f105f571318db7826d9b6fef7e4dce758faecd" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313-win_arm64.whl", hash = "sha256:c9619741e9da2059cd9c3f206110b97583c7152c1dc9f8aafd4beb450ac1c89d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7aa4e54f6469300ebca1d9eb80acd5253cdfa36f2c03d79a35883687da430875" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d1b90d840b25874cf5cd20c219af10bac3667db3876d9a495609273ebe679070" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:a749547700de0a20a6718293396ec237bb38218049cfce788e08fcb716e8cf73" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f3c4a151a2e529adf49c1d54f0f57ff8f9b233ee4d44af623a81553ab86368" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22c31dc07025123aedf7f2db9e91783df13f1776dc52c6b22c620870dc0fab22" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:148d59127ac95979d6f07e4d460f934ebdd6eed641db9c0db6c73026f2b2101a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a97cbf7e905c435865c2d939af3d93f99d18eaaa3cabe4256f4304fb51604349" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-win32.whl", hash = "sha256:be3b8487d725a77acccc9924f65fd8bce9af7fac8c9820df1049424a2115af6c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1ec84fd7c8e652b0f4aaaf2e6e9cc8eaa9b1b80a537e06b2e3a2fb176eedcb26" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:120df8c0a81ebbf5b9020c91439fccd85f5e018a927a39f624845be194a2be02" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5884ce5c7acfae1e4e1b6fde43797d10aa506074d25b531b4f54bde33c0c31d4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:297837823f5bc572c5f9379b0c9f3a3365f08492cbdc33bcc3af174372ebb168" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a111698b4a3f8dcbe54c64a7708f049355abd603e619013c346553c1fd4ca90b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:4bd4741a6a676770e0e97fe9ab2e51de01183df3dcbcec591d26d331a40de950" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54f29b877279d51e210e0c80709ee14ccbbad647810e8f3d375561c45ef613dd" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:679f2a834bae9020f81534671c56fd0cc76dd7e5182f57131478e23d0dc59e24" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d84f0f881cb2225c2dfd7f78a10a5645d487a496c6668d6cc39f0f114164f3d0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d213c7e6e8d211888cc359bab7199670a00f5b82c0978b9d1c75baf1eddbeac0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-win32.whl", hash = "sha256:52077feedeff7c76ed7c9f1a0428558e50825347b7545bbb8523da2cd55c547a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:0448e7f9caefb34b4b7dd2b77f21e8906e5d6f0365ad525f9f4f530b13df2afc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314-win_arm64.whl", hash = "sha256:b44fd60341c4d9783039598efadd03617fa28d041fc37d22b62d08f2027fa0e7" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0a195f4216be9305a73c0e91c9b026a35f2161237cf1c6de9b681637772ea657" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:cd32fbacb9fd1bf041bf8e89e4576b6f00b895f06d00914820ae06a616bdfef7" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:2e03c05abaee1f672e9d67bc858f300b5ccba1c21397211e8d77d98350972093" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d1ce23cce91fcea443320a9d0ece9b9305d4368875bab09538f7a5b4131938a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c59020932feb24ed49ffd03704fbab89f22aa9c0d4b180ff45542fe8918f5611" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9684823a78a6cd6ad7511fc5e25b07947d1d5b5e2812c93fe99d7d4195130720" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0200b25c687033316fb39f0ff4e3e690e8957a2c3c8d22499891ec58c37a3eb5" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7" },
 ]
 
 [[package]]
 name = "openai"
-version = "2.30.0"
+version = "2.24.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "anyio" },
@@ -1991,27 +2013,27 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/openai/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/openai/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/openai/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/openai/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94" },
 ]
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.37.0"
+version = "1.41.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-api/opentelemetry_api-1.37.0.tar.gz", hash = "sha256:540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-api/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-api/opentelemetry_api-1.37.0-py3-none-any.whl", hash = "sha256:accf2024d3e89faec14302213bc39550ec0f4095d1cf5ca688e1bfb1c8612f47" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-api/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-gcp-logging"
-version = "1.11.0a0"
+version = "1.12.0a0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-cloud-logging" },
@@ -2019,14 +2041,14 @@ dependencies = [
     { name = "opentelemetry-resourcedetector-gcp" },
     { name = "opentelemetry-sdk" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-logging/opentelemetry_exporter_gcp_logging-1.11.0a0.tar.gz", hash = "sha256:58496f11b930c84570060ffbd4343cd0b597ea13c7bc5c879df01163dd552f14" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-logging/opentelemetry_exporter_gcp_logging-1.12.0a0.tar.gz", hash = "sha256:586529dbbcae5e22b880f7c121fde3f0fe8ae997aba1bad53f13c20eeb27cb3a" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-logging/opentelemetry_exporter_gcp_logging-1.11.0a0-py3-none-any.whl", hash = "sha256:f8357c552947cb9c0101c4575a7702b8d3268e28bdeefdd1405cf838e128c6ef" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-logging/opentelemetry_exporter_gcp_logging-1.12.0a0-py3-none-any.whl", hash = "sha256:2aca9b01b3248c2fa95d38d01aa71aca8e22f640c44dba36ca6b883930762971" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-gcp-monitoring"
-version = "1.11.0a0"
+version = "1.12.0a0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-cloud-monitoring" },
@@ -2034,14 +2056,14 @@ dependencies = [
     { name = "opentelemetry-resourcedetector-gcp" },
     { name = "opentelemetry-sdk" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-monitoring/opentelemetry_exporter_gcp_monitoring-1.11.0a0.tar.gz", hash = "sha256:386276eddbbd978a6f30fafd3397975beeb02a1302bdad554185242a8e2c343c" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-monitoring/opentelemetry_exporter_gcp_monitoring-1.12.0a0.tar.gz", hash = "sha256:2b285078cddd4af78a363a55b5478e89f7df6f15bba9139d3f484099e534df4c" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-monitoring/opentelemetry_exporter_gcp_monitoring-1.11.0a0-py3-none-any.whl", hash = "sha256:b6740cba61b2f9555274829fe87a58447b64d0378f1067a4faebb4f5b364ca22" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-monitoring/opentelemetry_exporter_gcp_monitoring-1.12.0a0-py3-none-any.whl", hash = "sha256:1a7daf8c9350d55010fa33d2c2f646655a03a81d0d8073a2ae0e066791d6177d" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-gcp-trace"
-version = "1.11.0"
+version = "1.12.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "google-cloud-trace" },
@@ -2049,26 +2071,26 @@ dependencies = [
     { name = "opentelemetry-resourcedetector-gcp" },
     { name = "opentelemetry-sdk" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-trace/opentelemetry_exporter_gcp_trace-1.11.0.tar.gz", hash = "sha256:c947ab4ab53e16517ade23d6fe71fe88cf7ca3f57a42c9f0e4162d2b929fecb6" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-trace/opentelemetry_exporter_gcp_trace-1.12.0.tar.gz", hash = "sha256:18c6e56fe123eed020d5005fdd819b196d64f651545bce1ca7e2e2cbaf9d343b" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-trace/opentelemetry_exporter_gcp_trace-1.11.0-py3-none-any.whl", hash = "sha256:b3dcb314e1a9985e9185cb7720b693eb393886fde98ae4c095ffc0893de6cefa" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-gcp-trace/opentelemetry_exporter_gcp_trace-1.12.0-py3-none-any.whl", hash = "sha256:1538dab654bcb25e757ed34c94f27a2e30d90dc7deb3630f8d46d1111fcb3bad" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.37.0"
+version = "1.41.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-otlp-proto-common/opentelemetry_exporter_otlp_proto_common-1.37.0.tar.gz", hash = "sha256:c87a1bdd9f41fdc408d9cc9367bb53f8d2602829659f2b90be9f9d79d0bfe62c" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-otlp-proto-common/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-otlp-proto-common/opentelemetry_exporter_otlp_proto_common-1.37.0-py3-none-any.whl", hash = "sha256:53038428449c559b0c564b8d718df3314da387109c4d36bd1b94c9a641b0292e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-otlp-proto-common/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.37.0"
+version = "1.41.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -2079,26 +2101,26 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-otlp-proto-http/opentelemetry_exporter_otlp_proto_http-1.37.0.tar.gz", hash = "sha256:e52e8600f1720d6de298419a802108a8f5afa63c96809ff83becb03f874e44ac" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-otlp-proto-http/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-otlp-proto-http/opentelemetry_exporter_otlp_proto_http-1.37.0-py3-none-any.whl", hash = "sha256:54c42b39945a6cc9d9a2a33decb876eabb9547e0dcb49df090122773447f1aef" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-exporter-otlp-proto-http/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.37.0"
+version = "1.41.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-proto/opentelemetry_proto-1.37.0.tar.gz", hash = "sha256:30f5c494faf66f77faeaefa35ed4443c5edb3b0aa46dad073ed7210e1a789538" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-proto/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-proto/opentelemetry_proto-1.37.0-py3-none-any.whl", hash = "sha256:8ed8c066ae8828bbf0c39229979bdf583a126981142378a9cbe9d6fd5701c6e2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-proto/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720" },
 ]
 
 [[package]]
 name = "opentelemetry-resourcedetector-gcp"
-version = "1.11.0a0"
+version = "1.12.0a0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2106,45 +2128,45 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-resourcedetector-gcp/opentelemetry_resourcedetector_gcp-1.11.0a0.tar.gz", hash = "sha256:915a1d6fd15daca9eedd3fc52b0f705375054f2ef140e2e7a6b4cca95a47cdb1" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-resourcedetector-gcp/opentelemetry_resourcedetector_gcp-1.12.0a0.tar.gz", hash = "sha256:d5e3f78283a272eb92547e00bbeff45b7332a34ae791a70ab4eba81af9bc3baf" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-resourcedetector-gcp/opentelemetry_resourcedetector_gcp-1.11.0a0-py3-none-any.whl", hash = "sha256:5d65a2a039b1d40c6f41421dbb08d5f441368275ac6de6e76a8fccd1f6acb67e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-resourcedetector-gcp/opentelemetry_resourcedetector_gcp-1.12.0a0-py3-none-any.whl", hash = "sha256:e803688d14e2969fe816077be81f7b034368314d485863f12ce49daba7c81919" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.37.0"
+version = "1.41.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-sdk/opentelemetry_sdk-1.37.0.tar.gz", hash = "sha256:cc8e089c10953ded765b5ab5669b198bbe0af1b3f89f1007d19acd32dc46dda5" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-sdk/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-sdk/opentelemetry_sdk-1.37.0-py3-none-any.whl", hash = "sha256:8f3c3c22063e52475c5dbced7209495c2c16723d016d39287dfc215d1771257c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-sdk/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.58b0"
+version = "0.62b1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-semantic-conventions/opentelemetry_semantic_conventions-0.58b0.tar.gz", hash = "sha256:6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-semantic-conventions/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-semantic-conventions/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", hash = "sha256:5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/opentelemetry-semantic-conventions/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c" },
 ]
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/packaging/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/packaging/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/packaging/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/packaging/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e" },
 ]
 
 [[package]]
@@ -2333,14 +2355,14 @@ wheels = [
 
 [[package]]
 name = "proto-plus"
-version = "1.27.1"
+version = "1.27.2"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/proto-plus/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/proto-plus/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/proto-plus/proto_plus-1.27.1-py3-none-any.whl", hash = "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/proto-plus/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718" },
 ]
 
 [[package]]
@@ -2360,38 +2382,38 @@ wheels = [
 
 [[package]]
 name = "pyarrow"
-version = "23.0.1"
+version = "24.0.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyarrow/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19" },
 ]
 
 [[package]]
@@ -2494,25 +2516,25 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pydantic-settings/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pydantic-settings/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pydantic-settings/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pydantic-settings/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e" },
 ]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pygments/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pygments/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pygments/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pygments/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176" },
 ]
 
 [[package]]
@@ -2531,30 +2553,30 @@ crypto = [
 
 [[package]]
 name = "pymupdf"
-version = "1.27.2.2"
+version = "1.27.2.3"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2.tar.gz", hash = "sha256:ea8fdc3ab6671ca98f629d5ec3032d662c8cf1796b146996b7ad306ac7ed3335" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:800f43e60a6f01f644343c2213b8613db02eaf4f4ba235b417b3351fa99e01c0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e2e4299ef1ac0c9dff9be096cbd22783699673abecfa7c3f73173ae06421d73" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5e3d54922db1c7da844f1208ac1db05704770988752311f81dd36694ae0a07b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:892698c9768457eb0991c102c96a856c0a7062539371df5e6bee0816f3ef498e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b4bbfa6ef347fade678771a93f6364971c51a2cdc44cd2400dc4eeed1ddb4e6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2-cp310-abi3-win32.whl", hash = "sha256:0b8e924433b7e0bd46be820899300259235997d5a747638471fb2762baa8ee30" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2-cp310-abi3-win_amd64.whl", hash = "sha256:09bb53f9486ccb5297030cbc2dbdae845ba1c3c5126e96eb2d16c4f118de0b5b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6cebfbbdfd219ebdebf4d8e3914624b2e3d3a844c43f4f76935822dd9b13cc12" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pymupdf/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2" },
 ]
 
 [[package]]
 name = "pyopenssl"
-version = "26.0.0"
+version = "26.2.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyopenssl/pyopenssl-26.0.0.tar.gz", hash = "sha256:f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyopenssl/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyopenssl/pyopenssl-26.0.0-py3-none-any.whl", hash = "sha256:df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pyopenssl/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70" },
 ]
 
 [[package]]
@@ -2568,7 +2590,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2577,9 +2599,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pytest/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pytest/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pytest/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pytest/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9" },
 ]
 
 [[package]]
@@ -2605,20 +2627,20 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.27"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/python-multipart/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/python-multipart/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/python-multipart/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/python-multipart/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645" },
 ]
 
 [[package]]
 name = "pytz"
-version = "2026.1.post1"
+version = "2026.2"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pytz/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pytz/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pytz/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/pytz/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126" },
 ]
 
 [[package]]
@@ -2685,79 +2707,79 @@ wheels = [
 
 [[package]]
 name = "regex"
-version = "2026.3.32"
+version = "2026.4.4"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32.tar.gz", hash = "sha256:f1574566457161678297a116fa5d1556c5a4159d64c5ff7c760e7c564bf66f16" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c6d9c6e783b348f719b6118bb3f187b2e138e3112576c9679eb458cc8b2e164b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0f21ae18dfd15752cdd98d03cbd7a3640be826bfd58482a93f730dbd24d7b9fb" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:844d88509c968dd44b30daeefac72b038b1bf31ac372d5106358ab01d393c48b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8fc918cd003ba0d066bf0003deb05a259baaaab4dc9bd4f1207bbbe64224857a" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbc458a292aee57d572075f22c035fa32969cdb7987d454e3e34d45a40a0a8b4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:987cdfcfb97a249abc3601ad53c7de5c370529f1981e4c8c46793e4a1e1bfe8e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5d88fa37ba5e8a80ca8d956b9ea03805cfa460223ac94b7d4854ee5e30f3173" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d082be64e51671dd5ee1c208c92da2ddda0f2f20d8ef387e57634f7e97b6aae" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c1d7fa44aece1fa02b8927441614c96520253a5cad6a96994e3a81e060feed55" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d478a2ca902b6ef28ffc9521e5f0f728d036abe35c0b250ee8ae78cfe7c5e44e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2820d2231885e97aff0fcf230a19ebd5d2b5b8a1ba338c20deb34f16db1c7897" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc8ced733d6cd9af5e412f256a32f7c61cd2d7371280a65c689939ac4572499f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:847087abe98b3c1ebf1eb49d6ef320dbba75a83ee4f83c94704580f1df007dd4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-win32.whl", hash = "sha256:d21a07edddb3e0ca12a8b8712abc8452481c3d3db19ae87fc94e9842d005964b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-win_amd64.whl", hash = "sha256:3c054e39a9f85a3d76c62a1d50c626c5e9306964eaa675c53f61ff7ec1204bbb" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-win_arm64.whl", hash = "sha256:b2e9c2ea2e93223579308263f359eab8837dc340530b860cb59b713651889f14" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5d86e3fb08c94f084a625c8dc2132a79a3a111c8bf6e2bc59351fa61753c2f6e" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b6f366a5ef66a2df4d9e68035cfe9f0eb8473cdfb922c37fac1d169b468607b0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b8fca73e16c49dd972ce3a88278dfa5b93bf91ddef332a46e9443abe21ca2f7c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b953d9d496d19786f4d46e6ba4b386c6e493e81e40f9c5392332458183b0599d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b565f25171e04d4fad950d1fa837133e3af6ea6f509d96166eed745eb0cf63bc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f28eac18a8733a124444643a66ac96fef2c0ad65f50034e0a043b90333dc677f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cdd508664430dd51b8888deb6c5b416d8de046b2e11837254378d31febe4a98" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c35d097f509cf7e40d20d5bee548d35d6049b36eb9965e8d43e4659923405b9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:85c9b0c131427470a6423baa0a9330be6fd8c3630cc3ee6fdee03360724cbec5" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:e50af656c15e2723eeb7279c0837e07accc594b95ec18b86821a4d44b51b24bf" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:4bc32b4dbdb4f9f300cf9f38f8ea2ce9511a068ffaa45ac1373ee7a943f1d810" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e3e5d1802cba785210a4a800e63fcee7a228649a880f3bf7f2aadccb151a834b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ef250a3f5e93182193f5c927c5e9575b2cb14b80d03e258bc0b89cc5de076b60" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-win32.whl", hash = "sha256:9cf7036dfa2370ccc8651521fcbb40391974841119e9982fa312b552929e6c85" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-win_amd64.whl", hash = "sha256:c940e00e8d3d10932c929d4b8657c2ea47d2560f31874c3e174c0d3488e8b865" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-win_arm64.whl", hash = "sha256:ace48c5e157c1e58b7de633c5e257285ce85e567ac500c833349c363b3df69d4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a416ee898ecbc5d8b283223b4cf4d560f93244f6f7615c1bd67359744b00c166" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d76d62909bfb14521c3f7cfd5b94c0c75ec94b0a11f647d2f604998962ec7b6c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:631f7d95c83f42bccfe18946a38ad27ff6b6717fb4807e60cf24860b5eb277fc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12917c6c6813ffcdfb11680a04e4d63c5532b88cf089f844721c5f41f41a63ad" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3e221b615f83b15887636fcb90ed21f1a19541366f8b7ba14ba1ad8304f4ded4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4f9ae4755fa90f1dc2d0d393d572ebc134c0fe30fcfc0ab7e67c1db15f192041" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a094e9dcafedfb9d333db5cf880304946683f43a6582bb86688f123335122929" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c1cecea3e477af105f32ef2119b8d895f297492e41d317e60d474bc4bffd62ff" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f26262900edd16272b6360014495e8d68379c6c6e95983f9b7b322dc928a1194" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1cb22fa9ee6a0acb22fc9aecce5f9995fe4d2426ed849357d499d62608fbd7f9" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:9b9118a78e031a2e4709cd2fcc3028432e89b718db70073a8da574c249b5b249" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b193ed199848aa96618cd5959c1582a0bf23cd698b0b900cb0ffe81b02c8659c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:10fb2aaae1aaadf7d43c9f3c2450404253697bf8b9ce360bd5418d1d16292298" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-win32.whl", hash = "sha256:110ba4920721374d16c4c8ea7ce27b09546d43e16aea1d7f43681b5b8f80ba61" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-win_amd64.whl", hash = "sha256:245667ad430745bae6a1e41081872d25819d86fbd9e0eec485ba00d9f78ad43d" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-win_arm64.whl", hash = "sha256:1ca02ff0ef33e9d8276a1fcd6d90ff6ea055a32c9149c0050b5b67e26c6d2c51" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:51fb7e26f91f9091fd8ec6a946f99b15d3bc3667cb5ddc73dd6cb2222dd4a1cc" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:51a93452034d671b0e21b883d48ea66c5d6a05620ee16a9d3f229e828568f3f0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:03c2ebd15ff51e7b13bb3dc28dd5ac18cd39e59ebb40430b14ae1a19e833cff1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5bf2f3c2c5bd8360d335c7dcd4a9006cf1dabae063ee2558ee1b07bbc8a20d88" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a4a3189a99ecdd1c13f42513ab3fc7fa8311b38ba7596dd98537acb8cd9acc3" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3c0bbfbd38506e1ea96a85da6782577f06239cb9fcf9696f1ea537c980c0680b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8aaf8ee8f34b677f90742ca089b9c83d64bdc410528767273c816a863ed57327" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ea568832eca219c2be1721afa073c1c9eb8f98a9733fdedd0a9747639fc22a5" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e4c8fa46aad1a11ae2f8fcd1c90b9d55e18925829ac0d98c5bb107f93351745" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0cec365d44835b043d7b3266487797639d07d621bec9dc0ea224b00775797cc1" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:09e26cad1544d856da85881ad292797289e4406338afe98163f3db9f7fac816c" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:6062c4ef581a3e9e503dccf4e1b7f2d33fdc1c13ad510b287741ac73bc4c6b27" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88ebc0783907468f17fca3d7821b30f9c21865a721144eb498cb0ff99a67bcac" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-win32.whl", hash = "sha256:e480d3dac06c89bc2e0fd87524cc38c546ac8b4a38177650745e64acbbcfdeba" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-win_amd64.whl", hash = "sha256:67015a8162d413af9e3309d9a24e385816666fbf09e48e3ec43342c8536f7df6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-win_arm64.whl", hash = "sha256:1a6ac1ed758902e664e0d95c1ee5991aa6fb355423f378ed184c6ec47a1ec0e9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3790ba9fb5dd76715a7afe34dbe603ba03f8820764b1dc929dd08106214ed031" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e9638791082eaf5b3ac112c587518ee78e083a11c4b28012d8fe2a0f536dfb17" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae3e764bd4c5ff55035dc82a8d49acceb42a5298edf6eb2fc4d328ee5dd7afae" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffa81f81b80047ba89a3c69ae6a0f78d06f4a42ce5126b0eb2a0a10ad44e0b2e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f56ebf9d70305307a707911b88469213630aba821e77de7d603f9d2f0730687d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:773d1dfd652bbffb09336abf890bfd64785c7463716bf766d0eb3bc19c8b7f27" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d51d20befd5275d092cdffba57ded05f3c436317ee56466c8928ac32d960edaf" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:0a51cdb3c1e9161154f976cb2bef9894bc063ac82f31b733087ffb8e880137d0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ae5266a82596114e41fb5302140e9630204c1b5f325c770bec654b95dd54b0aa" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c882cd92ec68585e9c1cf36c447ec846c0d94edd706fe59e0c198e65822fd23b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-win32.whl", hash = "sha256:05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:36bcb9d6d1307ab629edc553775baada2aefa5c50ccc0215fbfd2afcfff43141" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c228cf65b4a54583763645dcd73819b3b381ca8b4bb1b349dee1c135f4112c07" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dd2630faeb6876fb0c287f664d93ddce4d50cd46c6e88e60378c05c9047e08ca" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a50ab11b7779b849472337191f3a043e27e17f71555f98d0092fa6d73364520" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0734f63afe785138549fbe822a8cfeaccd1bae814c5057cc0ed5b9f2de4fc883" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4ee50606cb1967db7e523224e05f32089101945f859928e65657a2cbb3d278b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6c1818f37be3ca02dcb76d63f2c7aaba4b0dc171b579796c6fbe00148dfec6b1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f5bfc2741d150d0be3e4a0401a5c22b06e60acb9aa4daa46d9e79a6dcd0f135b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:504ffa8a03609a087cad81277a629b6ce884b51a24bd388a7980ad61748618ff" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70aadc6ff12e4b444586e57fc30771f86253f9f0045b29016b9605b4be5f7dfb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f4f83781191007b6ef43b03debc35435f10cad9b96e16d147efe84a1d48bdde4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-win32.whl", hash = "sha256:e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:54a1189ad9d9357760557c91103d5e421f0a2dabe68a5cdf9103d0dcf4e00752" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e19e18c568d2866d8b6a6dfad823db86193503f90823a8f66689315ba28fbe8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7698a6f38730fd1385d390d1ed07bb13dce39aa616aca6a6d89bea178464b9a4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:173a66f3651cdb761018078e2d9487f4cf971232c990035ec0eb1cdc6bf929a9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa7922bbb2cc84fa062d37723f199d4c0cd200245ce269c05db82d904db66b83" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:59f67cd0a0acaf0e564c20bbd7f767286f23e91e2572c5703bf3e56ea7557edb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:475e50f3f73f73614f7cba5524d6de49dee269df00272a1b85e3d19f6d498465" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a1c0c7d67b64d85ac2e1879923bad2f08a08f3004055f2f406ef73c850114bd4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:1371c2ccbb744d66ee63631cc9ca12aa233d5749972626b68fe1a649dd98e566" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59968142787042db793348a3f5b918cf24ced1f23247328530e063f89c128a95" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-win32.whl", hash = "sha256:59efe72d37fd5a91e373e5146f187f921f365f4abc1249a5ab446a60f30dd5f8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ee7337f88f2a580679f7bbfe69dc86c043954f9f9c541012f49abc554a962f2e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4f10fbd5dd13dcf4265b4cc07d69ca70280742870c97ae10093e3d66000359" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a152560af4f9742b96f3827090f866eeec5becd4765c8e0d3473d9d280e76a5a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54170b3e95339f415d54651f97df3bff7434a663912f9358237941bbf9143f55" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07f190d65f5a72dcb9cf7106bfc3d21e7a49dd2879eda2207b683f32165e4d99" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9a2741ce5a29d3c84b0b94261ba630ab459a1b847a0d6beca7d62d188175c790" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b26c30df3a28fd9793113dac7385a4deb7294a06c0f760dd2b008bd49a9139bc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:421439d1bee44b19f4583ccf42670ca464ffb90e9fdc38d37f39d1ddd1e44f1f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b40379b53ecbc747fd9bdf4a0ea14eb8188ca1bd0f54f78893a39024b28f4863" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:08c55c13d2eef54f73eeadc33146fb0baaa49e7335eb1aff6ae1324bf0ddbe4a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9776b85f510062f5a75ef112afe5f494ef1635607bf1cc220c1391e9ac2f5e81" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d" },
 ]
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "certifi" },
@@ -2765,22 +2787,22 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/requests/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/requests/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/requests/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/requests/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a" },
 ]
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rich/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rich/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rich/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rich/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb" },
 ]
 
 [[package]]
@@ -2988,41 +3010,41 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.48"
+version = "2.0.49"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48.tar.gz", hash = "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e3070c03701037aa418b55d36532ecb8f8446ed0135acb71c678dbdf12f5b6e4" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2645b7d8a738763b664a12a1542c89c940daa55196e8d73e55b169cc5c99f65f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b19151e76620a412c2ac1c6f977ab1b9fa7ad43140178345136456d5265b32ed" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5b193a7e29fd9fa56e502920dca47dffe60f97c863494946bd698c6058a55658" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:36ac4ddc3d33e852da9cb00ffb08cea62ca05c39711dc67062ca2bb1fae35fd8" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313-win32.whl", hash = "sha256:389b984139278f97757ea9b08993e7b9d1142912e046ab7d82b3fbaeb0209131" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313-win_amd64.whl", hash = "sha256:d612c976cbc2d17edfcc4c006874b764e85e990c29ce9bd411f926bbfb02b9a2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69f5bc24904d3bc3640961cddd2523e361257ef68585d6e364166dfbe8c78fae" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd08b90d211c086181caed76931ecfa2bdfc83eea3cfccdb0f82abc6c4b876cb" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1ccd42229aaac2df431562117ac7e667d702e8e44afdb6cf0e50fa3f18160f0b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f0dcbc588cd5b725162c076eb9119342f6579c7f7f55057bb7e3c6ff27e13121" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313t-win32.whl", hash = "sha256:9764014ef5e58aab76220c5664abb5d47d5bc858d9debf821e55cfdd0f128485" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp313-cp313t-win_amd64.whl", hash = "sha256:e2f35b4cccd9ed286ad62e0a3c3ac21e06c02abc60e20aa51a3e305a30f5fa79" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e2d0d88686e3d35a76f3e15a34e8c12d73fc94c1dea1cd55782e695cc14086dd" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49b7bddc1eebf011ea5ab722fdbe67a401caa34a350d278cc7733c0e88fecb1f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:426c5ca86415d9b8945c7073597e10de9644802e2ff502b8e1f11a7a2642856b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:288937433bd44e3990e7da2402fabc44a3c6c25d3704da066b85b89a85474ae0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8183dc57ae7d9edc1346e007e840a9f3d6aa7b7f165203a99e16f447150140d2" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314-win32.whl", hash = "sha256:1182437cb2d97988cfea04cf6cdc0b0bb9c74f4d56ec3d08b81e23d621a28cc6" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314-win_amd64.whl", hash = "sha256:144921da96c08feb9e2b052c5c5c1d0d151a292c6135623c6b2c041f2a45f9e0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5aee45fd2c6c0f2b9cdddf48c48535e7471e42d6fb81adfde801da0bd5b93241" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cddca31edf8b0653090cbb54562ca027c421c58ddde2c0685f49ff56a1690e0" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7a936f1bb23d370b7c8cc079d5fce4c7d18da87a33c6744e51a93b0f9e97e9b3" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e004aa9248e8cb0a5f9b96d003ca7c1c0a5da8decd1066e7b53f59eb8ce7c62b" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314t-win32.whl", hash = "sha256:b8438ec5594980d405251451c5b7ea9aa58dda38eb7ac35fb7e4c696712ee24f" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-cp314-cp314t-win_amd64.whl", hash = "sha256:d854b3970067297f3a7fbd7a4683587134aa9b3877ee15aa29eea478dc68f933" },
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sqlalchemy/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0" },
 ]
 
 [[package]]
@@ -3050,14 +3072,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.0.3"
+version = "3.4.2"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "anyio" },
+    { name = "starlette" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sse-starlette/sse_starlette-3.0.3.tar.gz", hash = "sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sse-starlette/sse_starlette-3.4.2.tar.gz", hash = "sha256:2f9a7f51ed84395a0427fb9f66cb1ec11f7899d977a72cbc9070b962a2e14489" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sse-starlette/sse_starlette-3.0.3-py3-none-any.whl", hash = "sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/sse-starlette/sse_starlette-3.4.2-py3-none-any.whl", hash = "sha256:6ea5d35b7ce979a3de5a0db5f77fe886b1616e4b3e1ad93fba502bd9b5fb662f" },
 ]
 
 [[package]]
@@ -3179,7 +3202,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.24.1"
+version = "0.23.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "annotated-doc" },
@@ -3187,9 +3210,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/typer/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/typer/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/typer/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/typer/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e" },
 ]
 
 [[package]]
@@ -3215,11 +3238,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2025.3"
+version = "2026.2"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tzdata/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tzdata/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tzdata/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tzdata/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7" },
 ]
 
 [[package]]
@@ -3254,28 +3277,28 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.35.0"
+version = "0.46.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/uvicorn/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/uvicorn/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/uvicorn/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/uvicorn/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048" },
 ]
 
 [[package]]
 name = "uvicorn-worker"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "gunicorn" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/uvicorn-worker/uvicorn_worker-0.3.0.tar.gz", hash = "sha256:6baeab7b2162ea6b9612cbe149aa670a76090ad65a267ce8e27316ed13c7de7b" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/uvicorn-worker/uvicorn_worker-0.4.0.tar.gz", hash = "sha256:8ee5306070d8f38dce124adce488c3c0b50f20cf0c0222b12c66188da7214493" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/uvicorn-worker/uvicorn_worker-0.3.0-py3-none-any.whl", hash = "sha256:ef0fe8aad27b0290a9e602a256b03f5a5da3a9e5f942414ca587b645ec77dd52" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/uvicorn-worker/uvicorn_worker-0.4.0-py3-none-any.whl", hash = "sha256:e2ed952cef976f5e9e429d7269640bbcafbd36c80aa80f1003c8c77a6797abde" },
 ]
 
 [[package]]
@@ -3321,14 +3344,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.7"
+version = "3.1.8"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/werkzeug/werkzeug-3.1.7.tar.gz", hash = "sha256:fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/werkzeug/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/werkzeug/werkzeug-3.1.7-py3-none-any.whl", hash = "sha256:4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/werkzeug/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50" },
 ]
 
 [[package]]
@@ -3419,9 +3442,9 @@ wheels = [
 
 [[package]]
 name = "zipp"
-version = "3.23.0"
+version = "3.23.1"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/zipp/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/zipp/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/zipp/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/zipp/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ dependencies = [
     { name = "db-dtypes" },
     { name = "fastapi" },
     { name = "functions-framework" },
-    { name = "google-adk" },
+    { name = "google-adk", extra = ["eval"] },
     { name = "google-cloud-aiplatform", extra = ["agent-engines"] },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-pubsub" },
@@ -50,7 +50,7 @@ requires-dist = [
     { name = "db-dtypes", specifier = ">=1.4.3,<2.0.0" },
     { name = "fastapi", specifier = ">=0.124.1" },
     { name = "functions-framework", specifier = "==3.9.2" },
-    { name = "google-adk", specifier = ">=1.27.3,<2.0.0" },
+    { name = "google-adk", extras = ["eval"], specifier = ">=1.27.3,<2.0.0" },
     { name = "google-cloud-aiplatform", extras = ["agent-engines"], specifier = ">=1.125.0,<2.0.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.36.0,<4.0.0" },
     { name = "google-cloud-pubsub", specifier = ">=2.31.1,<3.0.0" },
@@ -506,6 +506,45 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fastuuid/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.2"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/filelock/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/filelock/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70" },
+]
+
+[[package]]
 name = "flask"
 version = "3.1.3"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
@@ -596,6 +635,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.3.0"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fsspec/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/fsspec/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4" },
+]
+
+[[package]]
 name = "functions-framework"
 version = "3.9.2"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
@@ -613,6 +661,15 @@ dependencies = [
 sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/functions-framework/functions_framework-3.9.2.tar.gz", hash = "sha256:4c9a25392b74f37fff45c679f48eb70849bfa59b7c191188794ffd0d46e7bc41" }
 wheels = [
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/functions-framework/functions_framework-3.9.2-py3-none-any.whl", hash = "sha256:c3b26dff88168a7405f9ee56b2fe9c2b2cbea5c9fe4d3cacbef85089a1e22c93" },
+]
+
+[[package]]
+name = "gepa"
+version = "0.1.1"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/gepa/gepa-0.1.1.tar.gz", hash = "sha256:643fda01c23de4c9f01306e01305dd69facc29bcb34ad59e4cd07e6621d34aa1" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/gepa/gepa-0.1.1-py3-none-any.whl", hash = "sha256:71ead7c591eafcc727b83509cdc4182f20264800a6ddf8520d61419daeb47466" },
 ]
 
 [[package]]
@@ -669,6 +726,16 @@ dependencies = [
 sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.28.0.tar.gz", hash = "sha256:3c7ef1a518296641b992cc68ae4795987da48765f9788af37da1acc39db0f362" }
 wheels = [
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.28.0-py3-none-any.whl", hash = "sha256:8470c2e5a97bcef9a54283148be9f4ffaa88b3eefe3f55f269183f715d8830b6" },
+]
+
+[package.optional-dependencies]
+eval = [
+    { name = "gepa" },
+    { name = "google-cloud-aiplatform", extra = ["evaluation"] },
+    { name = "jinja2" },
+    { name = "pandas" },
+    { name = "rouge-score" },
+    { name = "tabulate" },
 ]
 
 [[package]]
@@ -745,7 +812,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.142.0"
+version = "1.143.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "docstring-parser" },
@@ -761,9 +828,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-aiplatform/google_cloud_aiplatform-1.142.0.tar.gz", hash = "sha256:87b49e002703dc14885093e9b264587db84222bef5f70f5a442d03f41beecdd1" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-aiplatform/google_cloud_aiplatform-1.143.0.tar.gz", hash = "sha256:1f0124a89795a6b473deb28724dd37d95334205df3a9c9c48d0b8d7a3d5d5cc4" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-aiplatform/google_cloud_aiplatform-1.142.0-py2.py3-none-any.whl", hash = "sha256:17c91db9b613cbbafb2c36335b123686aeb2b4b8448be5134b565ae07165a39a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-aiplatform/google_cloud_aiplatform-1.143.0-py2.py3-none-any.whl", hash = "sha256:78df97d044859f743a9cc48b89a260d33579b0d548b1589bb3ae9f4c2afc0c5a" },
 ]
 
 [package.optional-dependencies]
@@ -780,6 +847,15 @@ agent-engines = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "typing-extensions" },
+]
+evaluation = [
+    { name = "jsonschema" },
+    { name = "litellm" },
+    { name = "pandas" },
+    { name = "pyyaml" },
+    { name = "ruamel-yaml" },
+    { name = "scikit-learn" },
+    { name = "tqdm" },
 ]
 
 [[package]]
@@ -1293,6 +1369,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.4.2"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ac8202ae1e664b2c15cdfc7298cbb25e80301ae596d602ef7870099a126fcad4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6d2f8ee39fa9fba9af929f8c0d0482f8ee6e209179ad14a909b6ad78ffcb7c81" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4642a6cf249c09da8c1f87fe50b24b2a3450b235bf8adb55700b52f0ea6e2eb6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:769431385e746c92dc05492dde6f687d304584b89c33d79def8367ace06cb555" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c9dd1c1bc4cc56168f81939b0e05b4c36dd2d28c13dc1364b17af89aa0082496" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fca58a2ae4e6f6755cc971ac6fcdf777ea9284d7e540e350bb000813b9a3008d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:163aab46854ccae0ab6a786f8edecbbfbaa38fcaa0184db6feceebf7000c93c0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:09b138422ecbe50fd0c84d4da5ff537d27d487d3607183cd10e3e53f05188e82" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:949dcf88b484bb9d9276ca83f6599e4aa03d493c08fc168c124ad10b2e6f75d7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:41659966020d59eb9559c57de2cde8128b706a26a64c60f0531fa2318f409418" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c588e21d80010119458dd5d02a69093f0d115d84e3467efe71ffb2c67c19146" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a296744d771a8621ad1d50c098d7ab975d599800dae6d48528ba3944e5001ba0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f563f7efe49588b7d0629d18d36f46d1658fe7e08dce3fa3d6526e1c98315e2d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5b2e0132c56d7ee1bf55bdb638c4b62e7106f6ac74f0b786fed499d5548c5570" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:2f45c712c2fa1215713db10df6ac84b49d0e1c393465440e9cb1de73ecf7bbf6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6d53df40616f7168abfccff100d232e9d460583b9d86fa4912c24845f192f2b8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/hf-xet/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
@@ -1339,6 +1447,26 @@ source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-sta
 sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/httpx-sse/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d" }
 wheels = [
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/httpx-sse/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.8.0"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/huggingface-hub/huggingface_hub-1.8.0.tar.gz", hash = "sha256:c5627b2fd521e00caf8eff4ac965ba988ea75167fad7ee72e17f9b7183ec63f3" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/huggingface-hub/huggingface_hub-1.8.0-py3-none-any.whl", hash = "sha256:d3eb5047bd4e33c987429de6020d4810d38a5bef95b3b40df9b17346b7f353f2" },
 ]
 
 [[package]]
@@ -1393,6 +1521,66 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jiter/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/joblib/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/joblib/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
@@ -1417,6 +1605,29 @@ dependencies = [
 sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jsonschema-specifications/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d" }
 wheels = [
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/jsonschema-specifications/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.82.6"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/litellm/litellm-1.82.6.tar.gz", hash = "sha256:2aa1c2da21fe940c33613aa447119674a3ad4d2ad5eb064e4d5ce5ee42420136" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/litellm/litellm-1.82.6-py3-none-any.whl", hash = "sha256:164a3ef3e19f309e3cabc199bef3d2045212712fefdfa25fc7f75884a5b5b205" },
 ]
 
 [[package]]
@@ -1702,6 +1913,21 @@ wheels = [
 ]
 
 [[package]]
+name = "nltk"
+version = "3.9.4"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/nltk/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/nltk/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.3"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
@@ -1749,6 +1975,25 @@ wheels = [
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0" },
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b" },
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/numpy/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e" },
+]
+
+[[package]]
+name = "openai"
+version = "2.30.0"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/openai/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/openai/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d" },
 ]
 
 [[package]]
@@ -2439,6 +2684,78 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.3.32"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32.tar.gz", hash = "sha256:f1574566457161678297a116fa5d1556c5a4159d64c5ff7c760e7c564bf66f16" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c6d9c6e783b348f719b6118bb3f187b2e138e3112576c9679eb458cc8b2e164b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0f21ae18dfd15752cdd98d03cbd7a3640be826bfd58482a93f730dbd24d7b9fb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:844d88509c968dd44b30daeefac72b038b1bf31ac372d5106358ab01d393c48b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8fc918cd003ba0d066bf0003deb05a259baaaab4dc9bd4f1207bbbe64224857a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbc458a292aee57d572075f22c035fa32969cdb7987d454e3e34d45a40a0a8b4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:987cdfcfb97a249abc3601ad53c7de5c370529f1981e4c8c46793e4a1e1bfe8e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5d88fa37ba5e8a80ca8d956b9ea03805cfa460223ac94b7d4854ee5e30f3173" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d082be64e51671dd5ee1c208c92da2ddda0f2f20d8ef387e57634f7e97b6aae" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c1d7fa44aece1fa02b8927441614c96520253a5cad6a96994e3a81e060feed55" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d478a2ca902b6ef28ffc9521e5f0f728d036abe35c0b250ee8ae78cfe7c5e44e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2820d2231885e97aff0fcf230a19ebd5d2b5b8a1ba338c20deb34f16db1c7897" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc8ced733d6cd9af5e412f256a32f7c61cd2d7371280a65c689939ac4572499f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:847087abe98b3c1ebf1eb49d6ef320dbba75a83ee4f83c94704580f1df007dd4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-win32.whl", hash = "sha256:d21a07edddb3e0ca12a8b8712abc8452481c3d3db19ae87fc94e9842d005964b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-win_amd64.whl", hash = "sha256:3c054e39a9f85a3d76c62a1d50c626c5e9306964eaa675c53f61ff7ec1204bbb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313-win_arm64.whl", hash = "sha256:b2e9c2ea2e93223579308263f359eab8837dc340530b860cb59b713651889f14" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5d86e3fb08c94f084a625c8dc2132a79a3a111c8bf6e2bc59351fa61753c2f6e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b6f366a5ef66a2df4d9e68035cfe9f0eb8473cdfb922c37fac1d169b468607b0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b8fca73e16c49dd972ce3a88278dfa5b93bf91ddef332a46e9443abe21ca2f7c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b953d9d496d19786f4d46e6ba4b386c6e493e81e40f9c5392332458183b0599d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b565f25171e04d4fad950d1fa837133e3af6ea6f509d96166eed745eb0cf63bc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f28eac18a8733a124444643a66ac96fef2c0ad65f50034e0a043b90333dc677f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cdd508664430dd51b8888deb6c5b416d8de046b2e11837254378d31febe4a98" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c35d097f509cf7e40d20d5bee548d35d6049b36eb9965e8d43e4659923405b9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:85c9b0c131427470a6423baa0a9330be6fd8c3630cc3ee6fdee03360724cbec5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:e50af656c15e2723eeb7279c0837e07accc594b95ec18b86821a4d44b51b24bf" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:4bc32b4dbdb4f9f300cf9f38f8ea2ce9511a068ffaa45ac1373ee7a943f1d810" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e3e5d1802cba785210a4a800e63fcee7a228649a880f3bf7f2aadccb151a834b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ef250a3f5e93182193f5c927c5e9575b2cb14b80d03e258bc0b89cc5de076b60" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-win32.whl", hash = "sha256:9cf7036dfa2370ccc8651521fcbb40391974841119e9982fa312b552929e6c85" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-win_amd64.whl", hash = "sha256:c940e00e8d3d10932c929d4b8657c2ea47d2560f31874c3e174c0d3488e8b865" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp313-cp313t-win_arm64.whl", hash = "sha256:ace48c5e157c1e58b7de633c5e257285ce85e567ac500c833349c363b3df69d4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a416ee898ecbc5d8b283223b4cf4d560f93244f6f7615c1bd67359744b00c166" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d76d62909bfb14521c3f7cfd5b94c0c75ec94b0a11f647d2f604998962ec7b6c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:631f7d95c83f42bccfe18946a38ad27ff6b6717fb4807e60cf24860b5eb277fc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12917c6c6813ffcdfb11680a04e4d63c5532b88cf089f844721c5f41f41a63ad" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3e221b615f83b15887636fcb90ed21f1a19541366f8b7ba14ba1ad8304f4ded4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4f9ae4755fa90f1dc2d0d393d572ebc134c0fe30fcfc0ab7e67c1db15f192041" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a094e9dcafedfb9d333db5cf880304946683f43a6582bb86688f123335122929" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c1cecea3e477af105f32ef2119b8d895f297492e41d317e60d474bc4bffd62ff" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f26262900edd16272b6360014495e8d68379c6c6e95983f9b7b322dc928a1194" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1cb22fa9ee6a0acb22fc9aecce5f9995fe4d2426ed849357d499d62608fbd7f9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:9b9118a78e031a2e4709cd2fcc3028432e89b718db70073a8da574c249b5b249" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b193ed199848aa96618cd5959c1582a0bf23cd698b0b900cb0ffe81b02c8659c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:10fb2aaae1aaadf7d43c9f3c2450404253697bf8b9ce360bd5418d1d16292298" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-win32.whl", hash = "sha256:110ba4920721374d16c4c8ea7ce27b09546d43e16aea1d7f43681b5b8f80ba61" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-win_amd64.whl", hash = "sha256:245667ad430745bae6a1e41081872d25819d86fbd9e0eec485ba00d9f78ad43d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314-win_arm64.whl", hash = "sha256:1ca02ff0ef33e9d8276a1fcd6d90ff6ea055a32c9149c0050b5b67e26c6d2c51" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:51fb7e26f91f9091fd8ec6a946f99b15d3bc3667cb5ddc73dd6cb2222dd4a1cc" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:51a93452034d671b0e21b883d48ea66c5d6a05620ee16a9d3f229e828568f3f0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:03c2ebd15ff51e7b13bb3dc28dd5ac18cd39e59ebb40430b14ae1a19e833cff1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5bf2f3c2c5bd8360d335c7dcd4a9006cf1dabae063ee2558ee1b07bbc8a20d88" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a4a3189a99ecdd1c13f42513ab3fc7fa8311b38ba7596dd98537acb8cd9acc3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3c0bbfbd38506e1ea96a85da6782577f06239cb9fcf9696f1ea537c980c0680b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8aaf8ee8f34b677f90742ca089b9c83d64bdc410528767273c816a863ed57327" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ea568832eca219c2be1721afa073c1c9eb8f98a9733fdedd0a9747639fc22a5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e4c8fa46aad1a11ae2f8fcd1c90b9d55e18925829ac0d98c5bb107f93351745" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0cec365d44835b043d7b3266487797639d07d621bec9dc0ea224b00775797cc1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:09e26cad1544d856da85881ad292797289e4406338afe98163f3db9f7fac816c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:6062c4ef581a3e9e503dccf4e1b7f2d33fdc1c13ad510b287741ac73bc4c6b27" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88ebc0783907468f17fca3d7821b30f9c21865a721144eb498cb0ff99a67bcac" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-win32.whl", hash = "sha256:e480d3dac06c89bc2e0fd87524cc38c546ac8b4a38177650745e64acbbcfdeba" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-win_amd64.whl", hash = "sha256:67015a8162d413af9e3309d9a24e385816666fbf09e48e3ec43342c8536f7df6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/regex/regex-2026.3.32-cp314-cp314t-win_arm64.whl", hash = "sha256:1a6ac1ed758902e664e0d95c1ee5991aa6fb355423f378ed184c6ec47a1ec0e9" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
@@ -2452,6 +2769,31 @@ sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-p
 wheels = [
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/requests/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6" },
 ]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rich/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rich/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d" },
+]
+
+[[package]]
+name = "rouge-score"
+version = "0.1.2"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "six" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rouge-score/rouge_score-0.1.2.tar.gz", hash = "sha256:c7d4da2683e68c9abf0135ef915d63a46643666f848e558a1b9f7ead17ff0f04" }
 
 [[package]]
 name = "rpds-py"
@@ -2517,6 +2859,113 @@ wheels = [
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rpds-py/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40" },
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rpds-py/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0" },
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/rpds-py/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/ruamel-yaml/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/ruamel-yaml/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scikit-learn/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/scipy/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/shellingham/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/shellingham/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686" },
 ]
 
 [[package]]
@@ -2639,6 +3088,108 @@ source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-sta
 sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tenacity/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a" }
 wheels = [
     { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tenacity/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/threadpoolctl/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/threadpoolctl/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tiktoken/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tokenizers/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tqdm/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/tqdm/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/typer/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45" }
+wheels = [
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/typer/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.27.3"
+version = "1.28.0"
 source = { registry = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/" }
 dependencies = [
     { name = "aiosqlite" },
@@ -666,9 +666,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.27.3.tar.gz", hash = "sha256:58945d207cc8f87a5ece7610b3b209f14e254d6f45283ee9431e487fe3552db5" }
+sdist = { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.28.0.tar.gz", hash = "sha256:3c7ef1a518296641b992cc68ae4795987da48765f9788af37da1acc39db0f362" }
 wheels = [
-    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.27.3-py3-none-any.whl", hash = "sha256:1ef8f32b1a9cc393a9de2fc8700d961b4c25206a7e8631c1386fa5d8c4f9628b" },
+    { url = "https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-adk/google_adk-1.28.0-py3-none-any.whl", hash = "sha256:8470c2e5a97bcef9a54283148be9f4ffaa88b3eefe3f55f269183f715d8830b6" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `creative_eval/` package that scores ad copies and visual concepts using Gemini-as-judge with rubric-based scoring across 12 dimensions (6 per creative type)
- Standalone evaluation pipeline (`evaluate.py`) usable outside ADK, plus an ADK agent wrapper (`agent.py`) for pipeline integration
- Wired `creative_eval_agent` into `creative_agent` workflow as step 6 (after image generation, before gallery export) — evaluation report stored in session state as `creative_evaluation_report`

### Evaluation dimensions
| Ad Copy | Visual Concept |
|---------|---------------|
| Strategic alignment | Trend visual connection |
| Trend authenticity | Brand/product representation |
| Platform viability | Audience appeal |
| Copy quality | Prompt technical quality |
| Audience fit | Stopping power |
| CTA strength | Concept coherence |

### New files
- `creative_eval/{__init__, config, schemas, prompts, evaluate, agent}.py`
- `tests/test_creative_eval.py` — 18 unit tests for schemas, scoring logic, config

## Test plan
- [x] All 112 tests pass (`uv run pytest tests/ -v`)
- [x] `creative_eval_agent` appears in root_agent tool list
- [ ] Run `creative_agent` end-to-end and verify `creative_evaluation_report` in session state
- [ ] Review evaluation scores for reasonableness on real campaign data

🤖 Generated with [Claude Code](https://claude.com/claude-code)