### PR TITLE
docs: extract tests/ tree into tests/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ python deployment/integration_test.py --check all
 
 The `creative_agent` eval must run with `PYTHONPATH="$PWD"` and its own rubric config — see [CLAUDE.md](CLAUDE.md) for the exact invocation and per-agent details.
 
+**→ See [tests/README.md](tests/README.md)** for the full test-suite layout and what each test file covers.
+
 **CI:** GitHub Actions runs frontend tests on push/PR to `main` when `frontend/**` files change (`.github/workflows/frontend-tests.yml`).
 
 
@@ -466,27 +468,7 @@ The `creative_agent` eval must run with `PYTHONPATH="$PWD"` and its own rubric c
 │   ├── next.config.ts
 │   ├── package.json
 │   └── vitest.config.ts
-├── tests/                        # pytest suite
-│   ├── __init__.py
-│   ├── eval/                     # ADK evals (rubric-based LLM-as-judge)
-│   │   ├── creative_eval_config.json
-│   │   ├── eval_config.json
-│   │   └── evalsets/
-│   │       ├── creative_agent_evalset.json
-│   │       └── trend_scout_evalset.json
-│   ├── test_agent_common_models.py
-│   ├── test_callbacks.py
-│   ├── test_config.py
-│   ├── test_creative_eval.py
-│   ├── test_crf_entrypoint.py
-│   ├── test_crf_logic.py
-│   ├── test_crf_worker_async.py
-│   ├── test_deploy_utils.py
-│   ├── test_pipeline_structure.py
-│   ├── test_retry_config.py
-│   ├── test_schemas.py
-│   ├── test_tools.py
-│   └── test_tools_retry.py
+├── tests/                        # pytest suite + ADK evals — see tests/README.md
 ├── docs/
 │   ├── architecture/             # pipeline + CRF fan-out diagrams
 │   ├── baselines/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,64 @@
+# Tests
+
+The Python test suite for Trend Trawler. Covers Pydantic schema validation, agent
+pipeline structure, tool functions, callbacks, deployment utilities, Cloud Run Function
+logic, and ADK end-to-end evals.
+
+```bash
+# Python tests (pytest) — requires GCP credentials (module-level genai.Client)
+uv run pytest tests/ -v
+
+# ADK evals — end-to-end LLM-as-judge (real API calls, ~5 min per case)
+uv run adk eval trend_scout tests/eval/evalsets/trend_scout_evalset.json \
+  --config_file_path=tests/eval/eval_config.json --print_detailed_results
+
+# creative_agent eval — needs PYTHONPATH + its own rubric config
+PYTHONPATH="$PWD" uv run adk eval creative_agent tests/eval/evalsets/creative_agent_evalset.json \
+  --config_file_path=tests/eval/creative_eval_config.json --print_detailed_results
+```
+
+See [CLAUDE.md](../CLAUDE.md) for the full testing notes (eval invocation gotchas,
+per-agent rubric configs, integration tests).
+
+## Structure
+
+```bash
+tests/
+├── __init__.py
+├── eval/                            # ADK evals — rubric-based LLM-as-judge (real APIs)
+│   ├── eval_config.json             # trend_scout rubric config
+│   ├── creative_eval_config.json    # creative_agent rubric config
+│   └── evalsets/
+│       ├── trend_scout_evalset.json
+│       └── creative_agent_evalset.json
+├── test_agent_common_models.py      # shared model location + build_gemini() factory
+├── test_callbacks.py                # citation replacement, state init, rate limiting
+├── test_config.py                   # per-agent config resolution
+├── test_creative_eval.py            # creative_eval schemas, scoring logic, config
+├── test_crf_entrypoint.py           # crf_entrypoint orchestrator (issue #46)
+├── test_crf_logic.py                # Cloud Run Function logic (orchestrator + worker)
+├── test_crf_worker_async.py         # async worker path of the CRF (issue #45)
+├── test_deploy_utils.py             # deploy_agent.py utils (env file, extra_packages)
+├── test_pipeline_structure.py       # agent pipeline composition + configuration
+├── test_retry_config.py             # scoped RetryConfig constants on infra agents
+├── test_schemas.py                  # Pydantic schemas in the creative_agent pipeline
+├── test_tools.py                    # backend tool functions (pure logic, no I/O)
+└── test_tools_retry.py              # infra tools propagate (don't swallow) exceptions
+```
+
+## Categories
+
+- **Schemas & config** — `test_schemas.py`, `test_creative_eval.py`, `test_config.py`,
+  `test_agent_common_models.py`: Pydantic validation, model-location pinning, per-agent
+  config resolution.
+- **Pipeline & callbacks** — `test_pipeline_structure.py`, `test_callbacks.py`,
+  `test_retry_config.py`: agent composition, state init, rate limiting, citation regex,
+  scoped `RetryConfig`.
+- **Tools** — `test_tools.py`, `test_tools_retry.py`: pure tool logic, plus the contract
+  that infra tools raise (rather than swallow errors into status dicts) so ADK retry works.
+- **Deployment & fan-out** — `test_deploy_utils.py`, `test_crf_entrypoint.py`,
+  `test_crf_logic.py`, `test_crf_worker_async.py`: deploy mappings/env wiring and the
+  orchestrator + worker Cloud Run Function paths.
+- **Evals** (`eval/`) — end-to-end `adk eval` cases with rubric-based LLM-as-judge scoring
+  (response quality + tool-use quality). One evalset + rubric config per agent. Runs
+  against real APIs.


### PR DESCRIPTION
## What

Moves the detailed `tests/` directory tree out of the root `README.md` and into a dedicated **`tests/README.md`**, then collapses the `tests/` block in the root repo-structure tree to a single line:

```
├── tests/                        # pytest suite + ADK evals — see tests/README.md
```

This mirrors the existing pattern where `frontend/` and `deployment/` each own their detailed tree in a sub-README.

## Contents of the new `tests/README.md`

- Run commands (pytest + both `adk eval` invocations, incl. the `PYTHONPATH` gotcha for `creative_agent`)
- Full per-file tree: the `eval/` subtree (rubric configs + evalsets) and all 13 `test_*.py` files, each with a one-line description
- A **Categories** section grouping the files by concern (schemas & config, pipeline & callbacks, tools, deployment & fan-out, evals)

## Root README changes

- `tests/` tree block collapsed from ~24 lines to one
- Added a `→ See tests/README.md` pointer in the Testing section (same style as the Frontend/Deployment pointers)

No test or source code touched — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)