### PR TITLE
feat: IAP-gate frontend + persistent Agent Engine sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Key ADK patterns used: `Agent`, `SequentialAgent`, `ParallelAgent`, `AgentTool` 
 
 Next.js 16 (App Router) + TypeScript + Tailwind CSS + shadcn/ui. Light theme with Sora font. Consumes the ADK `api_server` REST + SSE endpoints at `localhost:8000`.
 
-**Deployment:** the frontend now ships to Cloud Run as two services — `trend-trawler-web` (Next.js standalone) and `trend-trawler-api` (running `adk api_server`). The backend is private; the same-origin `/api/adk` proxy reaches it with a metadata-server ID token (`roles/run.invoker`). Runbook: [deployment/README.md → Frontend + api_server on Cloud Run](deployment/README.md#frontend--api_server-on-cloud-run).
+**Deployment:** the frontend now ships to Cloud Run as two services — `trend-trawler-web` (Next.js standalone) and `trend-trawler-api` (running `adk api_server`). The backend is private; the same-origin `/api/adk` proxy reaches it with a metadata-server ID token (`roles/run.invoker`). The frontend is **IAP-gated** (domain-restricted to `jordantotten.altostrat.com` via Cloud Run direct IAP), and the backend uses **persistent Agent Engine sessions** via `SESSION_SERVICE_URI` (a dedicated `trend-trawler-sessions` Reasoning Engine; entrypoint `deployment/backend_entrypoint.sh`). Runbook: [deployment/README.md → Frontend + api_server on Cloud Run](deployment/README.md#frontend--api_server-on-cloud-run).
 
 **Pages:**
 - `/` — Campaign input form (brand, audience, product, selling points, agent selector: `trend_scout`, `creative_agent`, `interactive_creative`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ ENV PORT=8080
 # cross-package imports (creative_eval, agent_common) resolvable. See agents/README.md.
 ENV PYTHONPATH=/app
 # Cloud Run sets $PORT; bind all interfaces. Same-origin frontend proxy means no CORS needed.
-CMD ["sh", "-c", "uv run adk api_server agents --host 0.0.0.0 --port ${PORT}"]
+# The entrypoint appends --session_service_uri only when SESSION_SERVICE_URI is set
+# (opt-in persistent Agent Engine sessions). See deployment/backend_entrypoint.sh.
+CMD ["sh", "deployment/backend_entrypoint.sh"]

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -537,14 +537,78 @@ curl -sS -o /dev/null -w "%{http_code}" \
 The frontend's `ADK_API_BASE` wiring is documented in
 [`frontend/.env.example`](../frontend/.env.example).
 
-### Deliberate gaps (follow-ups)
+### 6. Persistent sessions (Agent Engine)
 
-- **Frontend exposure:** the MVP is `--allow-unauthenticated`. Front it with **IAP** for
-  any non-demo use — the one deliberate gap left open.
-- **api_server statefulness:** default in-memory sessions mean a run must hit the same
-  instance for its lifetime. Fine at `min-instances 0` / low traffic; if scaled out, add
-  `--session_service_uri` (a database / Agent Engine session backend) for instance
-  affinity.
+By default the backend uses **in-memory** ADK sessions, so a run must stay on the same
+warm instance — a cold start or scale-out drops in-flight state. The backend now reads an
+optional `SESSION_SERVICE_URI`; when set, the container appends
+`--session_service_uri <uri>` to `adk api_server agents`
+(see [`deployment/backend_entrypoint.sh`](backend_entrypoint.sh), wired as the
+`Dockerfile` `CMD`). When unset, behaviour is unchanged (in-memory).
+
+We back sessions with a **dedicated** Agent Engine (Reasoning Engine) that serves no
+agent — its only job is to be the session store, so its lifetime is decoupled from any
+served-agent deploy. Create (or reuse) it with:
+
+```bash
+uv run python deployment/create_session_engine.py
+# prints: SESSION_SERVICE_URI=agentengine://projects/<num>/locations/us-central1/reasoningEngines/<id>
+```
+
+The URI is **fully qualified** on purpose: it encodes project + `us-central1`, so the
+session store pins to the region while models stay pinned to `global`
+(`GOOGLE_CLOUD_LOCATION` stays **unset** — verified: the client does not require it). The
+backend SA (`tt-api-sa`) needs `roles/aiplatform.user` (already granted in Step 1).
+
+Deploy the backend with the store (a plain redeploy of the already-private service — no
+auth change):
+
+```bash
+gcloud run deploy trend-trawler-api --source . --region $REGION \
+  --update-env-vars "SESSION_SERVICE_URI=agentengine://projects/$PROJECT_NUMBER/locations/$REGION/reasoningEngines/<id>"
+```
+
+Verify: POST a session with `{"state":{"brand":"X"}}`, restart / redeploy, then GET the
+same id — it returns the state (in-memory would `404`). Backend stays `403` unauth.
+
+### 7. IAP on the frontend (domain-restricted)
+
+The frontend is fronted by **Identity-Aware Proxy** directly on the Cloud Run service
+(GA — no manual load balancer / serverless NEG), so only signed-in
+`jordantotten.altostrat.com` users reach it. **No frontend code change**: IAP
+authenticates the user at the edge *before* requests reach the container; the same-origin
+`/api/adk` + `/api/gcs` handlers keep using the container SA to reach the private backend
+and GCS.
+
+```bash
+gcloud services enable iap.googleapis.com
+
+# Enable IAP on the web service (also provisions the IAP service agent).
+# NB: `--allow-unauthenticated` is a deploy-only flag; on `update` the public/private
+# switch is the allUsers IAM binding, removed below.
+gcloud run services update trend-trawler-web --region $REGION --iap
+
+# Let IAP invoke the (now private) service:
+gcloud run services add-iam-policy-binding trend-trawler-web --region $REGION \
+  --member="serviceAccount:service-$PROJECT_NUMBER@gcp-sa-iap.iam.gserviceaccount.com" \
+  --role="roles/run.invoker"
+
+# Grant the whole domain the IAP accessor role — this is on the IAP resource
+# (`gcloud iap web`, resource-type cloud-run), NOT `run services`:
+gcloud iap web add-iam-policy-binding --resource-type=cloud-run \
+  --service=trend-trawler-web --region=$REGION \
+  --member="domain:jordantotten.altostrat.com" --role="roles/iap.httpsResourceAccessor"
+
+# Remove public access — this is what makes it private:
+gcloud run services remove-iam-policy-binding trend-trawler-web --region $REGION \
+  --member="allUsers" --role="roles/run.invoker"
+```
+
+Verify: `curl -sI $WEB_URL/` returns **`HTTP/2 302`** to `accounts.google.com`
+(`x-goog-iap-generated-response: true`), not `200`. A `jordantotten.altostrat.com` user
+loads the app in a browser, a run streams via SSE, and an artifact loads via `/api/gcs`.
+Never re-add `allUsers`; add non-domain viewers individually with
+`roles/iap.httpsResourceAccessor`.
 
 ---
 

--- a/deployment/backend_entrypoint.sh
+++ b/deployment/backend_entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Container entrypoint for the trend-trawler-api Cloud Run backend.
+# Runs `adk api_server agents` and appends --session_service_uri ONLY when
+# SESSION_SERVICE_URI is set and non-empty (opt-in persistent sessions).
+# Set ADK_DRYRUN=1 to print the argv instead of exec'ing (used by tests).
+set -eu
+
+set -- adk api_server agents --host 0.0.0.0 --port "${PORT:-8080}"
+
+if [ -n "${SESSION_SERVICE_URI:-}" ]; then
+  set -- "$@" --session_service_uri "${SESSION_SERVICE_URI}"
+fi
+
+if [ -n "${ADK_DRYRUN:-}" ]; then
+  echo "$@"
+  exit 0
+fi
+
+exec uv run "$@"

--- a/deployment/create_session_engine.py
+++ b/deployment/create_session_engine.py
@@ -1,0 +1,64 @@
+"""Create (or reuse) the dedicated Agent Engine that backs persistent ADK sessions.
+
+The Cloud Run backend runs `adk api_server agents --session_service_uri
+agentengine://<resource>`, which builds a `VertexAiSessionService`. That service
+stores sessions *inside* a Reasoning Engine (Agent Engine). We give it a
+**dedicated** engine — `trend-trawler-sessions` — that serves no agent, so the
+session store's lifetime is decoupled from any served-agent deploy.
+
+The engine is created with no `agent_engine` payload (the SDK allows a bare
+container) in `us-central1`, which pins the session store to the region while the
+gemini-3.x models stay pinned to `global` in code. The printed, fully-qualified
+resource name is what ships as `SESSION_SERVICE_URI=agentengine://<resource>`.
+
+Idempotent: reuses an existing engine with the same display name if one exists.
+
+Usage:
+    uv run python deployment/create_session_engine.py
+"""
+
+from __future__ import annotations
+
+import vertexai
+from vertexai import agent_engines
+
+PROJECT = "hybrid-vertex"
+# Agent Engine / Reasoning Engine is a regional resource; keep the session store
+# in us-central1 alongside BigQuery/GCS. Models remain pinned to `global` in code
+# (agent_common), so GOOGLE_CLOUD_LOCATION stays unset — see CLAUDE.md.
+LOCATION = "us-central1"
+DISPLAY_NAME = "trend-trawler-sessions"
+
+
+def _resource_name(engine: object) -> str:
+    """Best-effort fully-qualified resource name across SDK versions."""
+    name = getattr(engine, "resource_name", None)
+    if name:
+        return name
+    gca = getattr(engine, "gca_resource", None)
+    if gca is not None and getattr(gca, "name", None):
+        return gca.name
+    raise RuntimeError(f"Could not determine resource name for {engine!r}")
+
+
+def main() -> None:
+    vertexai.init(project=PROJECT, location=LOCATION)
+
+    for existing in agent_engines.list():
+        if getattr(existing, "display_name", None) == DISPLAY_NAME:
+            name = _resource_name(existing)
+            print(f"Reusing existing session engine: {name}")
+            print(f"SESSION_SERVICE_URI=agentengine://{name}")
+            return
+
+    engine = agent_engines.create(
+        display_name=DISPLAY_NAME,
+        description="Dedicated Agent Engine backing persistent ADK api_server sessions.",
+    )
+    name = _resource_name(engine)
+    print(f"Created session engine: {name}")
+    print(f"SESSION_SERVICE_URI=agentengine://{name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/plans/2026-07-13-frontend-iap-and-persistent-sessions.md
+++ b/docs/plans/2026-07-13-frontend-iap-and-persistent-sessions.md
@@ -1,0 +1,532 @@
+# Frontend IAP + Persistent Agent-Engine Sessions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close the two remaining Cloud Run follow-ups: (1) put **Identity-Aware Proxy**
+in front of the public `trend-trawler-web` frontend so only org users can reach it, and
+(2) give the `trend-trawler-api` backend a **persistent, multi-instance session store**
+(Vertex AI Agent Engine sessions) so runs survive instance restarts / scale-out.
+
+**Architecture:** Two independent, sequenced workstreams against the existing two-service
+Cloud Run deployment (project `hybrid-vertex`, `us-central1`). **Sessions first** (mostly
+code/config, locally verifiable, low blast radius), **IAP second** (infra/IAM, changes who
+can reach the app). Sessions use ADK's `--session_service_uri=agentengine://…` with a
+**fully-qualified** resource name so the store is pinned to `us-central1` while models stay
+pinned to `global` (`GOOGLE_CLOUD_LOCATION` remains unset). IAP is enabled **directly on the
+Cloud Run service** via `gcloud run … --iap` (GA) — no manual load balancer / serverless NEG.
+
+**Tech Stack:** ADK `api_server` (`VertexAiSessionService`, already installed — **no new
+Python deps**), Vertex AI Agent Engine (Reasoning Engine) sessions API, Cloud Run direct
+IAP, gcloud, pytest, a small POSIX entrypoint script.
+
+---
+
+## Locked decisions (confirmed with the user)
+
+1. **Session backend = Agent Engine sessions** (`agentengine://`), not Cloud SQL. Uses
+   `VertexAiSessionService` (already importable — verified), so **zero new deps / no Cloud
+   SQL / Secret Manager / VPC**. A **dedicated** Reasoning Engine (`trend-trawler-sessions`)
+   is created to be the session container so the store's lifetime is decoupled from any
+   served-agent deploy.
+2. **IAP access = whole domain** — grant `roles/iap.httpsResourceAccessor` ("IAP-secured Web
+   App User") to `domain:altostrat.com`.
+3. **IAP method = direct on Cloud Run** (`gcloud run services update trend-trawler-web
+   --iap --no-allow-unauthenticated`). The project is under org `595744329948` and an OAuth
+   brand already exists (`projects/934903580331/brands/934903580331`), so no console-only
+   first-run setup is required.
+
+## Environment facts (already gathered — don't re-derive)
+
+- Project: `hybrid-vertex`, number **`934903580331`**, org `595744329948`.
+- Region (regional resources): `us-central1`. Models pinned to `global` in code
+  (`agent_common`); `GOOGLE_CLOUD_LOCATION` intentionally **unset** — keep it that way.
+- Frontend: `trend-trawler-web` (SA `tt-web-sa@hybrid-vertex.iam.gserviceaccount.com`),
+  currently `--allow-unauthenticated`, ingress `all`, URL
+  `https://trend-trawler-web-qqzji3hyoa-uc.a.run.app`.
+- Backend: `trend-trawler-api` (SA `tt-api-sa@hybrid-vertex.iam.gserviceaccount.com`),
+  private (`--no-allow-unauthenticated`), current revision `trend-trawler-api-00002-qxl`,
+  runs `adk api_server agents` (see `agents/README.md`), URL
+  `https://trend-trawler-api-qqzji3hyoa-uc.a.run.app`.
+- IAP service agent (created on first IAP API use):
+  `service-934903580331@gcp-sa-iap.iam.gserviceaccount.com`.
+- Backend build/deploy: `gcloud run deploy trend-trawler-api --source . --region us-central1`
+  from the repo root (the root `Dockerfile` bakes the CMD).
+
+## Auto-mode guardrails (who runs what)
+
+The Claude Code auto-mode classifier **blocks** and the **user must run via the `!` prefix**:
+- **Project- or service-level IAM grants** (`add-iam-policy-binding` for the IAP SA, the
+  domain grant, `roles/aiplatform.user` on `tt-api-sa`).
+- **Auth-surface changes** (`--iap`, `--no-allow-unauthenticated`, removing `allUsers`).
+
+Claude **may** run: all read-only `gcloud … describe/list`, `gcloud services enable`,
+creating the session Reasoning Engine (an SDK create, not an IAM/auth change), a plain
+`gcloud run deploy --source` **redeploy of the already-private backend** (no auth flag
+change), pytest/ruff/local smokes, git.
+
+For each user-run step, Claude prepares the exact command block, the user pastes it behind
+`!`, and Claude verifies the result with a read-only check.
+
+---
+
+# Workstream A — Persistent Agent-Engine sessions (do first)
+
+**Why first:** it's mostly local code + a private-backend redeploy (no auth change), fully
+verifiable before touching who-can-reach-what.
+
+**Design note (the one real risk):** ADK parses `agentengine://<x>` and builds
+`VertexAiSessionService`. Passing the **fully-qualified** resource name
+`agentengine://projects/934903580331/locations/us-central1/reasoningEngines/<ID>` encodes
+project+location, so it does **not** depend on `GOOGLE_CLOUD_LOCATION` (which stays unset for
+`global` models). Task A4 verifies this locally before any deploy; if the client still
+demands `GOOGLE_CLOUD_LOCATION`, the fallback is documented there.
+
+---
+
+### Task A1: Backend entrypoint that conditionally adds `--session_service_uri`
+
+The Dockerfile CMD currently hardcodes `adk api_server agents …`. We want the session URI to
+be **opt-in via an env var** (so local `adk web`/tests are unaffected, and the URI is a plain
+config value with no secret). A tiny POSIX script appends `--session_service_uri` only when
+`SESSION_SERVICE_URI` is set and non-empty. TDD it by running the script in a dry-run mode
+that prints the command instead of exec'ing.
+
+**Files:**
+- Create: `deployment/backend_entrypoint.sh`
+- Test: `tests/test_backend_entrypoint.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/test_backend_entrypoint.py
+"""The backend container entrypoint appends --session_service_uri only when set.
+
+Keeps the session store opt-in (local `adk web` / CI unaffected) and out of the
+Dockerfile CMD literal. ADK_DRYRUN=1 makes the script print the argv it would exec.
+"""
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "deployment" / "backend_entrypoint.sh"
+
+
+def _run(env_extra):
+    env = {"PATH": "/usr/bin:/bin", "PORT": "8080", "ADK_DRYRUN": "1", **env_extra}
+    out = subprocess.run(
+        ["sh", str(SCRIPT)], capture_output=True, text=True, env=env, check=True
+    )
+    return out.stdout.strip()
+
+def test_no_session_uri_omits_flag():
+    cmd = _run({})
+    assert "adk api_server agents" in cmd
+    assert "--host 0.0.0.0" in cmd
+    assert "--port 8080" in cmd
+    assert "--session_service_uri" not in cmd
+
+def test_empty_session_uri_omits_flag():
+    assert "--session_service_uri" not in _run({"SESSION_SERVICE_URI": ""})
+
+def test_session_uri_present_appends_flag():
+    uri = "agentengine://projects/934903580331/locations/us-central1/reasoningEngines/123"
+    cmd = _run({"SESSION_SERVICE_URI": uri})
+    assert f"--session_service_uri {uri}" in cmd
+```
+
+**Step 2: Run it — expect FAIL**
+
+Run: `export PATH="$HOME/.local/bin:$PATH" && uv run pytest tests/test_backend_entrypoint.py -q`
+Expected: FAIL (`backend_entrypoint.sh` does not exist).
+
+**Step 3: Write the script**
+
+```sh
+#!/bin/sh
+# Container entrypoint for the trend-trawler-api Cloud Run backend.
+# Runs `adk api_server agents` and appends --session_service_uri ONLY when
+# SESSION_SERVICE_URI is set and non-empty (opt-in persistent sessions).
+# Set ADK_DRYRUN=1 to print the argv instead of exec'ing (used by tests).
+set -eu
+
+set -- adk api_server agents --host 0.0.0.0 --port "${PORT:-8080}"
+
+if [ -n "${SESSION_SERVICE_URI:-}" ]; then
+  set -- "$@" --session_service_uri "${SESSION_SERVICE_URI}"
+fi
+
+if [ -n "${ADK_DRYRUN:-}" ]; then
+  echo "$@"
+  exit 0
+fi
+
+exec uv run "$@"
+```
+
+**Step 4: Run the test — expect PASS**
+
+Run: `export PATH="$HOME/.local/bin:$PATH" && uv run pytest tests/test_backend_entrypoint.py -q`
+Expected: PASS (3 passed).
+
+**Step 5: Lint + commit**
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+chmod +x deployment/backend_entrypoint.sh
+uvx ruff check tests/test_backend_entrypoint.py && uvx ruff format tests/test_backend_entrypoint.py
+git add deployment/backend_entrypoint.sh tests/test_backend_entrypoint.py
+git commit -m "feat(deploy): opt-in backend entrypoint for --session_service_uri"
+```
+
+---
+
+### Task A2: Wire the entrypoint into the Dockerfile
+
+**Files:**
+- Modify: `Dockerfile` (replace the CMD line)
+
+**Step 1:** Replace the final CMD block. Current:
+
+```dockerfile
+# Cloud Run sets $PORT; bind all interfaces. Same-origin frontend proxy means no CORS needed.
+CMD ["sh", "-c", "uv run adk api_server agents --host 0.0.0.0 --port ${PORT}"]
+```
+
+New:
+
+```dockerfile
+# Cloud Run sets $PORT; bind all interfaces. Same-origin frontend proxy means no CORS
+# needed. The entrypoint appends --session_service_uri when SESSION_SERVICE_URI is set
+# (persistent Agent Engine sessions); otherwise it runs the default in-memory store.
+CMD ["sh", "deployment/backend_entrypoint.sh"]
+```
+
+> `WORKDIR /app` + `COPY . .` means `deployment/backend_entrypoint.sh` is present at
+> `/app/deployment/backend_entrypoint.sh`; `PYTHONPATH=/app` is already set above.
+
+**Step 2: Local smoke (no network needed)**
+
+Run:
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+ADK_DRYRUN=1 PORT=8080 sh deployment/backend_entrypoint.sh
+ADK_DRYRUN=1 PORT=8080 SESSION_SERVICE_URI="agentengine://proj/x" sh deployment/backend_entrypoint.sh
+```
+Expected: first prints without `--session_service_uri`; second ends with
+`--session_service_uri agentengine://proj/x`.
+
+**Step 3: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "feat(deploy): backend runs via entrypoint (session-uri aware)"
+```
+
+---
+
+### Task A3: Create the dedicated session Reasoning Engine + grant the backend SA
+
+The `agentengine://` store needs a Reasoning Engine resource to namespace sessions. Create a
+dedicated, minimal one so its lifetime is independent of served-agent deploys.
+
+**Files:**
+- Create: `deployment/create_session_engine.py`
+
+**Step 1: Write the creator script** (uses the already-installed `vertexai` SDK)
+
+```python
+# deployment/create_session_engine.py
+"""Create (once) a dedicated Vertex AI Agent Engine to act as the ADK session store.
+
+Prints the fully-qualified resource name to use as:
+  SESSION_SERVICE_URI=agentengine://<resource_name>
+Region is us-central1 (regional resource); models stay pinned to `global` elsewhere.
+Idempotency: re-running creates another engine — list first and reuse if one named
+`trend-trawler-sessions` already exists.
+"""
+import vertexai
+from vertexai import agent_engines
+
+PROJECT = "hybrid-vertex"
+REGION = "us-central1"
+NAME = "trend-trawler-sessions"
+
+def main() -> None:
+    vertexai.init(project=PROJECT, location=REGION)
+    for e in agent_engines.list():
+        if getattr(e, "display_name", None) == NAME:
+            print(f"REUSING {e.resource_name}")
+            return
+    created = agent_engines.create(display_name=NAME)
+    print(f"CREATED {created.resource_name}")
+
+if __name__ == "__main__":
+    main()
+```
+
+> `agent_engines.create(display_name=...)` provisions an empty Agent Engine — enough to host
+> the Sessions API. If the installed SDK requires a positional agent arg, pass a trivial
+> object per the version's signature; verify with `uv run python -c "from vertexai import
+> agent_engines; help(agent_engines.create)"` first.
+
+**Step 2: Create it** (Claude may run — SDK create, not IAM/auth)
+
+Run: `export PATH="$HOME/.local/bin:$PATH" && uv run python deployment/create_session_engine.py`
+Expected: prints `CREATED projects/934903580331/locations/us-central1/reasoningEngines/<ID>`
+(or `REUSING …`). **Record the resource name** — call it `<SESSION_ENGINE>`.
+
+**Step 3 (USER-run — service-level IAM grant):** the backend SA must call the Vertex AI
+sessions API. Prepare for the user to paste behind `!`:
+
+```bash
+gcloud projects add-iam-policy-binding hybrid-vertex \
+  --member="serviceAccount:tt-api-sa@hybrid-vertex.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.user"
+```
+
+**Step 4: Verify the grant** (Claude, read-only)
+
+Run:
+```bash
+gcloud projects get-iam-policy hybrid-vertex \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:tt-api-sa@hybrid-vertex.iam.gserviceaccount.com" \
+  --format="table(bindings.role)"
+```
+Expected: includes `roles/aiplatform.user`.
+
+**Step 5: Commit the script**
+
+```bash
+git add deployment/create_session_engine.py
+git commit -m "feat(deploy): script to create dedicated Agent Engine session store"
+```
+
+---
+
+### Task A4: Local integration verify — sessions persist across a restart
+
+Prove the URI works and survives a process restart **before** deploying.
+
+**Step 1: Start api_server locally with the persistent store**
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+export SESSION_SERVICE_URI="agentengine://<SESSION_ENGINE>"   # fully-qualified name
+PYTHONPATH="$PWD" uv run adk api_server agents \
+  --session_service_uri "$SESSION_SERVICE_URI" --host 127.0.0.1 --port 8811
+```
+Expected: `Application startup complete` with no session-service import/location error.
+(If it errors demanding `GOOGLE_CLOUD_LOCATION`: the fully-qualified name *should* prevent
+this; if not, that is the finding to resolve here — do NOT globally set
+`GOOGLE_CLOUD_LOCATION` as it breaks `global` models. Prefer passing project/location through
+the resource name; capture the exact error for a targeted fix.)
+
+**Step 2: Create a session, then restart the server, then GET it back**
+
+```bash
+# create
+curl -s -X POST http://127.0.0.1:8811/apps/trend_scout/users/plan_test/sessions \
+  -H 'Content-Type: application/json' -d '{"state":{"brand":"ACME"}}' | tee /tmp/sess.json
+SID=$(python -c "import json;print(json.load(open('/tmp/sess.json'))['id'])")
+# kill the server (Ctrl-C / kill), start it again with the same SESSION_SERVICE_URI, then:
+curl -s http://127.0.0.1:8811/apps/trend_scout/users/plan_test/sessions/$SID
+```
+Expected: after restart the GET returns the same session id + `state.brand == "ACME"`
+(proves persistence — the default in-memory store would 404 here).
+
+**Step 3:** No code change if it passes — this is a verification gate. Note the result in the
+PR description. (No commit.)
+
+---
+
+### Task A5: Deploy backend with the session store + verify live
+
+**Step 1 (Claude may run — private backend redeploy, no auth change):**
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+gcloud run services update trend-trawler-api --region us-central1 \
+  --update-env-vars "SESSION_SERVICE_URI=agentengine://<SESSION_ENGINE>"
+```
+(Or fold `--update-env-vars` into a `gcloud run deploy --source .` from the branch. Using
+`services update` avoids a rebuild when only the env var changes — but the CMD change from
+Task A2 needs a **build**, so if A2 isn't live yet, use `gcloud run deploy --source .
+--update-env-vars SESSION_SERVICE_URI=…`.)
+
+**Step 2: Verify live persistence across instances** (Claude, authed)
+
+```bash
+URL="https://trend-trawler-api-qqzji3hyoa-uc.a.run.app"
+TOK=$(gcloud auth print-identity-token)
+# create
+curl -s -X POST "$URL/apps/trend_scout/users/live_test/sessions" \
+  -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d '{"state":{"brand":"ACME"}}' | tee /tmp/live.json
+SID=$(python -c "import json;print(json.load(open('/tmp/live.json'))['id'])")
+# read back
+curl -s -H "Authorization: Bearer $TOK" \
+  "$URL/apps/trend_scout/users/live_test/sessions/$SID"
+```
+Expected: create returns a session; read-back returns the same id + state. Optionally repeat
+the GET a few times to hit a cold/second instance.
+
+**Step 3:** No commit (deploy/verify only). Record revision + result for the PR.
+
+---
+
+# Workstream B — IAP on the frontend (do second)
+
+**Preconditions:** Workstream A verified; you accept that enabling IAP **removes public
+access** — only `domain:altostrat.com` users will reach the app afterward.
+
+**No frontend code change is expected.** IAP authenticates the user at the edge *before*
+requests reach the container; the same-origin `/api/adk` and `/api/gcs` handlers run inside
+the (now IAP-protected) origin and keep using the container SA to reach the private backend
+and GCS — unaffected. Task B4 explicitly verifies SSE still streams through IAP.
+
+---
+
+### Task B1: Pre-flight (Claude — read-only + enable API)
+
+**Step 1:** Enable the IAP API (safe, not an auth/IAM change):
+
+```bash
+gcloud services enable iap.googleapis.com --project hybrid-vertex
+```
+
+**Step 2:** Confirm the current public state so the change is reversible knowledge:
+
+```bash
+gcloud run services describe trend-trawler-web --region us-central1 \
+  --format="value(metadata.annotations['run.googleapis.com/ingress'])"
+gcloud run services get-iam-policy trend-trawler-web --region us-central1 \
+  --format="table(bindings.role, bindings.members)"
+```
+Expected: ingress `all`; policy includes `roles/run.invoker → allUsers` (today's public MVP).
+Record these — B3 removes the `allUsers` binding.
+
+---
+
+### Task B2: Enable IAP on the web service (USER-run — auth-surface change)
+
+Prepare for the user to paste behind `!`:
+
+```bash
+gcloud run services update trend-trawler-web --region us-central1 \
+  --iap --no-allow-unauthenticated
+```
+
+**Verify (Claude, read-only):**
+```bash
+gcloud run services describe trend-trawler-web --region us-central1 \
+  --format="yaml(metadata.annotations, spec.template.metadata.annotations)" | grep -i iap
+```
+Expected: an IAP-enabled annotation is present. Enabling IAP also creates the IAP service
+agent `service-934903580331@gcp-sa-iap.iam.gserviceaccount.com`.
+
+---
+
+### Task B3: IAM — let IAP invoke the service + grant the domain (USER-run)
+
+Two service-level bindings the user pastes behind `!`:
+
+```bash
+# 1) IAP service agent must be able to invoke the Cloud Run service (IAP fronts it)
+gcloud run services add-iam-policy-binding trend-trawler-web --region us-central1 \
+  --member="serviceAccount:service-934903580331@gcp-sa-iap.iam.gserviceaccount.com" \
+  --role="roles/run.invoker"
+
+# 2) Whole domain may pass IAP ("IAP-secured Web App User")
+gcloud run services add-iam-policy-binding trend-trawler-web --region us-central1 \
+  --member="domain:altostrat.com" \
+  --role="roles/iap.httpsResourceAccessor"
+```
+
+**Then remove the old public binding** (USER-run — this is the actual "make it private" step):
+
+```bash
+gcloud run services remove-iam-policy-binding trend-trawler-web --region us-central1 \
+  --member="allUsers" --role="roles/run.invoker"
+```
+
+**Verify (Claude, read-only):**
+```bash
+gcloud run services get-iam-policy trend-trawler-web --region us-central1 \
+  --format="table(bindings.role, bindings.members)"
+```
+Expected: `roles/run.invoker → serviceAccount:service-934903580331@gcp-sa-iap…`,
+`roles/iap.httpsResourceAccessor → domain:altostrat.com`, and **no** `allUsers`.
+
+---
+
+### Task B4: Verify IAP end-to-end
+
+**Step 1: Unauthenticated request is intercepted by IAP** (Claude)
+
+```bash
+WEB="https://trend-trawler-web-qqzji3hyoa-uc.a.run.app"
+curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" "$WEB/"
+```
+Expected: **302** redirecting to `https://accounts.google.com/…` (IAP sign-in) — **not** a
+200 (public) and **not** a bare 403. A `302` to Google sign-in is the success signal.
+
+**Step 2: Authenticated browser check** (user, manual): open `$WEB/` in a browser signed in
+as an `@altostrat.com` user → Google consent (first time) → the app loads (200). Submit a
+campaign and confirm the **SSE run stream** still updates live (proves IAP passes SSE
+through) and an artifact loads via `/api/gcs`.
+
+**Step 3:** No code change. Record results for the PR.
+
+---
+
+### Task B5: Docs + memory
+
+**Files:**
+- Modify: `deployment/README.md` — new subsection "Persistent sessions (Agent Engine)" (the
+  `SESSION_SERVICE_URI` env var, the dedicated engine, `roles/aiplatform.user` on
+  `tt-api-sa`) and "IAP on the frontend" (the `--iap` enablement, the two IAM grants, the
+  `allUsers` removal, `roles/iap.httpsResourceAccessor` to `domain:altostrat.com`, the 302
+  sign-in verification).
+- Modify: `CLAUDE.md` — one line under the frontend/deploy notes: frontend is now IAP-gated
+  (domain-restricted), backend uses persistent Agent Engine sessions via `SESSION_SERVICE_URI`.
+- Modify: memory `frontend-cloudrun-deployment-live.md` — mark IAP + persistent-sessions
+  follow-ups RESOLVED with the engine resource name and revisions.
+
+**Commit:**
+```bash
+git add deployment/README.md CLAUDE.md
+git commit -m "docs: IAP frontend + persistent Agent Engine sessions runbook"
+```
+
+---
+
+## Verification (whole plan)
+
+- **No-creds gate (CI-safe):** `uv run pytest tests/test_backend_entrypoint.py -q` +
+  full `uv run pytest tests/ -q` green; `uvx ruff check` clean; entrypoint dry-run smokes.
+- **Sessions (live):** create→restart→GET returns the same session with state (local A4 and
+  live A5); backend stays private (`403` unauth).
+- **IAP (live):** unauth `/` → `302` to Google sign-in; an `@altostrat.com` user loads the
+  app, a full campaign run streams via SSE, an artifact loads via `/api/gcs`; policy shows no
+  `allUsers`.
+
+## Risks / call-outs
+
+- **`GOOGLE_CLOUD_LOCATION` conflict (sessions):** models need `global`, the session engine
+  needs `us-central1`. Mitigated by the **fully-qualified** `agentengine://projects/…/
+  locations/us-central1/reasoningEngines/<ID>` URI; A4 is the gate that proves it before deploy.
+- **IAP removes public access immediately** after B2+B3. If a non-domain demo viewer needs
+  access, add them individually with `roles/iap.httpsResourceAccessor` — do not re-add
+  `allUsers`.
+- **SSE through IAP:** IAP streams responses; B4/step-2 explicitly confirms the run page still
+  updates live (guards against edge buffering).
+- **`agent_engines.create()` signature drift:** verify the installed SDK's signature (A3
+  step 1 note) before running; some versions want a positional agent.
+- **OAuth brand deprecation warning:** the IAP OAuth Admin *APIs* are being retired, but the
+  existing brand + direct Cloud Run `--iap` path do not depend on them; ignore the warning.
+
+## Out of scope (deferred)
+
+Cloud SQL/relational session store (chose Agent Engine); per-user/group IAP allowlists (chose
+whole-domain); context-aware access levels; custom domain + managed TLS; Artifact Registry +
+Cloud Build CI/CD; autoscaling/session-affinity tuning.

--- a/frontend/src/__tests__/adk-proxy-auth.test.ts
+++ b/frontend/src/__tests__/adk-proxy-auth.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { backendNeedsAuth } from "@/app/api/adk/[...path]/route";
+import {
+  backendNeedsAuth,
+  stripInboundCredentials,
+} from "@/app/api/adk/[...path]/route";
 
 describe("backendNeedsAuth", () => {
   it("is true for a remote https backend (private Cloud Run)", () => {
@@ -7,5 +10,33 @@ describe("backendNeedsAuth", () => {
   });
   it("is false for localhost dev backend", () => {
     expect(backendNeedsAuth("http://localhost:8000")).toBe(false);
+  });
+});
+
+describe("stripInboundCredentials", () => {
+  it("removes IAP's edge-injected credentials so they never reach the backend", () => {
+    // Simulates the request IAP forwards to the container.
+    const headers = new Headers({
+      authorization: "Bearer iap-jwt-wrong-audience",
+      "x-serverless-authorization": "Bearer iap-serverless-token",
+      cookie: "GCP_IAP_XSRF_NONCE=abc; GCP_IAPAuth=xyz",
+      "x-goog-iap-jwt-assertion": "assertion",
+      "x-goog-authenticated-user-email": "accounts.google.com:user@example.com",
+      "x-goog-authenticated-user-id": "accounts.google.com:12345",
+      "content-type": "application/json",
+    });
+
+    stripInboundCredentials(headers);
+
+    // X-Serverless-Authorization is the critical one: Cloud Run ingress checks it in
+    // preference to Authorization, so a leaked IAP token here causes a 401.
+    expect(headers.get("x-serverless-authorization")).toBeNull();
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("cookie")).toBeNull();
+    expect(headers.get("x-goog-iap-jwt-assertion")).toBeNull();
+    expect(headers.get("x-goog-authenticated-user-email")).toBeNull();
+    expect(headers.get("x-goog-authenticated-user-id")).toBeNull();
+    // Non-credential headers are preserved.
+    expect(headers.get("content-type")).toBe("application/json");
   });
 });

--- a/frontend/src/app/api/adk/[...path]/route.ts
+++ b/frontend/src/app/api/adk/[...path]/route.ts
@@ -25,6 +25,33 @@ export function backendNeedsAuth(base: string): boolean {
   return base.startsWith("https://");
 }
 
+/** Inbound credential headers that must NOT be forwarded to the private backend.
+ *
+ *  When the frontend is behind IAP, IAP authenticates the user at the edge and injects its
+ *  own credentials on the request that reaches this container: `Authorization` (the IAP
+ *  JWT, audience = IAP OAuth client ID), the `X-Goog-*` identity headers, and — critically —
+ *  `X-Serverless-Authorization`, which Cloud Run's ingress checks *in preference to*
+ *  `Authorization`. If any of these reach the backend, Cloud Run verifies the IAP token
+ *  (wrong audience) and returns `401 "The access token could not be verified"`, ignoring the
+ *  service-account token we set. Stripping them all guarantees the backend sees only our
+ *  minted token. The `cookie` (large IAP session cookie) is dropped too — the backend has no
+ *  use for it. */
+export const INBOUND_CREDENTIAL_HEADERS = [
+  "authorization",
+  "x-serverless-authorization",
+  "cookie",
+  "x-goog-iap-jwt-assertion",
+  "x-goog-authenticated-user-email",
+  "x-goog-authenticated-user-id",
+] as const;
+
+/** Remove every inbound credential header so IAP's edge credentials never leak to the
+ *  backend. Mutates and returns `headers`. */
+export function stripInboundCredentials(headers: Headers): Headers {
+  for (const name of INBOUND_CREDENTIAL_HEADERS) headers.delete(name);
+  return headers;
+}
+
 async function proxy(
   request: NextRequest,
   ctx: { params: Promise<{ path: string[] }> }
@@ -37,8 +64,21 @@ async function proxy(
   headers.delete("connection");
   headers.delete("content-length");
 
+  // Drop IAP's edge-injected credentials so only our minted token reaches the backend
+  // (see INBOUND_CREDENTIAL_HEADERS for why — X-Serverless-Authorization is the key one).
+  stripInboundCredentials(headers);
+
+  const audience = new URL(BACKEND).origin;
   if (backendNeedsAuth(BACKEND)) {
-    const token = await getIdentityToken(new URL(BACKEND).origin);
+    const token = await getIdentityToken(audience);
+    // Never forward a request to a private backend without a real token — that surfaces as
+    // an opaque backend 401. Fail fast with a clear signal instead.
+    if (!token) {
+      return new Response(
+        "Proxy could not obtain a backend identity token",
+        { status: 502 },
+      );
+    }
     headers.set("authorization", `Bearer ${token}`);
   }
 

--- a/tests/test_backend_entrypoint.py
+++ b/tests/test_backend_entrypoint.py
@@ -1,0 +1,38 @@
+"""The backend container entrypoint appends --session_service_uri only when set.
+
+Keeps the session store opt-in (local `adk web` / CI unaffected) and out of the
+Dockerfile CMD literal. ADK_DRYRUN=1 makes the script print the argv it would exec.
+"""
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "deployment" / "backend_entrypoint.sh"
+
+
+def _run(env_extra):
+    env = {"PATH": "/usr/bin:/bin", "PORT": "8080", "ADK_DRYRUN": "1", **env_extra}
+    out = subprocess.run(
+        ["sh", str(SCRIPT)], capture_output=True, text=True, env=env, check=True
+    )
+    return out.stdout.strip()
+
+
+def test_no_session_uri_omits_flag():
+    cmd = _run({})
+    assert "adk api_server agents" in cmd
+    assert "--host 0.0.0.0" in cmd
+    assert "--port 8080" in cmd
+    assert "--session_service_uri" not in cmd
+
+
+def test_empty_session_uri_omits_flag():
+    assert "--session_service_uri" not in _run({"SESSION_SERVICE_URI": ""})
+
+
+def test_session_uri_present_appends_flag():
+    uri = (
+        "agentengine://projects/934903580331/locations/us-central1/reasoningEngines/123"
+    )
+    cmd = _run({"SESSION_SERVICE_URI": uri})
+    assert f"--session_service_uri {uri}" in cmd


### PR DESCRIPTION
## Summary

Closes the two remaining follow-ups from the Cloud Run deployment: the frontend is now **IAP-gated** (domain-restricted) and the backend uses **persistent Agent Engine sessions**. Both are verified live end-to-end.

## Workstream A — persistent Agent-Engine sessions
- New `deployment/backend_entrypoint.sh`: appends `--session_service_uri` to `adk api_server agents` only when `SESSION_SERVICE_URI` is set (opt-in; unchanged/in-memory when unset). Wired as the `Dockerfile` `CMD`.
- New `deployment/create_session_engine.py`: creates (or reuses) a **dedicated** `trend-trawler-sessions` Agent Engine in `us-central1` to back sessions, decoupled from any served agent. Prints the fully-qualified `agentengine://` URI.
- The URI is fully-qualified on purpose — it pins the store to `us-central1` while models stay pinned to `global` (`GOOGLE_CLOUD_LOCATION` stays unset; verified the client doesn't require it).
- Backend redeployed with `SESSION_SERVICE_URI`. **Verified:** create → server restart → GET returns the same session with state (local gate); live round-trip via the proxy; backend stays `403` unauth.

## Workstream B — IAP on the frontend
- Direct Cloud Run IAP (`--iap`) on `trend-trawler-web`; `allUsers` removed; IAP SA granted `run.invoker`; `roles/iap.httpsResourceAccessor` granted to `domain:jordantotten.altostrat.com` on the IAP resource.
- **Verified:** unauth `curl` → `HTTP/2 302` to Google sign-in; a signed-in domain user runs a full campaign (session create + SSE) end-to-end.

## Frontend proxy fix (`b7fdc87`)
Enabling IAP broke the same-origin `/api/adk` proxy → **"Failed to create session"**. IAP injects edge credentials on the inbound request, and Cloud Run ingress checks **`X-Serverless-Authorization`** *in preference to* `Authorization` — so the forwarded IAP token (wrong audience) was verified instead of the proxy's minted service-account token, yielding `401 "access token could not be verified"`. Fix: strip all inbound IAP credential headers (`stripInboundCredentials`) before attaching the minted token, and fail fast (502) if minting yields nothing. Adds a regression test.

## Docs
- `deployment/README.md`: runbook sections for persistent sessions and IAP.
- `CLAUDE.md`: frontend IAP-gated + backend persistent sessions.
- Plan doc committed at `docs/plans/2026-07-13-frontend-iap-and-persistent-sessions.md`.

## Test plan
- `cd frontend && npm test` → 69 pass (incl. new `stripInboundCredentials` regression test); `tsc --noEmit` clean.
- `uv run pytest tests/test_backend_entrypoint.py tests/test_agents_dir.py -q` → green.
- Live: session persistence across restart/redeploy; IAP 302 for unauth; full campaign run behind IAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
