### PR TITLE
fix(creative_agent): tolerate missing refined_web_search_insights

### DIFF
--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -195,6 +195,12 @@ enhanced_combined_searcher = Agent(
 )
 
 
+# `{refined_web_search_insights?}` is intentionally OPTIONAL (trailing `?`): the upstream
+# enhanced_combined_searcher occasionally emits no final text (google_search + thinking
+# returning only tool calls), leaving its output_key unset. Without the `?`, ADK raises
+# `KeyError: Context variable not found` here and aborts the whole run after the expensive
+# research. The refinement is additive — the full base research is in
+# `{combined_web_search_insights}` — so degrading to an empty section is the right fallback.
 combined_report_composer = Agent(
     model=build_gemini(config.critic_model),
     name="combined_report_composer",
@@ -216,7 +222,7 @@ combined_report_composer = Agent(
         </combined_web_search_insights>
 
         <refined_web_search_insights>
-        {refined_web_search_insights}
+        {refined_web_search_insights?}
         </refined_web_search_insights>
 
         <key_selling_points>


### PR DESCRIPTION
## Problem

A live `creative_agent` run crashed mid-pipeline with:

```
KeyError: 'Context variable not found: `refined_web_search_insights`.'
```

`enhanced_combined_searcher` (a follow-up `google_search` + thinking step) occasionally emits **no final text**, so its `output_key="refined_web_search_insights"` is never written to session state. The next agent, `combined_report_composer`, referenced `{refined_web_search_insights}` as a **required** instruction variable, so ADK raised `KeyError` *before* the model call and aborted the entire run — after the expensive research and before ad copy / visuals / eval. Result: no gallery, and the Results page 404-loops on `creative_eval_report.json`.

Same flakiness class as the trend_scout `MALFORMED_FUNCTION_CALL` fix (#57).

## Fix

Mark the variable optional: `{refined_web_search_insights?}`. ADK's templating (`instructions_utils.py:90`) substitutes an empty string for a missing optional var instead of raising. The refinement is *additive* — the full base research is already in `{combined_web_search_insights}` — so a flaky supplementary search now degrades to an empty refinement section rather than nuking the run. Added a comment so the `?` isn't "tidied away" later.

## Verification

- `uvx ruff check` / `format --check` clean
- `import creative_agent.agent` succeeds (instantiates all agents)
- Full validation is the live redeploy + a creative run

🤖 Generated with [Claude Code](https://claude.com/claude-code)