### PR TITLE
exp(creative_agent): WS1 — retry-on-empty wrappers for flaky research producers

### DIFF
--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -15,6 +15,7 @@ from agent_common import build_gemini
 from .config import config, INFRA_RETRY
 from . import callbacks
 from . import tools
+from .retry_agent import RetryUntilKeyAgent
 from creative_eval.agent import creative_eval_agent
 
 
@@ -44,12 +45,13 @@ merge_planners = Agent(
     1.  **Analyze and Integrate:** Carefully read the two provided research summaries (Campaign and Trend).
     2.  **Cross-Reference:** Identify areas of overlap or synergy between the campaign insights and the trend analysis (e.g., does the trend reinforce a key selling point?)
     3.  **Synthesize and Structure:** Generate a new, integrated Strategic Brief, following the structure and guidance in the <REPORT_STRUCTURE> block. **Do not simply paste the old reports.**
+    4.  **Handle Missing Research:** If either the Campaign Insights or Trend Analysis section is empty, explicitly note the missing research in the brief (a short "Research Gaps" line) and synthesize from whatever is present — do not fabricate the missing report.
     </INSTRUCTIONS>
 
     <CONTEXT>
         The following research reports have been completed:
-        - **Campaign Insights:** {campaign_web_search_insights}
-        - **Trend Analysis:** {gs_web_search_insights}
+        - **Campaign Insights:** {campaign_web_search_insights?}
+        - **Trend Analysis:** {gs_web_search_insights?}
     </CONTEXT>
 
     <REPORT_STRUCTURE>
@@ -195,6 +197,18 @@ enhanced_combined_searcher = Agent(
 )
 
 
+# Retry-on-empty: enhanced_combined_searcher (google_search + thinking) intermittently
+# returns no final text, leaving `refined_web_search_insights` unset. combined_report_composer
+# already guards this with `{refined_web_search_insights?}`, but retrying recovers the
+# refinement (a quality gain) instead of silently dropping it. Re-run until populated (bounded).
+enhanced_combined_searcher_resilient = RetryUntilKeyAgent(
+    name="enhanced_combined_searcher_resilient",
+    sub_agents=[enhanced_combined_searcher],
+    output_key="refined_web_search_insights",
+    max_attempts=3,
+)
+
+
 # `{refined_web_search_insights?}` is intentionally OPTIONAL (trailing `?`): the upstream
 # enhanced_combined_searcher occasionally emits no final text (google_search + thinking
 # returning only tool calls), leaving its output_key unset. Without the `?`, ADK raises
@@ -290,7 +304,7 @@ combined_research_pipeline = SequentialAgent(
     sub_agents=[
         merge_parallel_insights,
         combined_web_evaluator,
-        enhanced_combined_searcher,
+        enhanced_combined_searcher_resilient,
         combined_report_composer,
     ],
 )

--- a/creative_agent/retry_agent.py
+++ b/creative_agent/retry_agent.py
@@ -1,0 +1,123 @@
+"""Retry-on-empty wrapper for research producer agents.
+
+## Why this exists
+
+creative_agent's research pipeline is brittle: a producer agent that finishes
+*without* writing its ``output_key`` makes the next consumer's ``{var}``
+instruction template raise ``KeyError: Context variable not found`` and abort
+the whole run. google_search + thinking agents on gemini-3 hit this
+intermittently — they can burn the output budget "thinking" (MAX_TOKENS),
+return only tool-call parts, or emit a MALFORMED_FUNCTION_CALL, any of which
+leaves the final text (and thus the ``output_key``) empty.
+
+``retry_config`` (INFRA_RETRY) does NOT help here: it only retries the model
+call on *infra exceptions* (transient 5xx / ServerError). An empty-but-
+successful turn raises nothing, so it never triggers a retry.
+
+## What this does (mitigation #1: retry-on-empty at the producer)
+
+``RetryUntilKeyAgent`` wraps a single inner producer agent and re-runs it until
+its ``output_key`` is populated in session state, up to ``max_attempts``. This
+is quality-preserving — a fresh model turn typically emits the summary the
+flaky turn dropped — and it does not touch the successful path (a healthy
+producer runs exactly once).
+
+State-delta timing: the runner appends each yielded event and merges its
+``state_delta`` into the *same* ``session`` object this agent reads, before our
+generator is resumed. So after the inner agent's event stream is exhausted,
+``ctx.session.state[output_key]`` reflects whatever it wrote (or didn't).
+
+## Observability (mitigation #3, folded in)
+
+If every attempt fails, the wrapper does NOT write a placeholder into
+``output_key`` (that would feed garbage to the downstream consumer). It leaves
+the key unset — so a downstream optional-var guard (``{var?}``) degrades
+cleanly — but records an observable ``<output_key>__retry_exhausted`` state
+marker and logs an error, so the failure is visible instead of silent.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import AsyncGenerator
+
+from google.adk.agents import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event
+from google.adk.events.event_actions import EventActions
+from google.adk.utils.context_utils import Aclosing
+from typing_extensions import override
+
+logger = logging.getLogger("google_adk." + __name__)
+
+
+class RetryUntilKeyAgent(BaseAgent):
+    """Re-run a single inner agent until its ``output_key`` is populated.
+
+    The inner agent is passed as the sole entry in ``sub_agents`` (so it gets
+    normal parent wiring). ``output_key`` must match the inner agent's
+    ``output_key``. Retries are bounded by ``max_attempts``.
+    """
+
+    output_key: str
+    """The session-state key the inner agent is expected to populate."""
+
+    max_attempts: int = 3
+    """Maximum number of times to run the inner agent (>= 1)."""
+
+    @staticmethod
+    def _is_populated(value: object) -> bool:
+        """A value counts as populated when it is a non-blank string."""
+        return isinstance(value, str) and bool(value.strip())
+
+    @override
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        if not self.sub_agents:
+            return
+        inner = self.sub_agents[0]
+
+        for attempt in range(1, self.max_attempts + 1):
+            async with Aclosing(inner.run_async(ctx)) as agen:
+                async for event in agen:
+                    yield event
+
+            if self._is_populated(ctx.session.state.get(self.output_key)):
+                if attempt > 1:
+                    logger.info(
+                        "%s populated '%s' on attempt %d/%d",
+                        inner.name,
+                        self.output_key,
+                        attempt,
+                        self.max_attempts,
+                    )
+                return
+
+            logger.warning(
+                "%s left '%s' empty on attempt %d/%d%s",
+                inner.name,
+                self.output_key,
+                attempt,
+                self.max_attempts,
+                "; retrying" if attempt < self.max_attempts else "",
+            )
+
+        # Exhausted every attempt: make the failure observable (mitigation #3)
+        # without corrupting output_key. Downstream must guard with `{var?}`.
+        logger.error(
+            "%s never populated '%s' after %d attempts; leaving it unset and "
+            "recording '%s__retry_exhausted'",
+            inner.name,
+            self.output_key,
+            self.max_attempts,
+            self.output_key,
+        )
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=ctx.branch,
+            actions=EventActions(
+                state_delta={f"{self.output_key}__retry_exhausted": True}
+            ),
+        )

--- a/creative_agent/sub_agents/campaign_researcher/agent.py
+++ b/creative_agent/sub_agents/campaign_researcher/agent.py
@@ -10,6 +10,7 @@ from google.adk.agents import Agent, SequentialAgent
 from agent_common import build_gemini
 from ...config import config
 from ... import callbacks
+from ...retry_agent import RetryUntilKeyAgent
 
 
 # --- config ---
@@ -141,8 +142,18 @@ campaign_web_searcher = Agent(
     after_agent_callback=callbacks.collect_research_sources_callback,
 )
 
+# Retry-on-empty: campaign_web_searcher (google_search + thinking) intermittently
+# returns no final text, leaving `campaign_web_search_insights` unset and crashing
+# merge_planners. Re-run until the key is populated (bounded by max_attempts).
+campaign_web_searcher_resilient = RetryUntilKeyAgent(
+    name="campaign_web_searcher_resilient",
+    sub_agents=[campaign_web_searcher],
+    output_key="campaign_web_search_insights",
+    max_attempts=3,
+)
+
 ca_sequential_planner = SequentialAgent(
     name="ca_sequential_planner",
     description="Executes sequential research tasks for concepts described in the campaign guide.",
-    sub_agents=[campaign_web_planner, campaign_web_searcher],
+    sub_agents=[campaign_web_planner, campaign_web_searcher_resilient],
 )

--- a/creative_agent/sub_agents/trend_researcher/agent.py
+++ b/creative_agent/sub_agents/trend_researcher/agent.py
@@ -10,6 +10,7 @@ from google.adk.agents import Agent, SequentialAgent
 from agent_common import build_gemini
 from ...config import config
 from ... import callbacks
+from ...retry_agent import RetryUntilKeyAgent
 
 
 # --- config ---
@@ -136,8 +137,18 @@ gs_web_searcher = Agent(
 
 # 4.  **Risk Assessment:** (Identify any potential pitfalls, controversies, or negative associations linked to the trend that marketers must be aware of.)
 
+# Retry-on-empty: gs_web_searcher (google_search + thinking) intermittently
+# returns no final text, leaving `gs_web_search_insights` unset and crashing
+# merge_planners. Re-run until the key is populated (bounded by max_attempts).
+gs_web_searcher_resilient = RetryUntilKeyAgent(
+    name="gs_web_searcher_resilient",
+    sub_agents=[gs_web_searcher],
+    output_key="gs_web_search_insights",
+    max_attempts=3,
+)
+
 gs_sequential_planner = SequentialAgent(
     name="gs_sequential_planner",
     description="Executes sequential research tasks for trends in Google Search.",
-    sub_agents=[gs_web_planner, gs_web_searcher],
+    sub_agents=[gs_web_planner, gs_web_searcher_resilient],
 )

--- a/docs/plans/2026-07-14-research-pipeline-hardening.md
+++ b/docs/plans/2026-07-14-research-pipeline-hardening.md
@@ -1,0 +1,219 @@
+# Research Pipeline Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate the class of crashes where a `creative_agent` research producer finishes without writing its `output_key`, making the next agent's `{var}` instruction template raise `KeyError: Context variable not found` and abort the whole run.
+
+**Architecture:** Three layered defenses, shipped in order of leverage-per-risk. (1) A small custom `BaseAgent` wrapper (`RetryUntilKeyAgent`) re-runs a flaky producer until its `output_key` is populated — immediate relief, low blast radius. (3) Observable guardrails make any residual empty-output degrade visibly (`{var?}` + a state marker + logs) instead of crashing or silently degrading. (2) The durable structural fix: split each "search **and** synthesize in one agent" producer into a tool-using searcher + a tool-free synthesizer, so the text-emitting step has no thinking/tool pressure to blow its output budget. Layered: #2 makes each attempt reliable, #1 covers the residual, #3 makes anything left observable.
+
+**Tech Stack:** google-adk (`BaseAgent`, `SequentialAgent`, `InMemoryRunner`), pytest (offline, `asyncio.run` — no pytest-asyncio), `uv`/`uvx ruff`, the isolated tagged-Cloud-Run-revision test harness (see memory `creative-agent-research-pipeline-brittleness`).
+
+---
+
+## Context (do not re-derive)
+
+The prototype for mitigation #1 is **already built and passing** on branch `exp/retry-until-key-prototype` (off `main`):
+- `creative_agent/retry_agent.py` — `RetryUntilKeyAgent` (standalone; no `genai` import so it stays offline-testable).
+- `tests/test_retry_agent.py` — 3 tests GREEN via a real `InMemoryRunner` + a deterministic `_FlakyProducer` double: recovers after 2 empty attempts, does not retry a healthy producer, and stays bounded + observable when the producer never populates.
+
+**Why the offline test is the real proof:** the empty-output flake is nondeterministic, so a live run can pass without ever triggering it — proving nothing. The `_FlakyProducer` triggers the exact failure deterministically and drives it through the genuine ADK state-delta path (the runner merges each event's `state_delta` into the same `session` object the wrapper reads, before the generator resumes — verified in `runners.py:~1412` → `base_session_service._update_session_state`).
+
+**The three landmines** (required `{var}`; producer → consumer). All three producers share the identical anti-pattern — `google_search` + `BuiltInPlanner` **and** final-text synthesis in one `Agent`:
+
+| # | `output_key` | Producer (file) | Consumer | Status |
+|---|---|---|---|---|
+| 1 | `campaign_web_search_insights` | `campaign_web_searcher` (`creative_agent/sub_agents/campaign_researcher/agent.py:95`) | `merge_planners` (`creative_agent/agent.py:51`) | UNGUARDED |
+| 2 | `gs_web_search_insights` | `gs_web_searcher` (`creative_agent/sub_agents/trend_researcher/agent.py:91`) | `merge_planners` (`creative_agent/agent.py:52`) | UNGUARDED |
+| 3 | `refined_web_search_insights` | `enhanced_combined_searcher` (`creative_agent/agent.py:160`) | `combined_report_composer` (`creative_agent/agent.py:232`) | GUARDED by `{var?}` (#69) |
+
+**Deprecation note (out of scope, flag only):** `SequentialAgent`/`ParallelAgent`/`LoopAgent` are all `@deprecated` in this ADK in favor of `Workflow`, which "cannot yet be used as an LlmAgent sub-agent" — migration is currently blocked. The whole pipeline sits on these. `RetryUntilKeyAgent` (custom `BaseAgent`) is unaffected. Do **not** attempt a `Workflow` migration in this plan.
+
+## Standing constraints (apply throughout)
+
+- `export PATH="$HOME/.local/bin:$PATH"` before any `uv`/`uvx`. Use `uv`/`uvx ruff`, never bare pip/python. Lint+format with `uvx ruff`.
+- **Only commit/push when the user explicitly asks.** Branch off `main` first; never commit to `main`. Do NOT commit `.python-version`; commit `uv.lock` normally. No `Co-Authored-By` trailers. PR bodies end with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- Models pinned to `global` in code via `agent_common` (env `GOOGLE_CLOUD_LOCATION` stays UNSET); regional resources use `GCP_REGION=us-central1`. BigQuery dataset `trend_trawler` is the data store — preserve.
+- Live deploys use the **isolated tagged no-traffic revision** harness (never touch prod traffic): `gcloud run deploy trend-trawler-api --source . --region us-central1 --project hybrid-vertex --no-traffic --tag <tag>`; auth by impersonating `tt-web-sa` with audience = the **base** service URL (see memory note for the full recipe). Plain private-service deploys are auto-mode-allowed; auth-surface/IAM changes are NOT (user runs via `!`).
+
+---
+
+# Workstream 1 — Productionize `RetryUntilKeyAgent` (validated #1)
+
+The prototype code is done; this workstream promotes it into the live pipeline around the two **unguarded** producers, plus landmine #3's producer (belt-and-suspenders with its existing downstream `{var?}`).
+
+**Wiring rule (critical):** an ADK agent can have exactly one parent. To wrap an existing producer you must **remove it from its current parent's `sub_agents` and put the wrapper there instead**, with the wrapper holding the producer as its sole `sub_agents` entry.
+
+### Task 1.1: Confirm the prototype is green on this branch
+
+**Files:** none (verification only).
+
+**Step 1:** Run `export PATH="$HOME/.local/bin:$PATH"; cd /home/user/adk_pipe; uv run pytest tests/test_retry_agent.py -q`
+Expected: `3 passed`. If red, stop — the prototype must be green before wiring.
+
+**Step 2:** `uvx ruff check creative_agent/retry_agent.py tests/test_retry_agent.py` → `All checks passed!`
+
+### Task 1.2: Wrap the two unguarded producers  *(TDD)*
+
+**Files:**
+- Modify: `creative_agent/sub_agents/campaign_researcher/agent.py` (wrap `campaign_web_searcher` inside `ca_sequential_planner`)
+- Modify: `creative_agent/sub_agents/trend_researcher/agent.py` (wrap `gs_web_searcher` inside `gs_sequential_planner`)
+- Test: `tests/test_pipeline_structure.py`
+
+**Step 1: Write the failing structural test.** Add to `tests/test_pipeline_structure.py`:
+
+```python
+def test_research_producers_are_retry_wrapped():
+    """The two unguarded research producers must be wrapped for retry-on-empty."""
+    from creative_agent.retry_agent import RetryUntilKeyAgent
+    from creative_agent.sub_agents.campaign_researcher.agent import ca_sequential_planner
+    from creative_agent.sub_agents.trend_researcher.agent import gs_sequential_planner
+
+    ca_last = ca_sequential_planner.sub_agents[-1]
+    gs_last = gs_sequential_planner.sub_agents[-1]
+
+    assert isinstance(ca_last, RetryUntilKeyAgent)
+    assert ca_last.output_key == "campaign_web_search_insights"
+    assert ca_last.sub_agents[0].output_key == "campaign_web_search_insights"
+
+    assert isinstance(gs_last, RetryUntilKeyAgent)
+    assert gs_last.output_key == "gs_web_search_insights"
+    assert gs_last.sub_agents[0].output_key == "gs_web_search_insights"
+```
+
+**Step 2: Run it to verify it fails.**
+Run: `PYTHONPATH="$PWD" uv run pytest tests/test_pipeline_structure.py::test_research_producers_are_retry_wrapped -v`
+Expected: FAIL (last sub_agent is the raw `Agent`, not `RetryUntilKeyAgent`). *(Requires GCP creds — module-level `genai.Client`. If unavailable locally, this test runs in CI / on the deploy host; note it and proceed to implement.)*
+
+**Step 3: Implement — campaign_researcher.** In `creative_agent/sub_agents/campaign_researcher/agent.py`, after `campaign_web_searcher` is defined and before `ca_sequential_planner`, add:
+
+```python
+from ...retry_agent import RetryUntilKeyAgent
+
+# Retry-on-empty: campaign_web_searcher (google_search + thinking) intermittently
+# returns no final text, leaving `campaign_web_search_insights` unset and crashing
+# merge_planners' `{campaign_web_search_insights}`. Re-run until populated (bounded).
+campaign_web_searcher_resilient = RetryUntilKeyAgent(
+    name="campaign_web_searcher_resilient",
+    sub_agents=[campaign_web_searcher],
+    output_key="campaign_web_search_insights",
+    max_attempts=3,
+)
+```
+
+Then change `ca_sequential_planner`'s `sub_agents` from `[campaign_web_planner, campaign_web_searcher]` to `[campaign_web_planner, campaign_web_searcher_resilient]`.
+
+**Step 4: Implement — trend_researcher.** Mirror it in `creative_agent/sub_agents/trend_researcher/agent.py`: add `gs_web_searcher_resilient` wrapping `gs_web_searcher` (`output_key="gs_web_search_insights"`), and swap it into `gs_sequential_planner.sub_agents`.
+
+**Step 5: Run tests to verify they pass.**
+Run: `PYTHONPATH="$PWD" uv run pytest tests/test_pipeline_structure.py -v`
+Expected: PASS (new test + all existing structure tests still green — check none asserted the old last-sub-agent name).
+
+**Step 6:** `uvx ruff check … && uvx ruff format …` on the two modified files. Do not commit yet.
+
+### Task 1.3: Wrap the third producer (`enhanced_combined_searcher`)  *(TDD)*
+
+**Files:**
+- Modify: `creative_agent/agent.py` (wrap `enhanced_combined_searcher` inside `combined_research_pipeline`)
+- Test: `tests/test_pipeline_structure.py`
+
+**Step 1: Update the existing order test.** `test_combined_research_pipeline_sub_agent_order` currently asserts the 3rd entry is `enhanced_combined_searcher`. Change that entry to the wrapper name `enhanced_combined_searcher_resilient`, and add an assertion that it is a `RetryUntilKeyAgent` with `output_key == "refined_web_search_insights"`.
+
+**Step 2: Run to verify fail.** `PYTHONPATH="$PWD" uv run pytest tests/test_pipeline_structure.py -v` → FAIL.
+
+**Step 3: Implement.** In `creative_agent/agent.py`, import `RetryUntilKeyAgent` (`from .retry_agent import RetryUntilKeyAgent`), and after `enhanced_combined_searcher` add a `RetryUntilKeyAgent` wrapping it (`output_key="refined_web_search_insights"`, `max_attempts=3`). Replace it in `combined_research_pipeline.sub_agents`. Keep the existing `{refined_web_search_insights?}` guard in `combined_report_composer` — retry reduces the chance of degrade; the guard + `__retry_exhausted` marker cover the residual.
+
+**Step 4: Verify.** `PYTHONPATH="$PWD" uv run pytest tests/test_pipeline_structure.py -v` → PASS. Ruff clean.
+
+### Task 1.4: Full offline test sweep + lint gate
+
+**Step 1:** `uv run pytest tests/test_retry_agent.py -q` → 3 passed.
+**Step 2:** `PYTHONPATH="$PWD" uv run pytest tests/ -q` → all green (or, for creds-gated files, run on the deploy host / CI; record which were skipped).
+**Step 3:** `uvx ruff check .` → clean.
+
+### Task 1.5: Live isolated smoke (gate before merge)
+
+**Step 1:** Deploy the branch to a no-traffic tagged revision (auto-mode-allowed — private service, no auth change):
+`gcloud run deploy trend-trawler-api --source . --region us-central1 --project hybrid-vertex --no-traffic --tag retry-harden`
+
+**Step 2:** Drive a full `creative_agent` run against the tag URL using the SA-impersonation + base-URL-audience recipe (memory note). Pick a campaign likely to exercise research.
+
+**Step 3:** Verify in logs: run completes through `combined_report_composer`; if any `*_resilient` retried, its `WARNING ... left '<key>' empty ... retrying` and (on recovery) `INFO ... populated ... on attempt N` appear. No `KeyError: Context variable not found`. Record the revision + outcome.
+
+**Step 4:** Clean up the tagged revision when done (leftover `exp-harden`/`retry-harden` no-traffic revisions).
+
+---
+
+# Workstream 3 — Observable guardrails (do before #2)
+
+Cheap, and it makes the bigger #2 refactor safe to land. Ensure every consumer of a research `output_key` degrades **observably** rather than crashing, and that retry-exhaustion is surfaced.
+
+### Task 3.1: Make `merge_planners` tolerate a missing input observably  *(TDD)*
+
+**Files:**
+- Modify: `creative_agent/agent.py` (`merge_planners`, lines ~35-68)
+- Test: `tests/test_pipeline_structure.py` (or a new `tests/test_research_guardrails.py`)
+
+**Design:** `merge_planners` reads `{campaign_web_search_insights}` and `{gs_web_search_insights}` — both required. Even with retry (#1), exhaustion can leave one unset. Two options; **prefer (a)**:
+- **(a)** Make both optional in the instruction (`{campaign_web_search_insights?}` / `{gs_web_search_insights?}`) AND add an instruction clause: "If either report is empty, note the gap explicitly in the brief and synthesize from what is present." This keeps the run alive and makes the gap visible in the output.
+- (b) A `before_agent_callback` that backfills a sentinel string ("_(campaign research unavailable this run)_") into any missing key. More moving parts; only if (a) underperforms.
+
+**Step 1:** Write a test that inspects `merge_planners.instruction` for the trailing-`?` optional markers on both keys (mirror how existing tests assert instruction content, or assert substring presence). RED.
+**Step 2:** Implement (a). **Step 3:** GREEN. **Step 4:** Ruff.
+
+### Task 3.2: Surface `__retry_exhausted` in run output / eval
+
+**Files:**
+- Modify: whichever persistence/logging path is most visible — e.g. include any `*__retry_exhausted` state keys in the run's final summary log, or add them to the eval report metadata (`creative_eval`), so an exhausted producer is queryable, not just buried in logs.
+
+**Step 1:** Decide the surfacing point (log line in a persistence tool vs. eval metadata). **Step 2:** TDD a small unit test asserting the marker is included when present. **Step 3:** Implement + GREEN + ruff.
+
+---
+
+# Workstream 2 — Split tool-use from synthesis (durable #2)
+
+The root cause: each producer does `google_search` (tool use) **and** final-text synthesis in one `Agent` under a thinking budget — the model can spend its whole output budget on tool calls/thinking and never emit the summary. Splitting removes the pressure: a **tool-free** synthesizer has nothing competing for its output budget, so it reliably emits text.
+
+Do this **last**, with #1 (retry) and #3 (guardrails) already protecting the pipeline, and land it **one producer at a time** behind the isolated-revision harness.
+
+**Pattern (apply per producer):** replace the single searcher `Agent` with a 2-step `SequentialAgent`:
+1. **Searcher** — `tools=[google_search]`, `BuiltInPlanner`, keeps `after_agent_callback=collect_research_sources_callback` (grounding capture). Its job is only to run the queries; it writes the **raw** findings to a new intermediate key, e.g. `campaign_search_raw`.
+2. **Synthesizer** — **no tools**, `include_contents="none"`, reads `{campaign_search_raw}`, writes the original `output_key` (`campaign_web_search_insights`) in the required report structure. Tool-free → reliable final text.
+
+The `RetryUntilKeyAgent` from Workstream 1 then wraps the **synthesizer** (or the whole 2-step sequence) — retry stays cheap because a tool-free re-run is fast and doesn't re-spend search calls if it wraps only the synthesizer.
+
+### Task 2.1: Prove the split reduces empty-output — spike + decision
+
+**Step 1:** Spike the split on **one** producer (`campaign_web_searcher` → `campaign_web_searcher` + `campaign_web_synthesizer`) on a scratch branch. Deploy to a tagged revision; run N campaigns; compare empty-`output_key` / retry-attempt rates vs. the un-split (Workstream-1-only) baseline from Task 1.5.
+**Step 2:** If the split materially lowers retries, proceed to roll out to all three; if not, stop at Workstream 1 + 3 and record why.
+
+### Task 2.2–2.4: Roll out the split per producer  *(TDD each)*
+
+For `campaign_researcher`, `trend_researcher`, and `enhanced_combined_searcher` respectively:
+- **Files:** the producer's `agent.py`; `tests/test_pipeline_structure.py`.
+- **Step 1:** Test that the searcher sequence exposes the original `output_key` via the synthesizer, the searcher has no `output_schema`/writes the raw key, and the pipeline sub-agent order/names are updated. RED.
+- **Step 2:** Implement the searcher/synthesizer split; re-point `RetryUntilKeyAgent` at the synthesizer; update `collect_research_sources_callback` placement (stays on the searcher). GREEN.
+- **Step 3:** Ruff; then one isolated-revision smoke per producer before moving to the next.
+
+---
+
+## Verification (whole plan)
+
+- **Offline gate (no creds / CI-safe):** `uv run pytest tests/test_retry_agent.py -q` (3 passed) + `PYTHONPATH="$PWD" uv run pytest tests/ -q` green (creds-gated files run on deploy host/CI); `uvx ruff check .` clean.
+- **Structure:** the two unguarded producers and `enhanced_combined_searcher` are `RetryUntilKeyAgent`-wrapped with matching `output_key`s; pipeline order tests updated and green.
+- **Live (isolated tagged revision, prod untouched):** a full `creative_agent` run completes through `combined_report_composer` with **no** `KeyError: Context variable not found`; retry WARN/INFO lines appear when a producer flakes; any exhaustion is visible via `__retry_exhausted`. After #2, retry-attempt rate drops vs. the Workstream-1 baseline.
+
+## Risks / call-outs
+
+- **One-parent constraint:** wrapping requires removing the producer from its old parent's `sub_agents`; forgetting leaves a dangling/duplicate parent — the structure tests catch this.
+- **`collect_research_sources_callback` on retry:** re-runs each attempt; it dedups by URL (`url_to_short_id`) so re-collection is idempotent. In #2 it stays on the searcher (which still calls `google_search`).
+- **`max_attempts` cost:** each retry is a full model turn (quota: pro 5 RPM / image 2 RPM — see memory). Keep `max_attempts=3`; retries are rare (only on the flake). #2 further lowers the rate.
+- **Existing structure tests:** several assert exact sub-agent names/order — update them in lockstep or they'll fail.
+- **ADK deprecation:** `SequentialAgent`/`ParallelAgent` are deprecated; this plan keeps using them (migration to `Workflow` is blocked). Track separately.
+
+## Out of scope (deferred)
+
+`Workflow` migration off deprecated `SequentialAgent`/`ParallelAgent`; changing the research model/thinking-budget knobs (unproven band-aid — the bounded `thinking_budget=512` on `enhanced_combined_searcher` from `exp/harden-enhanced-combined-searcher` is neither validated nor part of this plan); reworking the citation/grounding pipeline.
+
+## Execution
+
+Subagent-driven in this session (fresh subagent per task, review between tasks), OR a parallel session with `superpowers:executing-plans`. Live steps (1.5, 2.x smokes) use the isolated tagged-revision harness and pause for the user where auth/IAM is involved. A single PR opened when the user asks. Ordering: **Workstream 1 → 3 → 2.**

--- a/docs/plans/2026-07-14-ws1-retry-wrapper.md
+++ b/docs/plans/2026-07-14-ws1-retry-wrapper.md
@@ -1,0 +1,75 @@
+# Workstream 1 — Retry-on-Empty Wrapper Rollout (Implementation Plan)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire the already-built `RetryUntilKeyAgent` around all three flaky research producers, plus a minimal downstream guard, so a producer that finishes without writing its `output_key` no longer crashes the `creative_agent` / `interactive_creative` run — it retries, and on total exhaustion degrades observably instead of raising `KeyError: Context variable not found`.
+
+**Architecture:** Each flaky producer is an `Agent` that runs `google_search` under a `BuiltInPlanner` *and* synthesizes the final text in one turn; on gemini-3 it intermittently emits no final text, leaving its `output_key` unset. `RetryUntilKeyAgent` (a custom `BaseAgent`, `creative_agent/retry_agent.py`) re-runs a wrapped producer until its `output_key` is populated (bounded by `max_attempts`). We wrap each producer *inside its existing parent pipeline* (raw producer symbol preserved, wrapper named `*_resilient`), and additionally make the one **unguarded** consumer (`merge_planners`) tolerate a missing input. Because `interactive_creative` and the CRF fan-out worker both reuse the same shared pipeline objects, the fix propagates to every caller with no per-caller change.
+
+**Tech Stack:** google-adk 2.4.0 (`BaseAgent`, `SequentialAgent`, `InMemoryRunner`), pytest (offline; `asyncio.run`, no pytest-asyncio), `uv` / `uvx ruff`, the isolated tagged-Cloud-Run-revision smoke harness.
+
+---
+
+## Context (why this change)
+
+`creative_agent`'s research pipeline is brittle: any producer that finishes without writing its `output_key` makes the next agent's `{var}` instruction template raise `KeyError` and abort the whole run *after* the expensive research. This has caused real production crashes (PR #69 patched only the third landmine downstream). `retry_config`/`INFRA_RETRY` does **not** help — it retries only infra exceptions (transient 5xx), not an empty-but-successful model turn.
+
+The retry primitive was researched (Task #88) and prototyped: **PR #70** (branch `exp/retry-until-key-prototype`) already contains `creative_agent/retry_agent.py` (`RetryUntilKeyAgent`) and `tests/test_retry_agent.py` (3 tests green via a real `InMemoryRunner`). A custom `BaseAgent` was chosen because `LoopAgent`/`SequentialAgent`/`ParallelAgent` are all `@deprecated` in google-adk 2.4.0 in favor of `Workflow`, which cannot yet be an `LlmAgent` sub-agent.
+
+This plan **builds on PR #70's branch** — the wrapper module and its unit tests already exist and need no changes. WS1 adds the wiring, the guard, and the structural tests. (WS3 = richer observability, WS2 = split tool-use from synthesis; both are separate, later plans.)
+
+**Scope decisions (confirmed with the user):**
+- **Wrap all three** producers (the two unguarded landmines + `enhanced_combined_searcher`, whose downstream is already guarded — retrying it is a quality gain, not just crash-safety).
+- **Wrapper + minimal guard**: also make `merge_planners`' two inputs optional so WS1 *fully* eliminates the crash (retry recovers the common case; exhaustion degrades observably).
+
+---
+
+## Where `RetryUntilKeyAgent` is applied — the three wrap sites
+
+All three producers share the identical shape: `tools=[google_search]` + `BuiltInPlanner(include_thoughts=False)` + `after_agent_callback=callbacks.collect_research_sources_callback`. Each is wrapped **in place inside its existing parent** (the parent's other sub-agents and order are unchanged; only the flaky producer entry is replaced by its `*_resilient` wrapper).
+
+| Site | Producer (raw symbol kept) | File | `output_key` | Parent pipeline (entry replaced) | Consumer of the key | Guard status |
+|---|---|---|---|---|---|---|
+| 1 | `campaign_web_searcher` | `creative_agent/sub_agents/campaign_researcher/agent.py` | `campaign_web_search_insights` | `ca_sequential_planner` (entry `[1]`) | `merge_planners` | **UNGUARDED** → guard added in Task 5 |
+| 2 | `gs_web_searcher` | `creative_agent/sub_agents/trend_researcher/agent.py` | `gs_web_search_insights` | `gs_sequential_planner` (entry `[1]`) | `merge_planners` | **UNGUARDED** → guard added in Task 5 |
+| 3 | `enhanced_combined_searcher` | `creative_agent/agent.py` | `refined_web_search_insights` | `combined_research_pipeline` (entry `[2]`) | `combined_report_composer` | already guarded by `{refined_web_search_insights?}` (#69) |
+
+**Propagation (why this is enough):** `interactive_creative/agent.py` imports the *same* `combined_research_pipeline` object and exposes it as an `AgentTool`; `creative_agent`'s own root exposes it the same way; the CRF fan-out worker invokes `creative_agent` on Agent Engine. None of them reference the inner producers directly. So wrapping the leaves fixes all three entry points at once, provided `combined_research_pipeline`'s identity, sub-agent **order**, and asserted `output_key`s stay intact.
+
+**Naming rule:** keep the raw producer symbol bound to the raw `Agent` (so `test_output_keys_are_set_correctly` still imports it and checks its `output_key`); name each wrapper `<producer>_resilient`. Keep `after_agent_callback` on the **inner** producer (grounding capture must run per search attempt; `collect_research_sources_callback` dedups by URL so re-runs are idempotent).
+
+---
+
+## Tasks (as executed)
+
+- **Task 1 — baseline gate:** `uv run pytest tests/test_retry_agent.py -q` (3 passed) + `uvx ruff check creative_agent/retry_agent.py` clean.
+- **Task 2 — wrap `campaign_web_searcher`:** TDD `test_campaign_producer_is_retry_wrapped`; add `campaign_web_searcher_resilient`, swap into `ca_sequential_planner`.
+- **Task 3 — wrap `gs_web_searcher`:** TDD `test_trend_producer_is_retry_wrapped`; add `gs_web_searcher_resilient`, swap into `gs_sequential_planner`.
+- **Task 4 — wrap `enhanced_combined_searcher`:** update `test_combined_research_pipeline_sub_agent_order` (entry `[2]` → `enhanced_combined_searcher_resilient` + `RetryUntilKeyAgent` assertions); add `enhanced_combined_searcher_resilient`, swap into `combined_research_pipeline`.
+- **Task 5 — guard `merge_planners`:** TDD `test_merge_planners_inputs_are_optional`; change the two `<CONTEXT>` refs to `{campaign_web_search_insights?}` / `{gs_web_search_insights?}` and add a "Research Gaps" instruction clause.
+- **Task 6 — full offline gate:** `tests/test_retry_agent.py` 3 passed; full suite green; `uvx ruff check .` clean.
+- **Task 7 — live isolated smoke:** deploy branch as no-traffic tagged revision `retry-ws1`; drive a full `creative_agent` run; verify it reaches `combined_report_composer` with no `KeyError`, retry WARN/INFO lines on a flake.
+- **Task 8 — finalize:** mirror this plan; commit wiring + tests; retitle PR #70 for WS1 + mark ready; update memory.
+
+---
+
+## Verification (end-to-end)
+
+- **Offline (CI-safe):** `uv run pytest tests/test_retry_agent.py -q` (3 passed) + `PYTHONPATH="$PWD" uv run pytest tests/ -q` green; `uvx ruff check .` clean.
+- **Structure:** all three producers are `*_resilient` `RetryUntilKeyAgent`s with matching `output_key`s; `combined_research_pipeline` order test updated and green; `merge_planners` inputs optional.
+- **Live (isolated tagged revision, prod untouched):** a full `creative_agent` run completes through `combined_report_composer` with no `KeyError`; retry WARN/INFO lines appear on a flake; a forced/observed exhaustion leaves the run alive with a `Research Gaps` note + `<key>__retry_exhausted` marker.
+
+## Risks / call-outs
+
+- **Sub-agent order is load-bearing.** Replace *in place* at the same index; don't reorder. Task 4's test enforces this.
+- **One-parent constraint.** Wrapping removes the raw producer from its parent's `sub_agents` and inserts the wrapper instead; leaving both would give the producer two parents. The structure tests catch it.
+- **Resumability (`interactive_creative`).** `RetryUntilKeyAgent` does not emit ADK agent-state/resume events. Safe because the research pipeline runs to completion inside one pre-checkpoint `AgentTool` call (checkpoints are at the orchestrator level, after research). If a checkpoint is ever added *inside* research, the wrapper would need resumability support — flag, don't fix here.
+- **Retry cost.** Each retry is a full producer turn on `worker_model` (`gemini-3.5-flash`, higher RPM than pro/image). `max_attempts=3` is a safe default; retries fire only on the flake.
+- **`include_contents` on retry.** `campaign_web_searcher` / `gs_web_searcher` use the default (history included), so a retry sees the prior failed attempt's events (harmless); `enhanced_combined_searcher` uses `include_contents="none"` (clean retry).
+
+## Out of scope (later workstreams)
+
+- **WS3:** richer observable guardrails (surface `<key>__retry_exhausted` in the eval report / final summary; sentinel-text backfill).
+- **WS2:** split each producer into a tool-using searcher + a tool-free synthesizer (the durable root-cause fix).
+- **ADK deprecation:** migrating off deprecated `SequentialAgent`/`ParallelAgent` to `Workflow` (blocked — can't nest under `LlmAgent`).
+- Tuning research thinking budgets (the unproven `thinking_budget=512` experiment on `exp/harden-enhanced-combined-searcher`).

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -36,14 +36,20 @@ def test_creative_agent_root_output_key_not_set():
 
 def test_combined_research_pipeline_sub_agent_order():
     from creative_agent.agent import combined_research_pipeline
+    from creative_agent.retry_agent import RetryUntilKeyAgent
 
     names = [a.name for a in combined_research_pipeline.sub_agents]
     assert names == [
         "merge_parallel_insights",
         "combined_web_evaluator",
-        "enhanced_combined_searcher",
+        "enhanced_combined_searcher_resilient",
         "combined_report_composer",
     ]
+
+    w = combined_research_pipeline.sub_agents[2]
+    assert isinstance(w, RetryUntilKeyAgent)
+    assert w.output_key == "refined_web_search_insights"
+    assert w.sub_agents[0].output_key == "refined_web_search_insights"
 
 
 def test_ad_creative_pipeline_sub_agent_order():
@@ -70,6 +76,46 @@ def test_parallel_planner_has_both_researchers():
     names = [a.name for a in parallel_planner_agent.sub_agents]
     assert "gs_sequential_planner" in names
     assert "ca_sequential_planner" in names
+
+
+def test_campaign_producer_is_retry_wrapped():
+    """campaign_web_searcher must be wrapped in a RetryUntilKeyAgent so an empty
+    turn (no `campaign_web_search_insights`) retries instead of crashing
+    merge_planners."""
+    from creative_agent.retry_agent import RetryUntilKeyAgent
+    from creative_agent.sub_agents.campaign_researcher.agent import (
+        ca_sequential_planner,
+    )
+
+    w = ca_sequential_planner.sub_agents[-1]
+    assert isinstance(w, RetryUntilKeyAgent)
+    assert w.output_key == "campaign_web_search_insights"
+    assert w.sub_agents[0].output_key == "campaign_web_search_insights"
+
+
+def test_trend_producer_is_retry_wrapped():
+    """gs_web_searcher must be wrapped in a RetryUntilKeyAgent so an empty turn
+    (no `gs_web_search_insights`) retries instead of crashing merge_planners."""
+    from creative_agent.retry_agent import RetryUntilKeyAgent
+    from creative_agent.sub_agents.trend_researcher.agent import (
+        gs_sequential_planner,
+    )
+
+    w = gs_sequential_planner.sub_agents[-1]
+    assert isinstance(w, RetryUntilKeyAgent)
+    assert w.output_key == "gs_web_search_insights"
+    assert w.sub_agents[0].output_key == "gs_web_search_insights"
+
+
+def test_merge_planners_inputs_are_optional():
+    """merge_planners' two research inputs must use the optional `{var?}` syntax so
+    a producer that exhausted its retries (key unset) degrades observably instead of
+    raising KeyError: Context variable not found. Matched pair for the wrappers."""
+    from creative_agent.agent import merge_planners
+
+    instr = merge_planners.instruction
+    assert "{campaign_web_search_insights?}" in instr
+    assert "{gs_web_search_insights?}" in instr
 
 
 def test_output_keys_are_set_correctly():

--- a/tests/test_retry_agent.py
+++ b/tests/test_retry_agent.py
@@ -1,0 +1,128 @@
+"""Tests for RetryUntilKeyAgent — the retry-on-empty producer wrapper.
+
+These are fully offline: a fake inner agent (`_FlakyProducer`) deterministically
+emits no `output_key` for its first N runs, then a real value. Everything is
+driven through a real `InMemoryRunner`, so the wrapper's state check exercises
+the genuine ADK state-delta application path (runner appends each yielded event
+and merges its `state_delta` into `session.state` before the wrapper resumes) —
+not a mock of it. No model calls, no GCP credentials, no quota.
+
+Coroutines are driven with `asyncio.run` (no pytest-asyncio in this project,
+see tests/test_crf_worker_async.py).
+"""
+
+import asyncio
+import logging
+from typing import AsyncGenerator
+
+from google.adk.agents import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event
+from google.adk.events.event_actions import EventActions
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+from pydantic import PrivateAttr
+
+from creative_agent.retry_agent import RetryUntilKeyAgent
+
+
+class _FlakyProducer(BaseAgent):
+    """Test double for a research producer with an ``output_key``.
+
+    Emits an event carrying no ``state_delta`` (simulating a model turn that
+    returns only tool calls / thinking and no final text, leaving output_key
+    unset) for its first ``fail_first`` runs, then an event that writes the
+    real value. ``runs`` counts how many times it was invoked.
+    """
+
+    output_key: str
+    value: str = "REAL_REPORT"
+    fail_first: int = 0
+    _runs: int = PrivateAttr(default=0)
+
+    @property
+    def runs(self) -> int:
+        return self._runs
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        self._runs += 1
+        if self._runs <= self.fail_first:
+            # No state_delta → output_key never written (the landmine).
+            yield Event(invocation_id=ctx.invocation_id, author=self.name)
+            return
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            actions=EventActions(state_delta={self.output_key: self.value}),
+        )
+
+
+def _run(agent: BaseAgent):
+    """Drive ``agent`` once through an InMemoryRunner; return the final session."""
+    runner = InMemoryRunner(agent=agent, app_name="retry_test")
+
+    async def _go():
+        session = await runner.session_service.create_session(
+            app_name="retry_test", user_id="u"
+        )
+        async for _ in runner.run_async(
+            user_id="u",
+            session_id=session.id,
+            new_message=types.Content(role="user", parts=[types.Part(text="go")]),
+        ):
+            pass
+        return await runner.session_service.get_session(
+            app_name="retry_test", user_id="u", session_id=session.id
+        )
+
+    return asyncio.run(_go())
+
+
+def test_recovers_after_empty_attempts():
+    """Producer fails twice, succeeds on the third — wrapper retries and recovers."""
+    producer = _FlakyProducer(name="producer", output_key="report", fail_first=2)
+    wrapper = RetryUntilKeyAgent(
+        name="retry_wrapper", sub_agents=[producer], output_key="report", max_attempts=3
+    )
+
+    session = _run(wrapper)
+
+    assert producer.runs == 3
+    assert session.state.get("report") == "REAL_REPORT"
+
+
+def test_no_retry_when_first_attempt_succeeds():
+    """A healthy producer runs exactly once — no wasted retries."""
+    producer = _FlakyProducer(name="producer", output_key="report", fail_first=0)
+    wrapper = RetryUntilKeyAgent(
+        name="retry_wrapper", sub_agents=[producer], output_key="report", max_attempts=3
+    )
+
+    session = _run(wrapper)
+
+    assert producer.runs == 1
+    assert session.state.get("report") == "REAL_REPORT"
+
+
+def test_bounded_and_observable_when_never_populated(caplog):
+    """Producer never populates — wrapper stops at max_attempts and logs loudly.
+
+    The wrapper must NOT corrupt ``output_key`` with a placeholder (that would
+    feed garbage to the downstream consumer). Instead it leaves the key unset,
+    records an observable ``<key>__retry_exhausted`` marker, and logs an error —
+    mitigation #3 (observable guardrail), not silent degradation.
+    """
+    producer = _FlakyProducer(name="producer", output_key="report", fail_first=99)
+    wrapper = RetryUntilKeyAgent(
+        name="retry_wrapper", sub_agents=[producer], output_key="report", max_attempts=3
+    )
+
+    with caplog.at_level(logging.ERROR):
+        session = _run(wrapper)
+
+    assert producer.runs == 3
+    assert session.state.get("report") is None
+    assert session.state.get("report__retry_exhausted") is True
+    assert any("report" in r.message for r in caplog.records)


### PR DESCRIPTION
## Workstream 1 — Retry-on-Empty Wrapper Rollout

Wires the `RetryUntilKeyAgent` (prototyped earlier in this branch) around **all three** flaky research producers so a producer that finishes without writing its `output_key` no longer crashes the run with `KeyError: Context variable not found` — it retries (bounded), and on total exhaustion degrades observably instead of aborting.

### What changed
- **`campaign_web_searcher` → `campaign_web_searcher_resilient`** (in `ca_sequential_planner`)
- **`gs_web_searcher` → `gs_web_searcher_resilient`** (in `gs_sequential_planner`)
- **`enhanced_combined_searcher` → `enhanced_combined_searcher_resilient`** (`combined_research_pipeline[2]`)
- **`merge_planners`** inputs made optional (`{campaign_web_search_insights?}` / `{gs_web_search_insights?}`) + a "Research Gaps" clause — the matched pair for retry-exhaustion, so the one previously-unguarded consumer degrades observably.

Raw producer symbols are preserved (wrappers named `*_resilient`); each `after_agent_callback` stays on the inner producer (grounding capture runs per attempt; the callback dedups by URL, so retries are idempotent). `interactive_creative` and the CRF worker reuse the same shared pipeline objects, so the fix propagates to every caller.

### Verification
- **Offline:** `tests/test_retry_agent.py` (3) + full suite **194 passed**; `ruff check .` clean. New structural tests: `test_campaign_producer_is_retry_wrapped`, `test_trend_producer_is_retry_wrapped`, updated `test_combined_research_pipeline_sub_agent_order`, `test_merge_planners_inputs_are_optional`.
- **Live isolated smoke:** deployed as no-traffic tag `retry-ws1`; a full `creative_agent` run (trend "silent hiking") completed end-to-end — research PDF → ad copies → visuals → eval (100% pass) → GCS + BigQuery — with **zero `KeyError` and zero warnings/errors**. Producers succeeded first-try, so the wrapper stayed silent as designed.

Plan: `docs/plans/2026-07-14-ws1-retry-wrapper.md`. Follow-ups (separate): WS3 richer observability, WS2 split tool-use from synthesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)