### PR TITLE
chore(deploy): serve api_server from agents/ so /list-apps returns only the 3 agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,10 @@ RUN uv sync --frozen --no-dev
 COPY . .
 
 ENV PORT=8080
+# Serve from `agents/` (relative symlinks to the three runnable agents) rather than `.`
+# so `GET /list-apps` returns only those three instead of every top-level dir. The
+# loader only puts `agents/` on sys.path, so PYTHONPATH=/app keeps each agent's
+# cross-package imports (creative_eval, agent_common) resolvable. See agents/README.md.
+ENV PYTHONPATH=/app
 # Cloud Run sets $PORT; bind all interfaces. Same-origin frontend proxy means no CORS needed.
-CMD ["sh", "-c", "uv run adk api_server . --host 0.0.0.0 --port ${PORT}"]
+CMD ["sh", "-c", "uv run adk api_server agents --host 0.0.0.0 --port ${PORT}"]

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,29 @@
+# `agents/` — api_server serving view (do not "tidy")
+
+This directory exists **only** so the Cloud Run backend can run
+`adk api_server agents` instead of `adk api_server .`.
+
+ADK's `AgentLoader.list_agents()` returns *every* non-hidden subdirectory of the
+agents dir — not just the ones with a runnable root agent. Pointed at the repo root
+(`.`), `GET /list-apps` therefore listed `docs/`, `outputs/`, `deployment/`,
+`agent_common/`, `creative_eval/`, `tests/`, … as "apps". Pointing it at this
+directory — which holds one **relative symlink per runnable agent** — makes
+`/list-apps` return exactly the three we serve:
+
+- `trend_scout` → `../trend_scout`
+- `creative_agent` → `../creative_agent`
+- `interactive_creative` → `../interactive_creative`
+
+The real packages stay **flat at the repo root** (the layout Agent Engine's
+`extra_packages` staging depends on — see `CLAUDE.md`). These are just a view.
+
+Two things make it work, both required — see `tests/test_agents_dir.py`:
+
+1. **Relative** symlinks, so they resolve inside the container image
+   (`/app/agents/trend_scout → /app/trend_scout`).
+2. `PYTHONPATH=/app` (set in the root `Dockerfile`), so each agent's cross-package
+   imports (`from creative_eval …`, `from agent_common …`) still resolve — the loader
+   only puts `agents/` on `sys.path`, not the repo root.
+
+Do not add an `__init__.py`, `agent.py`, or `root_agent.yaml` here — a marker file
+would flip ADK into single-agent mode and break multi-agent serving.

--- a/agents/creative_agent
+++ b/agents/creative_agent
@@ -1,0 +1,1 @@
+../creative_agent

--- a/agents/interactive_creative
+++ b/agents/interactive_creative
@@ -1,0 +1,1 @@
+../interactive_creative

--- a/agents/trend_scout
+++ b/agents/trend_scout
@@ -1,0 +1,1 @@
+../trend_scout

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -370,10 +370,13 @@ diagram into real, reproducible infrastructure.
 
 ### Architecture
 
-- **Backend** — `trend-trawler-api` runs `adk api_server .`. It loads all three agent
-  packages (`trend_scout`, `creative_agent`, `interactive_creative`) and calls
-  Vertex/BigQuery/GCS in-process. It is **private** — deployed with
-  `--no-allow-unauthenticated`.
+- **Backend** — `trend-trawler-api` runs `adk api_server agents` (not `.`). It loads the
+  three runnable agent packages (`trend_scout`, `creative_agent`, `interactive_creative`)
+  and calls Vertex/BigQuery/GCS in-process. It is **private** — deployed with
+  `--no-allow-unauthenticated`. It serves from the `agents/` directory (relative symlinks
+  to the flat packages) so `GET /list-apps` returns exactly those three instead of every
+  top-level dir; the root `Dockerfile` sets `PYTHONPATH=/app` so cross-package imports
+  (`creative_eval`, `agent_common`) still resolve. See `agents/README.md`.
 - **Frontend** — `trend-trawler-web` runs the Next.js 16 standalone server
   (`output: "standalone"` → `server.js`). Its existing same-origin Route Handlers proxy
   to the backend (`/api/adk/*` → `ADK_API_BASE`) and to Cloud Storage (`/api/gcs`).

