### PR TITLE
fix(frontend): guard event timeline against missing timestamps

### DIFF
--- a/frontend/src/__tests__/event-log-time.test.ts
+++ b/frontend/src/__tests__/event-log-time.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { formatEventTime } from "@/components/event-log";
+
+describe("formatEventTime", () => {
+  it("formats a valid epoch-seconds timestamp as a local time string", () => {
+    // A real ADK event timestamp (epoch seconds, float). Just assert it renders
+    // some non-empty time string rather than the literal "Invalid Date".
+    const out = formatEventTime(1_700_000_000);
+    expect(out).not.toBe("");
+    expect(out).not.toBe("Invalid Date");
+  });
+
+  it("returns empty string for undefined (missing timestamp)", () => {
+    // The trigger for the "Invalid Date" bug: some events (e.g. the final
+    // streaming event) arrive with no numeric `timestamp`.
+    expect(formatEventTime(undefined)).toBe("");
+  });
+
+  it("returns empty string for NaN", () => {
+    expect(formatEventTime(NaN)).toBe("");
+  });
+
+  it("returns empty string for null", () => {
+    expect(formatEventTime(null)).toBe("");
+  });
+
+  it("never returns the literal 'Invalid Date'", () => {
+    for (const bad of [undefined, null, NaN, Infinity, -Infinity]) {
+      expect(formatEventTime(bad as number)).not.toBe("Invalid Date");
+    }
+  });
+});

--- a/frontend/src/components/event-log.tsx
+++ b/frontend/src/components/event-log.tsx
@@ -17,6 +17,16 @@ function summarizeArgs(args: Record<string, unknown>): string {
     .join(", ");
 }
 
+/** Format an ADK event timestamp (epoch seconds) as a local time string.
+ *  Returns "" when the timestamp is missing or unparseable so the UI shows
+ *  nothing instead of the literal "Invalid Date" (some events — e.g. the final
+ *  streaming event — arrive without a numeric `timestamp`). */
+export function formatEventTime(timestamp: number | undefined | null): string {
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) return "";
+  const d = new Date(timestamp * 1000);
+  return Number.isNaN(d.getTime()) ? "" : d.toLocaleTimeString();
+}
+
 /** Map agent name to a colored dot */
 function agentColor(author: string): string {
   if (author.includes("trend")) return "bg-emerald-500";
@@ -52,9 +62,11 @@ function EventItem({ event, isLast }: { event: AgentEvent; isLast: boolean }) {
           >
             {event.author}
           </Badge>
-          <span className="text-[10px] text-muted-foreground tabular-nums">
-            {new Date(event.timestamp * 1000).toLocaleTimeString()}
-          </span>
+          {formatEventTime(event.timestamp) && (
+            <span className="text-[10px] text-muted-foreground tabular-nums">
+              {formatEventTime(event.timestamp)}
+            </span>
+          )}
         </div>
 
         {parts.map((part, i) => {


### PR DESCRIPTION
## Problem

The run page's event timeline showed the literal string **"Invalid Date"** next to the final `trend_scout` event. The last streaming event arrives without a numeric `timestamp`, so `new Date(event.timestamp * 1000)` evaluated to `new Date(NaN)`, whose `toLocaleTimeString()` returns `"Invalid Date"`. Purely cosmetic — the run itself completes normally.

## Fix

- Extract `formatEventTime()` in `event-log.tsx` — returns `""` for a missing/non-finite/unparseable timestamp.
- The timeline now omits the time chip when there's no valid timestamp instead of rendering "Invalid Date".
- Add `event-log-time.test.ts` covering valid, `undefined`, `null`, `NaN`, and `Infinity` inputs (asserts none produce "Invalid Date").

## Verification

- `npm test` → 74 passed (5 new)
- `tsc --noEmit` clean
- lint: no new warnings (the one `page.tsx` warning is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)