### PR TITLE
fix(frontend): fixed 480px square images on Results tab

### DIFF
--- a/frontend/src/app/results/[sessionId]/page.tsx
+++ b/frontend/src/app/results/[sessionId]/page.tsx
@@ -467,8 +467,10 @@ export default function ResultsPage({
                       </p>
                     </div>
 
-                    {/* Image with hover overlay */}
-                    <div className="relative group overflow-hidden flex-1">
+                    {/* Image with hover overlay — fixed 480px square (mirrors the
+                        HTML gallery) so it stays a consistent size regardless of
+                        window width instead of stretching to the eval column. */}
+                    <div className="relative group overflow-hidden aspect-square w-full max-w-[480px] mx-auto">
                       {imgUrl ? (
                         // eslint-disable-next-line @next/next/no-img-element
                         <img
@@ -477,7 +479,7 @@ export default function ResultsPage({
                           className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
                         />
                       ) : (
-                        <div className="flex items-center justify-center h-64 bg-muted/50 text-sm text-muted-foreground">
+                        <div className="flex items-center justify-center h-full w-full bg-muted/50 text-sm text-muted-foreground">
                           No image available
                         </div>
                       )}


### PR DESCRIPTION
## Problem

On the Results tab, each visual concept's image was `w-full h-full object-cover` inside a flex cell that stretched to match the adjacent eval column's height — so the image grew with window width and varied in size row-to-row. This mirrors the HTML-gallery issue we already fixed (#66), but in the React UI.

## Fix

- Constrain the image to a **fixed 480px square** (`aspect-square w-full max-w-[480px] mx-auto`), responsive down on narrow screens — matching the HTML gallery.
- Fill the no-image fallback to the square (`h-full w-full`) instead of a fixed `h-64`.
- Bottom "Artifacts → Images" grid was already `aspect-square`; left unchanged.
- Hover behavior (110% zoom + 4-corner overlay) left as-is — that's the Results-tab UX.

## Verification

- `tsc --noEmit` clean
- `npm test` → 74 passed
- lint: no new warnings (the one `run/page.tsx` warning is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)