### PR TITLE
fix: .gcloudignore excluded pyproject.toml, breaking backend Cloud Run build

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,7 +1,19 @@
-poetry.lock
-pyproject.toml
-.vscode/
-output/*
-__pycache__/
-a_stash/*
+# Source-upload filter for `gcloud run deploy --source .` (the trend-trawler-api
+# backend image). IMPORTANT: pyproject.toml + uv.lock MUST be uploaded — the root
+# Dockerfile COPYs them for `uv sync`. Everything the Python image does not need is
+# excluded to keep the upload lean (the .dockerignore further trims the build context).
+.git/
 .venv/
+__pycache__/
+*.pyc
+.env*
+.vscode/
+a_stash/*
+output/*
+outputs/
+.adk
+**/.adk/
+frontend/
+node_modules/
+tests/
+docs/


### PR DESCRIPTION
## Problem

Deploying the `trend-trawler-api` backend via `gcloud run deploy --source .` (per the runbook added in #60) failed at build time:

```
Step 4/10 : COPY pyproject.toml uv.lock ./
COPY failed: file not found in build context: stat pyproject.toml: file does not exist
```

The pre-existing root `.gcloudignore` listed `pyproject.toml` (and `poetry.lock`), so `--source` never uploaded `pyproject.toml`, and the root `Dockerfile`'s `uv sync` layer couldn't `COPY` it. The same file also didn't exclude `.adk`/`tests`/`docs`/`node_modules`, bloating the source upload to ~313MB.

## Fix

Rewrite `.gcloudignore` to:
- **Keep `pyproject.toml` + `uv.lock`** (the image needs them for `uv sync --frozen`).
- Exclude what the Python backend image doesn't need — `frontend/`, `node_modules/`, `tests/`, `docs/`, `.adk`, `outputs/`, venv/caches — keeping the upload lean.

Verified: with this change the source upload shrinks dramatically and the build proceeds past the `COPY pyproject.toml` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)