### PR TITLE
docs: CODE_STANDARDS numbering + stale-gap fix, tests/README pointers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ PYTHONPATH="$PWD" uv run adk eval creative_agent tests/eval/evalsets/creative_ag
 ```
 
 - Frontend: `frontend/src/__tests__/` — pure logic tests (SSE parsing, form validation, GCS URI building, widget layouts, trend markdown parsing, extractItems, interactive mode pause/resume)
-- Python: `tests/` — Pydantic schema validation, agent pipeline structure, tool functions, callbacks (citation regex, state init, rate limiting), deployment utilities, cloud function logic
+- Python: `tests/` — Pydantic schema validation, agent pipeline structure, tool functions, callbacks (citation regex, state init, rate limiting), deployment utilities, cloud function logic. See [tests/README.md](tests/README.md) for the per-file breakdown.
 - ADK Evals: `tests/eval/` — end-to-end agent evaluation using `adk eval` CLI with rubric-based LLM-as-judge scoring (response quality + tool use quality). Runs against real APIs. One evalset + rubric config per agent: `evalsets/trend_scout_evalset.json` + `eval_config.json`; `evalsets/creative_agent_evalset.json` + `creative_eval_config.json`. The `creative_agent` eval must be run with `PYTHONPATH="$PWD"` (see command above).
 - Integration: `deployment/integration_test.py` — live GCP checks (health, session lifecycle, smoke tests). Requires deployed agents.
 - CI: `.github/workflows/frontend-tests.yml` — runs frontend tests on push/PR to `main` when `frontend/**` changes

--- a/CODE_STANDARDS.md
+++ b/CODE_STANDARDS.md
@@ -52,7 +52,8 @@ uv run ty check src/   # or the relevant package directories
 
 ## 5. Testing
 
-- **`pytest`** is the test runner. Python tests live in `tests/`; frontend tests
+- **`pytest`** is the test runner. Python tests live in `tests/` (see
+  [tests/README.md](./tests/README.md) for the suite layout); frontend tests
   live in `frontend/src/__tests__/` (Vitest).
 - Enforce a coverage minimum where practical (`--cov`, `--cov-fail-under`).
 - `ty` type-checking is part of the test/verification loop, not a separate optional
@@ -90,12 +91,13 @@ resource, target `GCP_REGION`.
 | `requirements.txt` | `pyproject.toml` (projects) / PEP 723 (scripts) |
 | `Co-Authored-By` trailers | (never add them) |
 
-## 7. Current State / Known Gaps
+## 8. Current State / Known Gaps
 
 These reflect the repo as of writing and are follow-ups, not exceptions to the rules:
 
-- `ruff` and `ty` are **not yet** declared in `pyproject.toml` `[dependency-groups]`
-  or configured (`[tool.ruff]`, `[tool.ty]`). They should be added via
-  `uv add --group dev ruff ty` and configured before the standards above are fully
-  enforceable.
+- `ruff` and `ty` are **not yet** declared in `pyproject.toml` `[dependency-groups]`.
+  They should be added via `uv add --group dev ruff ty` before the standards above are
+  fully enforceable.
+- `ruff` is partially configured (`[tool.ruff.lint.per-file-ignores]`); `[tool.ty]` is
+  not configured yet.
 - The `dev` dependency group currently contains only `pytest`.


### PR DESCRIPTION
Follow-up to #53 (tests/README.md extraction).

## CODE_STANDARDS.md
- **Fix duplicate section number.** There were two `## 7.` headings — "Anti-Patterns to Avoid" and "Current State / Known Gaps". Renumbered the latter to `## 8.` so the doc now runs 1–8.
- **Correct a stale "Known Gaps" bullet.** It claimed `[tool.ruff]` was *"not yet configured"*, but `pyproject.toml` now has a real `[tool.ruff.lint.per-file-ignores]` block. Narrowed the note to what's actually still true: `ruff`/`ty` aren't in `[dependency-groups]`, and `[tool.ty]` isn't configured yet.
- Added a `tests/README.md` pointer to the Testing section.

## CLAUDE.md
- Added a `tests/README.md` pointer to the Python-tests bullet in the Testing section.

Docs only — no source or tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)