### PR TITLE
fix(frontend): retry eval-report fetch to fix results-page race

### DIFF
--- a/frontend/src/__tests__/eval-report.test.ts
+++ b/frontend/src/__tests__/eval-report.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchEvalReport } from "@/lib/eval-report";
+
+// The creative eval report is the LAST artifact the pipeline writes to GCS, so the
+// results page can load (and fetch it) a few seconds before it exists — a 404 race.
+// fetchEvalReport retries on 404 (the file is still being written) and reports a
+// distinct "pending" outcome instead of silently swallowing the miss.
+
+const noSleep = () => Promise.resolve();
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe("fetchEvalReport", () => {
+  it("returns the parsed report on a 200", async () => {
+    const report = { summary: { overall_pass_rate: 0.8 } };
+    const fetchImpl = vi.fn(async () => jsonResponse(report));
+
+    const result = await fetchEvalReport("/api/gcs?x=1", { fetchImpl, sleep: noSleep });
+
+    expect(result).toEqual({ status: "found", report });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 404 and succeeds once the report appears", async () => {
+    const report = { summary: {} };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(null, 404))
+      .mockResolvedValueOnce(jsonResponse(null, 404))
+      .mockResolvedValueOnce(jsonResponse(report, 200));
+
+    const result = await fetchEvalReport("/api/gcs?x=1", {
+      retries: 4,
+      fetchImpl,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ status: "found", report });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns 'pending' after exhausting retries on persistent 404", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(null, 404));
+
+    const result = await fetchEvalReport("/api/gcs?x=1", {
+      retries: 2,
+      fetchImpl,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ status: "pending" });
+    // initial attempt + 2 retries
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on a non-404 error and reports it", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(null, 500));
+
+    const result = await fetchEvalReport("/api/gcs?x=1", {
+      retries: 3,
+      fetchImpl,
+      sleep: noSleep,
+    });
+
+    expect(result.status).toBe("error");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a thrown network error as retryable, then pending", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    const result = await fetchEvalReport("/api/gcs?x=1", {
+      retries: 1,
+      fetchImpl,
+      sleep: noSleep,
+    });
+
+    expect(result.status).toBe("pending");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("makes exactly one attempt when retries is 0", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(null, 404));
+
+    const result = await fetchEvalReport("/api/gcs?x=1", {
+      retries: 0,
+      fetchImpl,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ status: "pending" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/results/[sessionId]/page.tsx
+++ b/frontend/src/app/results/[sessionId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, use } from "react";
+import { useEffect, useState, useCallback, use } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
@@ -13,6 +13,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { GcsWidget } from "@/components/gcs-widget";
 import { getSession, listArtifacts, getArtifact } from "@/lib/api";
+import { fetchEvalReport } from "@/lib/eval-report";
 import { formatStateValue } from "@/lib/utils";
 import type { Session } from "@/lib/types";
 
@@ -116,8 +117,35 @@ export default function ResultsPage({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [evalReport, setEvalReport] = useState<EvalReport | null>(null);
+  const [evalStatus, setEvalStatus] = useState<
+    "idle" | "loading" | "pending" | "error"
+  >("idle");
   const [stateOpen, setStateOpen] = useState(false);
   const [artifactsOpen, setArtifactsOpen] = useState(false);
+
+  // The eval report is the LAST artifact the run writes to GCS, so it can 404 if the
+  // results page opens before the run's final write lands. fetchEvalReport retries on
+  // 404 and reports "pending" so the UI can offer a refresh instead of silently
+  // showing nothing (see lib/eval-report.ts).
+  const loadEval = useCallback(async (sess: Session) => {
+    const folder = sess.state?.gcs_folder as string;
+    const subdir = sess.state?.agent_output_dir as string;
+    const bucket =
+      (sess.state?.gcs_bucket_name as string) ||
+      (sess.state?.gcs_bucket as string)?.replace(/^gs:\/\//, "") ||
+      "";
+    if (!(bucket && folder && subdir)) return;
+
+    setEvalStatus("loading");
+    const evalUrl = `/api/gcs?bucket=${encodeURIComponent(bucket)}&path=${encodeURIComponent(`${folder}/${subdir}/creative_eval_report.json`)}`;
+    const result = await fetchEvalReport<EvalReport>(evalUrl);
+    if (result.status === "found") {
+      setEvalReport(result.report);
+      setEvalStatus("idle");
+    } else {
+      setEvalStatus(result.status);
+    }
+  }, []);
 
   useEffect(() => {
     async function load() {
@@ -139,36 +167,19 @@ export default function ResultsPage({
           })
         );
         setArtifacts(loaded);
+        setLoading(false);
 
-        // Fetch eval report from GCS (optional — silently skip if missing)
-        const folder = sess.state?.gcs_folder as string;
-        const subdir = sess.state?.agent_output_dir as string;
-        const bucket =
-          (sess.state?.gcs_bucket_name as string) ||
-          (sess.state?.gcs_bucket as string)?.replace(/^gs:\/\//, "") ||
-          "";
-        if (bucket && folder && subdir) {
-          try {
-            const evalUrl = `/api/gcs?bucket=${encodeURIComponent(bucket)}&path=${encodeURIComponent(`${folder}/${subdir}/creative_eval_report.json`)}`;
-            const evalRes = await fetch(evalUrl);
-            if (evalRes.ok) {
-              const evalData = await evalRes.json();
-              setEvalReport(evalData);
-            }
-          } catch {
-            // eval report not available — skip
-          }
-        }
+        // Fetch eval report (retries on 404 for the last-written-artifact race).
+        await loadEval(sess);
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "Failed to load results"
         );
-      } finally {
         setLoading(false);
       }
     }
     load();
-  }, [appName, userId, sessionId]);
+  }, [appName, userId, sessionId, loadEval]);
 
   if (loading) {
     return (
@@ -339,6 +350,38 @@ export default function ResultsPage({
           {gcsUri && <GcsWidget uri={gcsUri} />}
         </div>
       </div>
+
+      {/* Eval still generating / failed — offer a manual refresh (race: the report
+          is the last artifact written, so it can lag the page load). */}
+      {!evalReport &&
+        (evalStatus === "loading" ||
+          evalStatus === "pending" ||
+          evalStatus === "error") && (
+          <div className="glass rounded-2xl mb-6 px-5 py-4 flex items-center justify-between gap-4 animate-fadeIn">
+            <div>
+              <h2 className="text-sm font-semibold text-foreground">
+                Creative Evaluation
+              </h2>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {evalStatus === "loading" &&
+                  "Loading evaluation report…"}
+                {evalStatus === "pending" &&
+                  "The evaluation report is still being generated — it's the final step of the run. Give it a moment, then refresh."}
+                {evalStatus === "error" &&
+                  "Couldn't load the evaluation report."}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-xs border-border bg-muted/50 hover:bg-muted shrink-0"
+              disabled={evalStatus === "loading" || !session}
+              onClick={() => session && loadEval(session)}
+            >
+              {evalStatus === "loading" ? "Loading…" : "Refresh"}
+            </Button>
+          </div>
+        )}
 
       {/* Eval summary header */}
       {evalReport && (

--- a/frontend/src/lib/eval-report.ts
+++ b/frontend/src/lib/eval-report.ts
@@ -1,0 +1,63 @@
+/**
+ * Fetches the creative evaluation report from the /api/gcs proxy.
+ *
+ * The report (`creative_eval_report.json`) is the LAST artifact the creative pipeline
+ * writes — it lands seconds after the images/PDF and after the run stream reports
+ * "completed". So the results page can mount and fetch it *before* it exists, getting
+ * a 404. Rather than swallow that miss, we retry on 404 (and on transient network
+ * errors) and surface a distinct "pending" outcome the UI can show + let the user
+ * refresh.
+ */
+export interface FetchEvalOptions {
+  /** Retries after the first attempt (default 5). Total attempts = retries + 1. */
+  retries?: number;
+  /** Base backoff between attempts in ms (default 2000). */
+  delayMs?: number;
+  /** Injectable fetch (tests). Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Injectable sleep (tests). Defaults to setTimeout-based delay. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export type EvalFetchResult<T> =
+  | { status: "found"; report: T }
+  | { status: "pending" }
+  | { status: "error"; message: string };
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export async function fetchEvalReport<T = unknown>(
+  url: string,
+  opts: FetchEvalOptions = {}
+): Promise<EvalFetchResult<T>> {
+  const {
+    retries = 5,
+    delayMs = 2000,
+    fetchImpl = fetch,
+    sleep = defaultSleep,
+  } = opts;
+
+  const attempts = retries + 1;
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const res = await fetchImpl(url);
+      if (res.ok) {
+        return { status: "found", report: (await res.json()) as T };
+      }
+      // 404 = report not written yet (race). Any other status is a real failure.
+      if (res.status !== 404) {
+        return { status: "error", message: `GCS error: ${res.status}` };
+      }
+    } catch {
+      // Transient network error — treat like a 404 and retry.
+    }
+
+    // Not the last attempt → wait, then retry.
+    if (attempt < attempts - 1) {
+      await sleep(delayMs);
+    }
+  }
+
+  return { status: "pending" };
+}


### PR DESCRIPTION
## Problem

Testing `creative_agent` from the Cloud Run deployment, the **Creative Evaluation** section never appeared on the results page — even though the eval ran successfully and the report was written to GCS + BigQuery.

Backend logs proved it's a **race**, not an eval failure:

| Time | Event |
|------|-------|
| 13:05:37 | Results page loads session (200) |
| 13:06:08 | Results page fetches images + PDF (200) |
| **13:06:19** | Backend writes `creative_eval_report.json` to GCS |
| 13:06:35 | Eval summary row inserted into `creative_evals` |

`creative_eval_report.json` is the **last** artifact the pipeline writes (images/PDF land minutes earlier). The results page fetched it **once on mount** and swallowed the resulting 404 in a bare `catch {}`, so `evalReport` stayed `null` and the eval card never rendered — while the earlier-written images/PDF showed normally.

## Fix

- **New `frontend/src/lib/eval-report.ts`** — `fetchEvalReport(url, opts)` retries on 404 (default 5 × 2s ≈ 10s, covering the measured ~11s lag) and on transient network errors, returning a typed `found` / `pending` / `error` outcome.
- **`results/[sessionId]/page.tsx`** — replaces the silent one-shot fetch with `loadEval()`, adds an `evalStatus` state and a "still being generated — **Refresh**" banner, and stops blocking the page spinner on the eval fetch (session/artifacts render immediately).

## Testing

- New `frontend/src/__tests__/eval-report.test.ts` — 6 cases (200, retry-then-succeed, exhaust→pending, non-404→error, network-error→pending, retries=0).
- `68/68` frontend tests pass · eslint clean · `npm run build` compiles (types OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)