### PR TITLE
docs: ambient-agents vs cloud-functions design note + p95 duration instrumentation

### DIFF
--- a/cloud_funktions/creative_crf/main.py
+++ b/cloud_funktions/creative_crf/main.py
@@ -36,6 +36,7 @@ import os
 os.environ["PYTHONUNBUFFERED"] = "1"
 
 import json
+import time
 import base64
 import asyncio
 import logging
@@ -236,6 +237,12 @@ async def _execute_agent_and_update_status(
 
     # --- ONLY ONE WORKER PROCEEDS PAST THIS POINT ---
 
+    # Wall-clock timer for the end-to-end agent run. Emitted as a structured log
+    # marker (AGENT_RUN_DURATION_SECS) on both the success and failure paths so we
+    # can compute p50/p95 pipeline duration from Cloud Logging — the key input to
+    # the Ambient-Agent trigger-endpoint decision (10-min ceiling). See
+    # docs/notes/ambient-agents-vs-cloud-functions.md.
+    run_start = time.monotonic()
     try:
         # 2. Run the Agent (The heavy async part)
         # The row status is now 'PROCESSING'
@@ -255,12 +262,20 @@ async def _execute_agent_and_update_status(
             timestamps=[timestamp],
             status="PROCESSED",
         )
+        logging.info(
+            f"AGENT_RUN_DURATION_SECS row={timestamp} index={trend_dict['index']} "
+            f"status=PROCESSED secs={time.monotonic() - run_start:.1f}"
+        )
         logging.info(f"Successfully processed and marked row {timestamp} as PROCESSED.")
 
     except Exception as e:
         # If the Agent Run fails, we update the status to FAILED and re-raise.
         # This keeps the FAILED status visible and ensures the worker Pub/Sub message retries
         # (if you want retries for FAILED status, otherwise just return here too).
+        logging.info(
+            f"AGENT_RUN_DURATION_SECS row={timestamp} index={trend_dict['index']} "
+            f"status=FAILED secs={time.monotonic() - run_start:.1f}"
+        )
         logging.error(f"Failed processing row {timestamp}: {e}")
 
         # 4. Update status to FAILED

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -15,3 +15,8 @@ it was written on, since some describe uncommitted working-tree state.
   separate.
 - [frontend.md](frontend.md) — React crash from nested session-state values and
   its confusing backend cascade; the same-origin proxy.
+- [ambient-agents-vs-cloud-functions.md](ambient-agents-vs-cloud-functions.md) —
+  compares our Cloud Run Functions fan-out with ADK's Ambient Agent trigger
+  endpoints; why we keep the current executor (10-min ceiling + idempotency), the
+  target event-native architecture (scheduled trawler + BQ-triggered creative,
+  with the "BQ has no per-row event" caveat), and the proposed parallel experiment.

--- a/docs/notes/ambient-agents-vs-cloud-functions.md
+++ b/docs/notes/ambient-agents-vs-cloud-functions.md
@@ -1,0 +1,222 @@
+# Event-driven execution: ADK Ambient Agents vs. our Cloud Run Functions fan-out
+
+**Date:** 2026-07-12 · **Branch:** `docs/readme-updates` (research note; no code change beyond
+the duration instrumentation described below) · **Status:** decision recorded — keep the current
+architecture as the primary executor; run a parallel Ambient-Agent experiment before committing.
+
+This note captures a comparison between our current event-driven orchestration
+(`cloud_funktions/creative_crf/`) and ADK's newer **Ambient Agent** concept
+(<https://adk.dev/runtime/ambient-agents/>), plus the target event-native
+architecture we want to move toward and the experiment that will decide it.
+
+---
+
+## TL;DR
+
+- **Conceptually**, our creative fan-out is a textbook *ambient* workload: event-triggered,
+  no human, background execution, results routed to external sinks (GCS/BigQuery).
+- **Mechanically**, ADK's preferred ambient path — **trigger endpoints**
+  (`/apps/{app}/trigger/pubsub` and `/trigger/eventarc`) — is **not a drop-in replacement**
+  today, for two reasons:
+  1. **10-minute synchronous ceiling.** Trigger endpoints hold the HTTP request open until
+     the agent finishes and are capped by the Pub/Sub push ack deadline (~10 min). Our full
+     creative pipeline runs *right around* 10 minutes and is growing. The ADK docs explicitly
+     redirect >10-min workloads to "Pub/Sub pull subscriptions, Cloud Run Jobs, or a worker
+     pool architecture" — which is essentially what we already built.
+  2. **No built-in idempotency.** Ambient trigger sessions are ephemeral and per-delivery
+     ("each redelivery creates a new session… stateless by design"). Pub/Sub is at-least-once,
+     so we'd reprocess trends (each an expensive image-gen run) without the atomic BigQuery lock
+     we rely on today.
+- **Recommendation:** keep the current CRF + Agent Engine + BigQuery-lock fan-out as the primary
+  executor. Adopt ambient concepts *selectively* (Eventarc triggering, retry defaults) and, per
+  the owner's request, **stand up a parallel Ambient-Agent Cloud Run deployment as an experiment**
+  to measure the differences before deciding.
+
+---
+
+## What we built today
+
+A two-stage Pub/Sub fan-out where **the agent runs on Vertex AI Agent Engine** and the Cloud Run
+Functions are thin orchestration glue (`cloud_funktions/creative_crf/main.py`):
+
+- **Orchestrator** (`crf_entrypoint`, concurrency=100): Eventarc→Pub/Sub-triggered
+  (`CREATIVE_TOPIC_NAME`/`CREATIVE_TRIGGER_NAME`) → queries BigQuery for `processed_status IS NULL`
+  rows → marks them `QUEUED` → publishes one worker message per row (fire-and-forget).
+- **Worker** (`agent_worker_entrypoint`, concurrency=1, timeout=900s): Pub/Sub-triggered
+  (`CREATIVE_WORKER_TOPIC_NAME`) → **atomic BigQuery lock** (`acquire_processing_lock`:
+  conditional `UPDATE … WHERE processed_status='QUEUED'`, verifying `num_dml_affected_rows == 1`)
+  → invokes Agent Engine via `async_stream_query` → marks `PROCESSED` / `FAILED`.
+
+The BigQuery status column (`NULL → QUEUED → PROCESSING → PROCESSED/FAILED`) does triple duty as
+**work queue + idempotency lock + observability surface**.
+
+> Note: `cloud_funktions/trawler_crf/main.py` is currently a `# TODO` stub — the trend_trawler
+> half of the pipeline is not yet wired for scheduled/event-driven execution. The target
+> architecture below is greenfield for that side.
+
+---
+
+## What an Ambient Agent is
+
+An ADK agent configured to activate in response to external events/data rather than human input —
+"run as background processes to process data, monitor events, and respond asynchronously." Two
+implementation approaches:
+
+- **Approach 1 — `/run` endpoint** (`adk api_server --auto_create_session`): full manual control;
+  you parse the payload, create the session, handle concurrency/retries. A Cloud Run function
+  acts as a thin webhook forwarder that POSTs to `/apps/{app}/run`. Best for non-GCP sources.
+- **Approach 2 — Trigger endpoints** (preferred for GCP): ADK owns the plumbing. Sources are
+  **Pub/Sub** (`/trigger/pubsub`) and **Eventarc** (`/trigger/eventarc`). On each event ADK
+  parses the CloudEvent/Base64 payload, creates a UUID session, runs the agent with the normalized
+  `{data, attributes}` as a user message, and returns `200` (ack) or `500` (retry).
+
+Enabled at deploy time:
+
+```
+adk deploy cloud_run \
+  --project=$GOOGLE_CLOUD_PROJECT --region=$GOOGLE_CLOUD_LOCATION \
+  --trigger_sources="pubsub,eventarc" \
+  path/to/your/agent
+```
+
+Config knobs (per-process): concurrency semaphore `ADK_TRIGGER_MAX_CONCURRENT` (default 10);
+retry `ADK_TRIGGER_MAX_RETRIES` (3) with exponential backoff + jitter
+(`ADK_TRIGGER_RETRY_BASE_DELAY`=1.0s, `ADK_TRIGGER_RETRY_MAX_DELAY`=30s).
+
+---
+
+## Compare & contrast
+
+| Dimension | Current: CRF + Agent Engine | Ambient: trigger endpoints |
+|---|---|---|
+| Event parsing | Hand-rolled Base64/CloudEvent decode (×2 entrypoints) | Automatic (Base64, CloudEvents; normalized `{data, attributes}`) |
+| Session lifecycle | Manual create/delete per run | Automatic per-event UUID session |
+| Concurrency | Pub/Sub + worker concurrency=1 + BigQuery lock | Built-in per-process semaphore + Cloud Run autoscaling |
+| Retry | Re-raise → Pub/Sub NACK/redeliver (coarse) | Built-in exp. backoff + jitter, then 500 → Pub/Sub |
+| Idempotency / dedup | **Strong** — atomic BQ lock, exactly-once-ish | **None built-in** — per-delivery sessions, stateless |
+| Max runtime | Worker timeout **900s**; CF Pub/Sub trigger extends ack deadline to the function timeout | **Synchronous, ~10-min hard ceiling** (Pub/Sub push ack) |
+| Deployment | Two CF deployments from one source ("deploy twice") | One `adk deploy cloud_run --trigger_sources=…` |
+| Agent hosting | Managed Agent Engine (scaling, sessions, tracing) | Self-hosted on Cloud Run |
+| Glue to maintain | High (orchestrator + worker + lock + parse + stream loop) | Low (ADK owns the plumbing) |
+| Eventarc / GCS/BQ-native triggers | Custom wiring | First-class |
+
+### The two decisive factors
+
+1. **10-minute ceiling.** Our pipeline (research → PDF → ad copy → visuals → eval judge) is
+   ~10 min and growing. Trigger endpoints would time out; the docs point long workloads at the
+   worker-pool/pull pattern we already have. **We must measure p95 before trusting any conclusion
+   here** (see instrumentation below).
+2. **Idempotency.** At-least-once delivery + expensive per-trend work means we can't drop the BQ
+   lock. Ambient gives us nothing here, so a naive migration would force us to re-add exactly the
+   lock we already wrote — erasing much of the "less glue" benefit.
+
+---
+
+## Recommendation
+
+**Keep the current architecture as the primary batch executor.** It is the ADK-recommended shape
+for >10-min agent work, it provides idempotency ambient lacks, and it keeps the managed Agent
+Engine runtime. Migrating the *executor* to trigger endpoints would trade a working long-run design
+for one with a timeout risk plus a re-implemented lock.
+
+**Adopt ambient concepts selectively:**
+- **Eventarc** to move toward event-native triggering (see target architecture).
+- Borrow the ambient **retry defaults** (backoff + jitter) — today we just re-raise to Pub/Sub.
+- Revisit trigger endpoints as the *executor* **only if** we decompose the pipeline into shorter
+  (<10-min) stages, each its own event-triggered short agent. That is the architecture ambient is
+  built for and would delete most of our glue. It's a larger refactor, tracked as a roadmap item.
+
+---
+
+## Q1 — Measuring pipeline duration (p95)
+
+We had no wall-clock data, which is the single biggest input to the runtime-ceiling question. Added
+lightweight, zero-schema-risk instrumentation to the worker: it times the end-to-end Agent Engine
+run and emits a structured log marker on both the success and failure paths
+(`cloud_funktions/creative_crf/main.py`, `_execute_agent_and_update_status`):
+
+```
+AGENT_RUN_DURATION_SECS row=<ts> index=<i> status=<PROCESSED|FAILED> secs=<float>
+```
+
+**Log-based p95 query** (Cloud Logging → Log Analytics / BigQuery-linked sink), once a handful of
+runs have accumulated:
+
+```sql
+-- Extract secs=… from the structured marker and compute percentiles
+SELECT
+  APPROX_QUANTILES(
+    CAST(REGEXP_EXTRACT(text_payload, r'secs=([0-9.]+)') AS FLOAT64), 100
+  )[OFFSET(50)]  AS p50_secs,
+  APPROX_QUANTILES(
+    CAST(REGEXP_EXTRACT(text_payload, r'secs=([0-9.]+)') AS FLOAT64), 100
+  )[OFFSET(95)]  AS p95_secs,
+  COUNT(*)       AS runs
+FROM `<log_sink_dataset>._AllLogs`
+WHERE text_payload LIKE 'AGENT_RUN_DURATION_SECS%';
+```
+
+**Decision rule:** if p95 is reliably **< ~8 min**, trigger endpoints become viable and worth the
+experiment below; if p95 flirts with **10+ min**, they're out for the executor and we stay put.
+**Optional upgrade:** add a `duration_secs FLOAT64` column to the trends table and write it in
+`update_rows_status` for first-class querying (deferred — it's a shared-schema change).
+
+---
+
+## Q3 — Target event-native architecture
+
+Two workflows, two trigger styles:
+
+1. **trend_trawler → scheduled.** Cloud Scheduler (cron) → Pub/Sub topic → trigger. This is the
+   natural fit and low-risk (`trawler_crf/main.py` is a stub today, so it's greenfield).
+2. **creative_agent → on new BigQuery rows.** This is the nuanced one.
+
+> **Caveat — BigQuery has no native per-row "row inserted" event.** Eventarc can trigger on BQ
+> **audit-log job-completion** events (`google.cloud.bigquery.v2.JobService.InsertJob` /
+> `jobCompleted`) — which fire when a **load or query job** writes — but **not on streaming
+> inserts**. So "run when rows are added" needs a deliberate choice:
+>
+> - **(a) Eventarc on BQ audit logs** — works only if trend rows land via a load/query job, not
+>   `insertAll` streaming; coarse (fires per job, not per row).
+> - **(b) App-level event (recommended)** — have the trawler's persistence step *also* publish a
+>   Pub/Sub message when it writes target trends to BQ. Most reliable, truly event-native, decouples
+>   from BQ's audit-log semantics, and lets the message carry the exact rows/agent_resource_id.
+> - **(c) Scheduled poll** — the current orchestrator pattern (Scheduler → orchestrator → BQ query).
+>   Simplest; not strictly event-native.
+
+**Recommendation for Q3:** trend_trawler on **(1)** Cloud Scheduler; creative_agent on **(b)**
+app-level Pub/Sub emitted at BQ-write time. Keep the BigQuery status lock regardless of trigger
+style — it's the idempotency guarantee, independent of what fires the run.
+
+---
+
+## Q2 — Parallel Ambient-Agent experiment (proposed, not yet built)
+
+Per the owner: stand up a **parallel** Ambient-Agent Cloud Run deployment alongside the existing
+CRF path so we can observe the differences on real traffic before committing. Sketch:
+
+1. Deploy `creative_agent` (or a short sub-stage of it) to Cloud Run via
+   `adk deploy cloud_run --trigger_sources="pubsub,eventarc"` — **without** decommissioning the
+   CRF path.
+2. Point a **separate** Pub/Sub push subscription (new topic, e.g. `creative-ambient-topic`) at
+   `/apps/creative_agent/trigger/pubsub`; leave the existing worker topic untouched.
+3. Mirror a *fraction* of trends to the ambient topic (shadow traffic), or drive it with a
+   dedicated test trend, so both paths process comparable work.
+4. Compare: end-to-end latency vs. the 10-min ceiling, timeout/retry behavior, cost, operational
+   surface (one deployment vs. two), idempotency gaps (does at-least-once cause dupes without our
+   lock?), and tracing/observability.
+5. Decide: promote ambient (if p95 fits and dedup is solvable cheaply), keep CRF, or adopt the
+   hybrid (Eventarc triggering into the existing worker-pool executor).
+
+**Open prerequisites to resolve before building the experiment:** (i) p95 duration data from Q1;
+(ii) confirm willingness to self-host the agent on Cloud Run for the experiment (Agent Engine is
+the current managed runtime); (iii) a dedup strategy for the ambient path (reuse the BQ lock).
+
+---
+
+## Related
+
+- `cloud_funktions/creative_crf/main.py` — the current fan-out (orchestrator + worker).
+- `docs/notes/local-testing.md` — the ~12-min UI request timeout, headless Runner, where results land.
+- GitHub issues for the two incidental bugs found while reviewing the worker (swallowed streaming
+  exception → false `PROCESSED`; unguarded `message_payload`/`df` in `crf_entrypoint`).


### PR DESCRIPTION
## Summary

Research + decision record comparing our current event-driven executor (`cloud_funktions/creative_crf/`) with ADK's newer **Ambient Agent** concept (trigger endpoints), plus the lightweight instrumentation needed to make the call with data.

## What's in here

**1. Design note — `docs/notes/ambient-agents-vs-cloud-functions.md`** (indexed in `docs/notes/README.md`)
- Side-by-side comparison of the current CRF + Agent Engine + BigQuery-lock fan-out vs. ADK ambient trigger endpoints (`/trigger/pubsub`, `/trigger/eventarc`).
- **Decision: keep the current executor** as primary. Two decisive factors:
  - **~10-min synchronous ceiling** on trigger endpoints (Pub/Sub push ack deadline) — our creative pipeline runs right around 10 min and is growing; ADK docs redirect >10-min workloads to the worker-pool/pull pattern we already have.
  - **No built-in idempotency** — at-least-once delivery + expensive per-trend work means we can't drop the atomic BQ lock.
- Adopt ambient concepts *selectively*: Eventarc triggering, retry defaults (backoff + jitter).
- **Target event-native architecture (Q3):** trend_trawler on Cloud Scheduler; creative_agent on an **app-level Pub/Sub event emitted at BQ-write time** — because **BigQuery has no native per-row event** (Eventarc only fires on BQ *job-completion* audit logs, not streaming inserts).
- **Parallel experiment (Q2):** documented a shadow-traffic plan to compare ambient vs. CRF on real traffic before committing — proposed, not built (depends on p95 data + a Cloud Run self-hosting decision).

**2. Instrumentation — `cloud_funktions/creative_crf/main.py`**
- Times the end-to-end Agent Engine run in the worker and emits a structured marker on both success and failure paths:
  ```
  AGENT_RUN_DURATION_SECS row=<ts> index=<i> status=<PROCESSED|FAILED> secs=<float>
  ```
- Log-only, **no schema change**. The design note includes the p95 query and the decision rule (p95 < ~8 min → ambient viable; 10+ → stay put).
- ⚠️ Requires committing + redeploying the worker CF to start emitting data.

## Follow-ups filed while reviewing the worker

- #45 — worker marks *failed* agent runs as `PROCESSED` (swallowed streaming exception) — data-integrity gap.
- #46 — `crf_entrypoint` can `NameError`/`UnboundLocalError` on a malformed/empty trigger message — crash-loop instead of clean skip.

## Testing

Docs-only + log-line addition. `uvx ruff check`/`format` clean on the edited file; `py_compile` passes. No behavioral change to the pipeline (instrumentation is additive logging).