--- a/tests/test_agents_dir.py
+++ b/tests/test_agents_dir.py
@@ -1,0 +1,47 @@
+"""Tests for the `agents/` serving directory used by the Cloud Run api_server.
+
+`adk api_server .` (pointed at the repo root) lists *every* top-level directory as
+an "app" — because ADK's `AgentLoader.list_agents()` returns all non-hidden subdirs,
+not just the ones containing a runnable root agent. The deployed backend instead points
+at `agents/`, a thin directory holding one symlink per *runnable* agent, so `/list-apps`
+returns exactly the three we serve. The real packages stay flat at the repo root (the
+flat layout Agent Engine's `extra_packages` staging depends on — see CLAUDE.md); the
+symlinks are only a serving view.
+
+These tests guard that view: exactly the three expected agents, symlinks that resolve to
+the sibling flat packages, and no `agent.py`/`root_agent.yaml` in `agents/` itself (which
+would flip ADK into single-agent mode).
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+AGENTS_DIR = REPO_ROOT / "agents"
+EXPECTED_AGENTS = {"trend_scout", "creative_agent", "interactive_creative"}
+
+
+def test_agents_dir_lists_exactly_the_runnable_agents():
+    from google.adk.cli.utils.agent_loader import AgentLoader
+
+    loader = AgentLoader(str(AGENTS_DIR))
+    assert not loader.is_single_agent, "agents/ must stay in multi-agent mode"
+    assert set(loader.list_agents()) == EXPECTED_AGENTS
+
+
+def test_agents_dir_entries_are_symlinks_to_flat_packages():
+    for name in EXPECTED_AGENTS:
+        entry = AGENTS_DIR / name
+        assert entry.is_symlink(), f"agents/{name} should be a symlink"
+        # Relative symlink → sibling package at the repo root (portable into the container).
+        assert not Path.readlink(entry).is_absolute(), (
+            f"agents/{name} must use a relative symlink so it resolves inside the image"
+        )
+        target = entry.resolve()
+        assert target == (REPO_ROOT / name).resolve()
+        assert (target / "agent.py").is_file() or (target / "__init__.py").is_file()
+
+
+def test_agents_dir_has_no_agent_marker_files():
+    # A bare agent.py / root_agent.yaml in agents/ would put ADK in single-agent mode.
+    assert not (AGENTS_DIR / "agent.py").exists()
+    assert not (AGENTS_DIR / "root_agent.yaml").exists()


### PR DESCRIPTION
## What

The Cloud Run backend runs `adk api_server` pointed at the repo root (`.`), which made `GET /list-apps` return **every** top-level directory as an "app" — `docs/`, `outputs/`, `deployment/`, `tests/`, `agent_common/`, `creative_eval/`, … not just the three runnable agents.

Root cause: ADK's `AgentLoader.list_agents()` returns all non-hidden subdirs of the agents dir (`os.listdir` + `isdir`, with no agent-marker check).

## Fix

Serve from a new `agents/` directory holding **relative symlinks** to the three runnable agents (`trend_scout`, `creative_agent`, `interactive_creative`) and run `adk api_server agents`. `/list-apps` now returns exactly those three.

The real packages stay **flat at the repo root** (the layout Agent Engine's `extra_packages` staging depends on — see `CLAUDE.md`); `agents/` is only a serving view.

**One gotcha, proven out and handled:** the loader only puts `agents/` on `sys.path`, so each agent's cross-package imports (`from creative_eval …`, `from agent_common …`) fail with `ModuleNotFoundError`. The root `Dockerfile` now sets `ENV PYTHONPATH=/app` so the repo root is importable too.

## Changes

- `agents/` — 3 relative symlinks + `README.md` (explains why, warns not to "tidy" it)
- `Dockerfile` — `ENV PYTHONPATH=/app` + `CMD … adk api_server agents …`
- `tests/test_agents_dir.py` — guard: exactly the 3 apps, relative symlinks resolving to the flat packages, no `agent.py`/`root_agent.yaml` marker in `agents/`
- `deployment/README.md` — backend now serves from `agents/`

## Verification

- New test RED → GREEN
- Full Python suite: **185 passed**; `ruff check`/`format` clean
- Real `adk api_server agents` → `/list-apps` = `["creative_agent","interactive_creative","trend_scout"]`
- Symlinks tracked with git mode `120000` (survive checkout + Docker `COPY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)