### PR TITLE
fix(interactive_creative): memorize target_search_trends explicitly

### DIFF
--- a/interactive_creative/agent.py
+++ b/interactive_creative/agent.py
@@ -54,7 +54,7 @@ root_agent = Agent(
 
     <INSTRUCTIONS>
     1. Receive and validate inputs. If critical inputs missing, respond with error.
-    2. Use `memorize` to store all campaign metadata into session state.
+    2. Use the `memorize` tool to store **all** the validated input campaign metadata into the corresponding session state variables: `brand`, `target_audience`, `target_product`, `key_selling_points`, and `target_search_trends`. Call `memorize` for ALL of them (in a single turn or as parallel calls).
     3. Follow the <WORKFLOW> steps strictly in order. **You MUST complete ALL 13 steps. Do NOT stop early.**
     4. **CRITICAL:** When you receive a response from a checkpoint tool (review_research, review_ad_copies, or review_visual_concepts), that response contains the user's feedback. Read the `instruction` field in the response — it tells you to continue to the next step. You MUST immediately proceed to the next WORKFLOW step after each checkpoint. NEVER treat a checkpoint response as the end of the workflow.
     </INSTRUCTIONS>

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -162,3 +162,16 @@ def test_visual_concept_finalizer_has_ad_copy_context():
 
     assert "ad_copy_critique" in visual_concept_finalizer.instruction
     assert "ad_copy_id" in visual_concept_finalizer.instruction
+
+
+def test_interactive_creative_memorizes_target_search_trends():
+    """The interactive orchestrator's memorize step must explicitly enumerate
+    target_search_trends. A vague 'store all campaign metadata' instruction lets
+    the LLM drop the trend, leaving target_search_trends empty in state (and in
+    the trend_creatives / creative_evals BigQuery rows)."""
+    from interactive_creative.agent import root_agent
+
+    instr = root_agent.instruction
+    # The memorize step must name every state key it has to persist, mirroring
+    # creative_agent, not just say "all campaign metadata".
+    assert "`key_selling_points`, and `target_search_trends`" in instr


### PR DESCRIPTION
## Problem

Running `interactive_creative` through the frontend leaves `target_search_trends` **empty** in session state, so the trend shows up blank in the persisted BigQuery rows (`trend_creatives`, and — once #55 lands — `creative_evals`). `creative_agent` does not have this problem for the same campaign input.

Observed live (interactive run, folder `2026_07_13_09_30_a57f`):
```
write_trends_to_bq → DML INSERT ... for trend: ''   ← empty
```
…while brand and product populated fine.

## Root cause

Not the frontend, and not Option 4 (#55) — this is pre-existing. The frontend sends the trend identically for both agents (`frontend/src/app/page.tsx:82`, and it's a **required** field to submit interactive). The difference is the `memorize` instruction:

- `creative_agent` (agent.py:837): *"store **all** … into … `brand`, `target_audience`, `target_product`, `key_selling_points`, and `target_search_trends`"* — enumerates every state key.
- `interactive_creative` (agent.py:57, before this fix): *"Use `memorize` to store all campaign metadata into session state."* — vague, names no keys.

Both inherit the same `load_session_state`, which defaults `target_search_trends` to `""`. With the vague instruction the LLM under-memorizes and the trend stays at that empty default.

## Fix

Make the interactive orchestrator's memorize step enumerate every key, mirroring `creative_agent`. Add a guard test asserting the memorize step names `target_search_trends` (fails against the old vague wording).

- `interactive_creative/agent.py` — explicit `memorize` enumeration
- `tests/test_pipeline_structure.py` — `test_interactive_creative_memorizes_target_search_trends`

## Verification

- `uv run pytest tests/test_pipeline_structure.py` → 12 passed (RED before the one-line fix, GREEN after)
- `uvx ruff check` / `format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)