### PR TITLE
feat: split research producers into searcher + synthesizer (WS2)

### DIFF
--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -160,27 +160,62 @@ combined_web_evaluator = Agent(
 )
 
 
+# WS2 split — searcher half: runs the follow-up google_search and emits RAW
+# findings only. Separating tool-use from synthesis is the durable fix for the
+# empty-turn flake. Grounding metadata lives on this turn, so
+# `collect_research_sources_callback` stays here.
 enhanced_combined_searcher = Agent(
     model=build_gemini(config.worker_model),
     name="enhanced_combined_searcher",
     include_contents="none",
-    description="Executes follow-up searches and integrates new findings.",
+    description="Executes follow-up searches and returns raw new findings.",
     planner=BuiltInPlanner(
         thinking_config=types.ThinkingConfig(include_thoughts=False)
     ),
-    instruction="""Role: You are a focused Research Refinement Specialist. 
-    Your sole task is to execute the final set of follow-up web queries and generate a concise summary of only the *new* insights discovered.
+    instruction="""Role: You are a web research operator executing a final set of follow-up queries.
 
     <INSTRUCTIONS>
     1.  **Access Queries:** The follow-up queries are contained within the `combined_research_evaluation` JSON object in the `follow_up_queries` key.
     2.  **Execute Search:** Use the `google_search` tool to execute **all** queries from the `follow_up_queries` list.
-    3.  **Synthesize New Findings:** Synthesize the results of these new searches into a **brief, structured summary** focusing *only* on the information that addresses the identified research gap or opportunity.
+    3.  **Report RAW Findings:** For each query, list the concrete new facts, quotes, entities, dates, and numbers you found, grouped by query. Do NOT write a polished summary and do NOT omit specifics — the next agent needs the raw material. Plain text with light markdown is fine.
     </INSTRUCTIONS>
 
     <CONTEXT>
         <combined_research_evaluation>
         {combined_research_evaluation}
         </combined_research_evaluation>
+    </CONTEXT>
+
+    ---
+    ### Final Instruction
+    **Output the raw new findings grouped by query. Preserve specifics. Do not editorialize into a final summary — that is the next agent's job.**
+    """,
+    tools=[google_search],
+    output_key="refined_web_search_raw",
+    after_agent_callback=callbacks.collect_research_sources_callback,
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
+)
+
+
+# WS2 split — synthesizer half: tool-free / planner-free. Reads the raw follow-up
+# findings (optional `{...?}` so an empty searcher turn degrades to empty synthesis
+# and the wrapper retries the whole pair rather than raising KeyError inside it) and
+# shapes them into the existing "New Research Findings" summary.
+refined_web_synthesizer = Agent(
+    model=build_gemini(config.worker_model),
+    name="refined_web_synthesizer",
+    include_contents="none",
+    description="Synthesizes the raw follow-up findings into a concise new-insights summary.",
+    instruction="""Role: You are a focused Research Refinement Specialist. Your sole task is to turn the raw follow-up findings into a concise summary of only the *new* insights discovered.
+
+    <INSTRUCTIONS>
+    Synthesize **only** the data in <refined_web_search_raw> into a **brief, structured summary** focusing *only* on the information that addresses the identified research gap or opportunity.
+    </INSTRUCTIONS>
+
+    <CONTEXT>
+        <refined_web_search_raw>
+        {refined_web_search_raw?}
+        </refined_web_search_raw>
     </CONTEXT>
 
     <OUTPUT_FORMAT>
@@ -192,20 +227,26 @@ enhanced_combined_searcher = Agent(
     </OUTPUT_FORMAT>
 
     """,
-    tools=[google_search],
     output_key="refined_web_search_insights",
-    after_agent_callback=callbacks.collect_research_sources_callback,
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
 
+refined_search_and_synthesize = SequentialAgent(
+    name="refined_search_and_synthesize",
+    description="Runs the follow-up web search then synthesizes the new findings.",
+    sub_agents=[enhanced_combined_searcher, refined_web_synthesizer],
+)
 
-# Retry-on-empty: enhanced_combined_searcher (google_search + thinking) intermittently
-# returns no final text, leaving `refined_web_search_insights` unset. combined_report_composer
-# already guards this with `{refined_web_search_insights?}`, but retrying recovers the
-# refinement (a quality gain) instead of silently dropping it. Re-run until populated (bounded).
+
+# Retry-on-empty: if the searcher OR synthesizer emits no final text (leaving
+# `refined_web_search_insights` unset), re-run the whole pair until populated
+# (bounded). combined_report_composer already guards with
+# `{refined_web_search_insights?}`, but retrying recovers the refinement (a
+# quality gain) instead of silently dropping it. The wrapper runs only
+# sub_agents[0], so we wrap the SequentialAgent pair.
 enhanced_combined_searcher_resilient = RetryUntilKeyAgent(
     name="enhanced_combined_searcher_resilient",
-    sub_agents=[enhanced_combined_searcher],
+    sub_agents=[refined_search_and_synthesize],
     output_key="refined_web_search_insights",
     max_attempts=3,
 )

--- a/creative_agent/sub_agents/campaign_researcher/agent.py
+++ b/creative_agent/sub_agents/campaign_researcher/agent.py
@@ -93,20 +93,24 @@ campaign_web_planner = Agent(
 )
 
 
+# WS2 split — searcher half: runs google_search and emits RAW findings only.
+# Separating tool-use from synthesis is the durable fix for the empty-turn flake:
+# no single turn has to think, search, AND author a long report. Grounding
+# metadata lives on this turn, so `collect_research_sources_callback` stays here.
 campaign_web_searcher = Agent(
     model=build_gemini(config.worker_model),
     name="campaign_web_searcher",
+    include_contents="none",
     description="Performs the crucial first pass of web research about the campaign guide.",
     planner=BuiltInPlanner(
         thinking_config=types.ThinkingConfig(include_thoughts=False)
     ),
-    instruction="""Role: You are a strategic market research analyst and synthesis expert. 
-    Your primary goal is to transform raw web search data into an actionable, structured report for marketers.
+    instruction="""Role: You are a web research operator gathering raw market-research material.
 
     <INSTRUCTIONS>
     1.  **Access Queries:** Retrieve the list of web search queries from the `initial_campaign_queries` input in the <CONTEXT> block.
-    2.  **Execute Research:** Use the `google_search` tool to exhaustively execute **all** retrieved queries. The raw output of this tool call is the data you must work with.
-    3.  **Synthesize and Structure:** Synthesize **only** the data obtained from the search tool and present it as a detailed, structured, and objective summary following the <REPORT_STRUCTURE> block.
+    2.  **Execute Research:** Use the `google_search` tool to exhaustively execute **all** retrieved queries.
+    3.  **Report RAW Findings:** For each query, list the concrete facts, quotes, entities, competitors, data points, and sentiment you found, grouped by query. Do NOT write a polished report and do NOT omit specifics — the next agent needs the raw material to synthesize from. Plain text with light markdown is fine.
     </INSTRUCTIONS>
 
     <CONTEXT>
@@ -116,7 +120,47 @@ campaign_web_searcher = Agent(
     </CONTEXT>
 
     <CONTEXT_GUIDANCE>
-    The research should primarily focus on extracting insights related to:
+    Capture material relevant to:
+    -   **Target Audience Insights:** Pain points, current conversations, unmet needs, or aspirations relevant to the product. Assume the given `target_audience` description is correct.
+    -   **Product/Market Landscape:** Competitive alternatives, common use cases, and general market sentiment around the product category.
+    -   **Key Selling Point Validation:** Evidence, data, or public opinion that supports or contradicts the effectiveness of the intended key selling points.
+    -   **Cultural Relevance:** Current trends or cultural shifts that could impact campaign messaging.
+    </CONTEXT_GUIDANCE>
+
+    ---
+    ### Final Instruction
+    **Output the raw findings grouped by query. Preserve specifics (names, competitors, numbers, direct quotes). Do not editorialize into a final report — that is the next agent's job.**
+    """,
+    tools=[google_search],
+    output_key="campaign_web_search_raw",
+    after_agent_callback=callbacks.collect_research_sources_callback,
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
+)
+
+
+# WS2 split — synthesizer half: tool-free / planner-free. Reads the raw findings
+# (optional `{...?}` so an empty searcher turn degrades to empty synthesis and the
+# wrapper retries the whole pair rather than raising KeyError inside it) and shapes
+# them into the existing consumer-facing report.
+campaign_web_synthesizer = Agent(
+    model=build_gemini(config.worker_model),
+    name="campaign_web_synthesizer",
+    include_contents="none",
+    description="Synthesizes the raw campaign findings into a structured strategic report.",
+    instruction="""Role: You are a strategic market research analyst and synthesis expert. Your goal is to transform the raw web-research findings into an actionable, structured report for marketers.
+
+    <INSTRUCTIONS>
+    Synthesize **only** the data in <campaign_web_search_raw> and present it as a detailed, structured, and objective summary following the <REPORT_STRUCTURE> block.
+    </INSTRUCTIONS>
+
+    <CONTEXT>
+        <campaign_web_search_raw>
+        {campaign_web_search_raw?}
+        </campaign_web_search_raw>
+    </CONTEXT>
+
+    <CONTEXT_GUIDANCE>
+    The report should primarily focus on insights related to:
     -   **Target Audience Insights:** Pain points, current conversations, unmet needs, or aspirations relevant to the product. Remember, you should assume the given `target_audience` description is correct.
     -   **Product/Market Landscape:** Competitive alternatives, common use cases, and general market sentiment around the product category.
     -   **Key Selling Point Validation:** Evidence, data, or public opinion that supports or contradicts the effectiveness of the intended key selling points.
@@ -137,18 +181,24 @@ campaign_web_searcher = Agent(
     **CRITICAL RULE 1: Do not include any of the raw search query results, links, or tool output. The output must be the final, synthesized report.**
     **CRITICAL RULE 2: Output the synthesized report entirely in Markdown format, using Level 2 Headings (`##`) for the main sections listed in <REPORT_STRUCTURE>.**
     """,
-    tools=[google_search],
     output_key="campaign_web_search_insights",
-    after_agent_callback=callbacks.collect_research_sources_callback,
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
 
-# Retry-on-empty: campaign_web_searcher (google_search + thinking) intermittently
-# returns no final text, leaving `campaign_web_search_insights` unset and crashing
-# merge_planners. Re-run until the key is populated (bounded by max_attempts).
+campaign_search_and_synthesize = SequentialAgent(
+    name="campaign_search_and_synthesize",
+    description="Runs the raw web search then synthesizes the campaign report.",
+    sub_agents=[campaign_web_searcher, campaign_web_synthesizer],
+)
+
+# Retry-on-empty: if the searcher OR synthesizer emits no final text (leaving
+# `campaign_web_search_insights` unset), re-run the whole pair until the key is
+# populated (bounded by max_attempts). The wrapper runs only sub_agents[0], so we
+# wrap the SequentialAgent pair — the searcher re-runs too, which is the only way
+# to recover a searcher that itself emptied.
 campaign_web_searcher_resilient = RetryUntilKeyAgent(
     name="campaign_web_searcher_resilient",
-    sub_agents=[campaign_web_searcher],
+    sub_agents=[campaign_search_and_synthesize],
     output_key="campaign_web_search_insights",
     max_attempts=3,
 )

--- a/creative_agent/sub_agents/trend_researcher/agent.py
+++ b/creative_agent/sub_agents/trend_researcher/agent.py
@@ -87,19 +87,25 @@ gs_web_planner = Agent(
 )
 
 
+# WS2 split — searcher half: runs google_search and emits RAW findings only.
+# Separating tool-use from synthesis is the durable fix for the empty-turn flake:
+# no single turn has to think, search, AND author a long report (which burned the
+# output budget → MAX_TOKENS → empty `output_key`). Grounding metadata lives on
+# this turn, so `collect_research_sources_callback` stays here.
 gs_web_searcher = Agent(
     model=build_gemini(config.worker_model),
     name="gs_web_searcher",
+    include_contents="none",
     description="Performs the crucial first pass of web research about the trending Search terms.",
     planner=BuiltInPlanner(
         thinking_config=types.ThinkingConfig(include_thoughts=False)
     ),
-    instruction="""Role: You are a cultural trend analyst and synthesis expert. Your primary goal is to transform raw web search data about a trending topic into an urgent, actionable, and culturally relevant summary for marketers.
+    instruction="""Role: You are a web research operator gathering raw material about a trending topic.
 
     <INSTRUCTIONS>
     1.  **Access Queries:** Retrieve the list of web search queries from the `initial_gs_queries` input in the <CONTEXT> block.
-    2.  **Execute Research:** Use the `google_search` tool to exhaustively execute **all** retrieved queries. The raw output of this tool call is the data you must synthesize.
-    3.  **Synthesize and Structure:** Synthesize **only** the data obtained from the search tool and present it as a detailed, structured, and objective trend report following the <REPORT_STRUCTURE> block.
+    2.  **Execute Research:** Use the `google_search` tool to exhaustively execute **all** retrieved queries.
+    3.  **Report RAW Findings:** For each query, list the concrete facts, quotes, entities, dates, numbers, and sentiment you found, grouped by query. Do NOT write a polished report and do NOT omit specifics — the next agent needs the raw material to synthesize from. Plain text with light markdown is fine.
     </INSTRUCTIONS>
 
     <CONTEXT>
@@ -107,7 +113,47 @@ gs_web_searcher = Agent(
         {initial_gs_queries}
         </initial_gs_queries>
     </CONTEXT>
-    
+
+    <CONTEXT_GUIDANCE>
+    Capture material that lets a strategist judge:
+    -   **Immediacy and Trajectory:** current status of the trend — peaking or gaining momentum?
+    -   **Cultural Narrative:** the central story, sentiment (positive/negative), key quotes or memes.
+    -   **Audience Resonance:** how the trend connects to the target audience's values, language, or social platforms.
+    </CONTEXT_GUIDANCE>
+
+    ---
+    ### Final Instruction
+    **Output the raw findings grouped by query. Preserve specifics (names, dates, numbers, direct quotes). Do not editorialize into a final report — that is the next agent's job.**
+    """,
+    tools=[google_search],
+    output_key="gs_web_search_raw",
+    after_agent_callback=callbacks.collect_research_sources_callback,
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
+)
+
+
+# WS2 split — synthesizer half: tool-free / planner-free. Reads the raw findings
+# (optional `{...?}`: if the searcher empty-turned, degrade to empty synthesis so
+# the wrapper retries the whole pair rather than raising KeyError inside it) and
+# shapes them into the existing consumer-facing report. This is the reliable shape
+# already proven by merge_planners (never flakes).
+gs_web_synthesizer = Agent(
+    model=build_gemini(config.worker_model),
+    name="gs_web_synthesizer",
+    include_contents="none",
+    description="Synthesizes the raw trend findings into a structured cultural report.",
+    instruction="""Role: You are a cultural trend analyst and synthesis expert. Your goal is to transform the raw web-research findings about a trending topic into an urgent, actionable, and culturally relevant summary for marketers.
+
+    <INSTRUCTIONS>
+    Synthesize **only** the data in <gs_web_search_raw> and present it as a detailed, structured, and objective trend report following the <REPORT_STRUCTURE> block.
+    </INSTRUCTIONS>
+
+    <CONTEXT>
+        <gs_web_search_raw>
+        {gs_web_search_raw?}
+        </gs_web_search_raw>
+    </CONTEXT>
+
     <CONTEXT_GUIDANCE>
     The research synthesis must focus on providing marketers with timely, strategic insight. Specifically, prioritize:
     -   **Immediacy and Trajectory:** What is the current status of the trend? Is it peaking, or is it gaining momentum?
@@ -115,7 +161,6 @@ gs_web_searcher = Agent(
     -   **Audience Resonance:** How does the trend connect to the target audience's values, language, or social platforms? What is the *potential* for this trend to intersect with the campaign?
     </CONTEXT_GUIDANCE>
 
-    
     <REPORT_STRUCTURE>
     Your output must be a single, detailed, easy-to-read report sectioned with bold headings. The report should contain the following specific sections:
 
@@ -124,26 +169,31 @@ gs_web_searcher = Agent(
     3.  **Marketing Opportunity Analysis:** (**CRITICAL:** Identify 2-3 specific, actionable ways the trend could be leveraged to create culturally relevant messaging for the campaign, specifically considering the target audience.)
     </REPORT_STRUCTURE>
 
-    
     ---
     ### Final Instruction
     **CRITICAL RULE 1: Do not include any of the raw search query results, links, or tool output. The output must be the final, synthesized report.**
     **CRITICAL RULE 2: Output the synthesized report entirely in Markdown format, using Level 2 Headings (`##`) for the main sections listed in <REPORT_STRUCTURE>.**
     """,
-    tools=[google_search],
     output_key="gs_web_search_insights",
-    after_agent_callback=callbacks.collect_research_sources_callback,
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
 
 # 4.  **Risk Assessment:** (Identify any potential pitfalls, controversies, or negative associations linked to the trend that marketers must be aware of.)
 
-# Retry-on-empty: gs_web_searcher (google_search + thinking) intermittently
-# returns no final text, leaving `gs_web_search_insights` unset and crashing
-# merge_planners. Re-run until the key is populated (bounded by max_attempts).
+gs_search_and_synthesize = SequentialAgent(
+    name="gs_search_and_synthesize",
+    description="Runs the raw web search then synthesizes the trend report.",
+    sub_agents=[gs_web_searcher, gs_web_synthesizer],
+)
+
+# Retry-on-empty: if the searcher OR synthesizer emits no final text (leaving
+# `gs_web_search_insights` unset), re-run the whole pair until the key is
+# populated (bounded by max_attempts). The wrapper runs only sub_agents[0], so we
+# wrap the SequentialAgent pair — the searcher re-runs too, which is the only way
+# to recover a searcher that itself emptied.
 gs_web_searcher_resilient = RetryUntilKeyAgent(
     name="gs_web_searcher_resilient",
-    sub_agents=[gs_web_searcher],
+    sub_agents=[gs_search_and_synthesize],
     output_key="gs_web_search_insights",
     max_attempts=3,
 )

--- a/docs/plans/2026-07-14-ws2-split-producers.md
+++ b/docs/plans/2026-07-14-ws2-split-producers.md
@@ -1,0 +1,186 @@
+# Workstream 2 — Split Research Producers (searcher + synthesizer) — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate the intermittent "empty-turn" flake at its root by splitting each of the **four** combined `google_search`+thinking+synthesis research producers (three in `creative_agent` + `trend_scout`'s `understand_trends_agent`) into two agents — a tool-using **searcher** (runs `google_search`, emits raw findings) and a tool-free **synthesizer** (shapes the raw findings into the existing report, no tools/no planner) — while preserving the WS1 retry safety net and the WS3 observability surfaces.
+
+**Architecture:** For each producer, replace the single `Agent(planner+tools=[google_search]→output_key)` with `SequentialAgent[X_searcher → X_synthesizer]`, wrapped by the existing `RetryUntilKeyAgent` (now watching the synthesizer's key). The searcher writes a new intermediate `*_raw` key; the synthesizer reads `{*_raw?}` and writes the existing consumer-facing `*_insights` key. Neither turn does "think + search + author a full report" at once, which is what burned the output budget and left the key unset. Keep the retry wrapper (belt-and-suspenders) so the `*__retry_exhausted` markers that WS3's warnings / `research_gaps` / HTML banner depend on still fire.
+
+**Tech Stack:** google-adk 2.x (`Agent`, `SequentialAgent`, `BuiltInPlanner`, `RetryUntilKeyAgent`, `{var?}` optional templates), pydantic v2, pytest (offline `test_retry_agent.py` + creds-gated `test_pipeline_structure.py`), `uv` / `uvx ruff`, the isolated tagged-Cloud-Run-revision smoke harness + SA-impersonation auth recipe.
+
+---
+
+## Context (why this change)
+
+The four research producers (three in `creative_agent`, one in `trend_scout`) each do `google_search` + a thinking `BuiltInPlanner` + full-report synthesis in **one** agent turn. On gemini-3 this intermittently finishes with no final text (thinking burns the output budget → MAX_TOKENS, or the turn returns only tool-call parts), leaving the `output_key` unset and crashing the next consumer's `{var}` template with `KeyError`. (`trend_scout`'s `understand_trends_agent` → `info_gtrends` is the same anti-pattern; PR #71 already wrapped it in `RetryUntilKeyAgent` and guarded its consumer with `{info_gtrends?}`, so it fits WS2's split cleanly.) WS1 (PR #70) added a bounded retry-on-empty (`RetryUntilKeyAgent`) and WS3 (PR #72) surfaced exhaustion to the user — both are **mitigations**. WS2 is the **durable root-cause fix**: separate tool-use from synthesis so no single turn has to think, search, and author a long report simultaneously. A tool-free synthesizer that only reads state and emits text is the reliable shape already proven by `merge_planners` (never retry-wrapped, never flakes).
+
+Design decision (confirmed with user): **keep the `RetryUntilKeyAgent` wrappers** as a safety net, wrapping the `[searcher → synthesizer]` pair. This preserves the exact external contract (same `*_insights` keys, same `*_resilient` names, same `*__retry_exhausted` markers WS3 consumes).
+
+**Branch base:** off `main` once the `#70 → #71 → #72` stack merges (preferred — `main` will then carry WS1 + trend_scout hardening + WS3). If starting before the stack lands, branch off `exp/ws3-observability` (the state this plan was explored against). Do NOT tangle with the independent `fix/trend-scout-pick-3-trends` branch.
+
+---
+
+## Key files (from exploration)
+
+Producers to split (each currently: `Agent(planner=BuiltInPlanner, tools=[google_search], output_key=…, after_agent_callback=collect_research_sources_callback, after_model_callback=log_empty_turn_finish_reason)`):
+- `creative_agent/sub_agents/trend_researcher/agent.py` — `gs_web_searcher` (`:90-137`) → `gs_web_search_insights`; wrapper `gs_web_searcher_resilient` (`:144-149`); in `gs_sequential_planner` (`:151-155`) = `[gs_web_planner, gs_web_searcher_resilient]`. Reads `{initial_gs_queries}`.
+- `creative_agent/sub_agents/campaign_researcher/agent.py` — `campaign_web_searcher` (`:96-144`) → `campaign_web_search_insights`; wrapper `:149-154`; in `ca_sequential_planner` (`:156-160`). Reads `{initial_campaign_queries}`.
+- `creative_agent/agent.py` — `enhanced_combined_searcher` (`:163-199`) → `refined_web_search_insights`; wrapper `enhanced_combined_searcher_resilient` (`:206-211`); in `combined_research_pipeline` (`:304-313`) at index 2. Reads `{combined_research_evaluation}`.
+- `trend_scout/agent.py` — `understand_trends_agent` (`:61-110`) → `info_gtrends`; wrapper `understand_trends_agent_resilient` (`:122-128`); exposed to the orchestrator as `AgentTool(agent=understand_trends_agent_resilient)` (`:248`), **not** inside a `SequentialAgent` parent. Reads `{raw_gtrends}`. Differs from the creative producers: **no** `collect_research_sources_callback` (trend_scout has no citation flow), and its output is a **JSON** object (`analyzed_trends`), not markdown. Consumer `pick_trends_agent` reads `{info_gtrends?}` (`:152`, already optional).
+
+Shared primitives (reuse, do NOT modify):
+- `agent_common/retry_agent.py` — `RetryUntilKeyAgent` runs `sub_agents[0].run_async(ctx)` and checks `ctx.session.state.get(output_key)`. **Wrapping a `SequentialAgent` as the sole sub_agent works unchanged** (verified): it runs the whole sequence, then reads the synthesizer's key. No change needed here.
+- `creative_agent/callbacks.py` — `collect_research_sources_callback` (`:130`, harvests `google_search` grounding → `sources`/`url_to_short_id`); `citation_replacement_callback` (`:192`, stays on `combined_report_composer`).
+- `agent_common/observability.py` — `log_empty_turn_finish_reason`, re-exported at `creative_agent/callbacks.py:28`.
+- `build_gemini(config.worker_model)` — `gemini-3.5-flash`; existing tool-free synthesizer to mirror: `merge_planners` (`creative_agent/agent.py:35-70`).
+
+Consumers (reads unchanged — synthesizers still write the same keys):
+- `merge_planners` reads `{campaign_web_search_insights?}` / `{gs_web_search_insights?}` (`agent.py:52-53`, already optional).
+- `combined_report_composer` reads `{refined_web_search_insights?}` (`agent.py:241`, already optional) + `{sources}` (`:253`).
+
+Tests:
+- `tests/test_retry_agent.py` — offline, `InMemoryRunner` + `_FlakyProducer` double; the oracle for the retry primitive.
+- `tests/test_pipeline_structure.py` — creds-gated (imports `creative_agent.agent` → module-level genai client). Asserts producer wiring at `:37-52`, `:81-93`, `:96-107`, `:121-149`, `:175-213`.
+- `tests/eval/evalsets/creative_agent_evalset.json` + `creative_eval_config.json` — judge only the **root** tool trajectory (`combined_research_pipeline`, …); the split is internal, so **eval trajectory is unaffected**.
+
+---
+
+## Tasks
+
+### Task 1: Prove `RetryUntilKeyAgent` retries a searcher+synthesizer *pair* *(TDD, offline)*
+**Files:** Test: `tests/test_retry_agent.py`.
+
+1. **Failing test** `test_retries_sequential_pair_until_synthesizer_populates`: build a fake searcher (`_FlakyProducer`-style `BaseAgent` writing an intermediate `*_raw` key) and a fake synthesizer (`BaseAgent` that reads `*_raw` from `ctx.session.state`; leaves the final key empty for the first N runs, then writes it). Wrap `SequentialAgent(sub_agents=[fake_searcher, fake_synth])` in `RetryUntilKeyAgent(sub_agents=[that_seq], output_key="report", max_attempts=3)`. Drive with the existing `_run(agent)` helper. Assert: the pair re-runs until `state["report"]` is populated, and on total failure `state["report__retry_exhausted"] is True`. Mirror the existing `_FlakyProducer` / `_run` setup verbatim.
+2. **Run → FAIL** (or as a lock confirming the primitive behaves): `export PATH="$HOME/.local/bin:$PATH"; cd /home/user/adk_pipe; uv run pytest tests/test_retry_agent.py -q`.
+3. **Implement:** no production change — this task *locks the primitive contract* the whole plan relies on (wrap-the-pair). If the test reveals the pair isn't retried as expected, STOP and reassess before Task 2.
+4. **Run → PASS.** `uvx ruff check tests/test_retry_agent.py`.
+
+### Task 2: Split `gs_web_searcher` → searcher + synthesizer *(TDD — the template for Tasks 3–4)*
+**Files:** Modify `creative_agent/sub_agents/trend_researcher/agent.py`; Test: `tests/test_pipeline_structure.py`.
+
+1. **Failing tests** in `test_pipeline_structure.py`:
+   - Update `test_trend_producer_is_retry_wrapped` (`:96-107`): `w = gs_sequential_planner.sub_agents[-1]` is still a `RetryUntilKeyAgent` with `output_key == "gs_web_search_insights"`, but now `w.sub_agents[0]` is a `SequentialAgent` whose **last** child has `output_key == "gs_web_search_insights"` and whose **first** child has `output_key == "gs_web_search_raw"` and `google_search` in `.tools`.
+   - New `test_gs_synthesizer_is_tool_free`: the synthesizer has no `tools`, no `planner`, and `after_model_callback is callbacks.log_empty_turn_finish_reason`.
+   - New `test_gs_searcher_keeps_source_collection`: the searcher's `after_agent_callback is callbacks.collect_research_sources_callback`.
+2. **Run → FAIL.**
+3. **Implement** — restructure the `gs_web_searcher` block:
+   ```python
+   gs_web_searcher = Agent(
+       model=build_gemini(config.worker_model),
+       name="gs_web_searcher",
+       include_contents="none",
+       description="Runs google_search for the trend queries and returns raw findings.",
+       planner=BuiltInPlanner(
+           thinking_config=types.ThinkingConfig(include_thoughts=False)
+       ),
+       instruction="""Role: You are a web research operator.
+       1. Read the queries in <initial_gs_queries>.
+       2. Use the `google_search` tool to run EVERY query.
+       3. Output the RAW findings: for each query, list the concrete facts,
+          quotes, entities, dates, and sentiment you found, grouped by query.
+          Do NOT write a polished report and do NOT omit specifics — the next
+          agent needs the raw material. Plain text / light markdown is fine.
+       <CONTEXT><initial_gs_queries>{initial_gs_queries}</initial_gs_queries></CONTEXT>
+       """,
+       tools=[google_search],
+       output_key="gs_web_search_raw",
+       after_agent_callback=callbacks.collect_research_sources_callback,
+       after_model_callback=callbacks.log_empty_turn_finish_reason,
+   )
+
+   gs_web_synthesizer = Agent(
+       model=build_gemini(config.worker_model),
+       name="gs_web_synthesizer",
+       include_contents="none",
+       description="Synthesizes the raw trend findings into a structured report.",
+       instruction="""Role: You are a cultural trend analyst and synthesis expert.
+       Transform the raw findings in <gs_web_search_raw> into the report below.
+       <CONTEXT><gs_web_search_raw>{gs_web_search_raw?}</gs_web_search_raw></CONTEXT>
+       <REPORT_STRUCTURE>
+       ## Trend Overview & Trajectory ...
+       ## Key Entities and Cultural Narrative ...
+       ## Marketing Opportunity Analysis ...  (2-3 actionable angles)
+       </REPORT_STRUCTURE>
+       CRITICAL: Output ONLY the synthesized report in Markdown (## headings).
+       Do not include raw links or tool output.
+       """,  # move the existing <REPORT_STRUCTURE> + <CONTEXT_GUIDANCE> text here verbatim
+       output_key="gs_web_search_insights",
+       after_model_callback=callbacks.log_empty_turn_finish_reason,
+   )
+
+   gs_search_and_synthesize = SequentialAgent(
+       name="gs_search_and_synthesize",
+       sub_agents=[gs_web_searcher, gs_web_synthesizer],
+   )
+
+   gs_web_searcher_resilient = RetryUntilKeyAgent(
+       name="gs_web_searcher_resilient",   # keep name: outer composition unchanged
+       sub_agents=[gs_search_and_synthesize],
+       output_key="gs_web_search_insights",
+       max_attempts=3,
+   )
+   ```
+   `gs_sequential_planner` (`:151-155`) is unchanged (`[gs_web_planner, gs_web_searcher_resilient]`). Move the existing `<REPORT_STRUCTURE>` and `<CONTEXT_GUIDANCE>` text into the synthesizer verbatim (keep quality); the searcher's old "do not include raw output" rule is inverted — it now emits raw findings.
+4. **Run → PASS.** `uvx ruff check … && uvx ruff format …`.
+
+### Task 3: Split `campaign_web_searcher` *(TDD — mirror Task 2)*
+**Files:** Modify `creative_agent/sub_agents/campaign_researcher/agent.py`; Test: `tests/test_pipeline_structure.py`.
+- Same pattern: `campaign_web_searcher` → `campaign_web_search_raw`; new `campaign_web_synthesizer` → `campaign_web_search_insights` (reads `{campaign_web_search_raw?}`, carries the existing `<REPORT_STRUCTURE>`: Target Audience & Behavioral Insights / Product Landscape & Competitive Context / Strategic Opportunities & Key Message Validation / Key Research Gaps); `campaign_search_and_synthesize` SequentialAgent; keep `campaign_web_searcher_resilient` name wrapping the pair. Update `test_campaign_producer_is_retry_wrapped` (`:81-93`) + add the two tool-free / source-collection asserts. `ca_sequential_planner` unchanged.
+
+### Task 4: Split `enhanced_combined_searcher` *(TDD — mirror Task 2)*
+**Files:** Modify `creative_agent/agent.py`; Test: `tests/test_pipeline_structure.py`.
+- `enhanced_combined_searcher` → `refined_web_search_raw` (reads `{combined_research_evaluation}`, runs `google_search` on the `follow_up_queries`, emits raw findings; keep `include_contents="none"`, keep `after_agent_callback=collect_research_sources_callback`). New `refined_web_synthesizer` → `refined_web_search_insights` (reads `{refined_web_search_raw?}`, carries the "New Research Findings" summary text). `refined_search_and_synthesize` SequentialAgent; keep `enhanced_combined_searcher_resilient` name wrapping the pair; `combined_research_pipeline` (`:304-313`) unchanged.
+- Update `test_combined_research_pipeline_sub_agent_order` (`:37-52`): index-2 name stays `enhanced_combined_searcher_resilient`; `w.sub_agents[0]` is now a `SequentialAgent`, last child `output_key == "refined_web_search_insights"`, first child `output_key == "refined_web_search_raw"`.
+- Update `test_output_keys_are_set_correctly` (`:121-149`): `enhanced_combined_searcher.output_key` is now `refined_web_search_raw`; add the synthesizer's `refined_web_search_insights`.
+
+### Task 5: Split `trend_scout`'s `understand_trends_agent` *(TDD — mirror Task 2, with trend_scout differences)*
+**Files:** Modify `trend_scout/agent.py`; Test: `tests/test_pipeline_structure.py`.
+- `understand_trends_searcher` → `info_gtrends_raw` (reads `{raw_gtrends}`; filter to the top 5–8 narrative-driven terms, run `google_search`, emit raw findings; keep `include_contents="none"`, keep the `BuiltInPlanner`, carry the existing `generate_content_config` labels; **NO** source-collection callback — trend_scout has none). New `understand_trends_synthesizer` → `info_gtrends` (reads `{info_gtrends_raw?}`, tool-free/planner-free, emits the existing **JSON** `analyzed_trends` structure verbatim). `understand_trends_search_and_synthesize` SequentialAgent; keep the `understand_trends_agent_resilient` **name and `description`** (AgentTool builds the orchestrator's tool declaration from them) wrapping the pair. The orchestrator `AgentTool(agent=understand_trends_agent_resilient)` wiring (`:248`) is unchanged.
+- Update `test_trend_scout_sub_agent_output_keys` (`:258-265`): the searcher writes `info_gtrends_raw`; add the synthesizer's `info_gtrends` (update the import from `understand_trends_agent` to the new searcher/synthesizer names).
+- Update `test_understand_trends_is_retry_wrapped` (`:268-284`): `matching[0].sub_agents[0]` is now a `SequentialAgent`; assert its **last** child `output_key == "info_gtrends"` and **first** child `output_key == "info_gtrends_raw"`.
+- `test_pick_trends_info_gtrends_optional` (`:287-294`) and `test_trend_scout_orchestrator_thinking_budget_is_bounded_nonzero` (`:297-310`) are unchanged.
+
+### Task 6: Restore callback-parity + confirm WS3 surfaces untouched *(TDD)*
+**Files:** Test: `tests/test_pipeline_structure.py`.
+- Add the three new creative synthesizers to `test_creative_model_agents_have_finish_reason_callback` (`:175-200`) and/or `test_creative_researcher_agents_have_finish_reason_callback` (`:202-213`) so every model agent still asserts `after_model_callback is callbacks.log_empty_turn_finish_reason` (searchers + synthesizers). Ensure the new trend_scout searcher + synthesizer also set `after_model_callback=callbacks.log_empty_turn_finish_reason` (as the current `understand_trends_agent` does).
+- Confirm `test_observability.py`, `test_creative_eval.py`, and `test_trend_scout_logging.py` still pass **unchanged** — the `*_insights`/`info_gtrends` keys and `*__retry_exhausted` markers are identical, so WS3's degradation surfaces are unaffected (the new `*_raw`/`info_gtrends_raw` keys are internal and not retry-wrapped individually, so they never produce an exhaustion marker).
+
+### Task 7: Full offline gate *(gate)*
+- `uv run pytest tests/test_retry_agent.py -q` → green (offline, no creds).
+- `PYTHONPATH="$PWD" uv run pytest tests/ -q` → green (note `test_pipeline_structure.py` is creds-gated — run with ADC on the deploy host / this session).
+- `uvx ruff check . && uvx ruff format --check .` → clean.
+
+### Task 8: Live smoke on an isolated tagged revision *(gate before PR ready)*
+- Deploy the branch as a no-traffic tagged revision (auto-mode-allowed — private service, no auth change): `gcloud run deploy trend-trawler-api --source . --region us-central1 --project hybrid-vertex --no-traffic --tag ws2-split`. Verify clean boot + `/list-apps` returns all 3 agents.
+- **creative_agent** run against the tag (SA-impersonation token, audience = base service URL; `POST /apps/creative_agent/users/{uid}/sessions` then `POST /run_sse`). **Verify:** research completes with a non-empty `combined_final_cited_report`; logs show **two** turns per producer (`*_searcher` then `*_synthesizer`) instead of one; **zero** `empty/abnormal model turn` warnings on the happy path; citations still render (`sources` populated, `<cite …/>` replaced); run finishes through eval → GCS → BQ.
+- **trend_scout** run against the tag (`/apps/trend_scout/...`). **Verify:** `info_gtrends` is produced across two turns (`understand_trends_searcher` → `understand_trends_synthesizer`); `pick_trends_agent` selects trends; `write_trends_to_bq` succeeds; zero empty-turn warnings; `trend_scout final state […]` summary shows `info_gtrends` present.
+- ADK eval trajectory is unchanged for both agents (splits are internal) — an `adk eval` run is optional confirmation, not required. Delete the tagged revision when done.
+
+### Task 9: Finalize *(only when the user asks to commit)*
+- Mirror this plan to `docs/plans/2026-07-14-ws2-split-producers.md`.
+- Commit per-task (conventional `feat(creative_agent):` / `test:`; **no `Co-Authored-By`**). Open a PR based on `main` (if `#70/#71/#72` merged) or stacked on `exp/ws3-observability`.
+- Update memory: `creative-agent-research-pipeline-brittleness` (mitigation #2 SHIPPED — the durable fix), `adk-retry-until-populated-research` (wrappers now guard searcher+synth pairs), `trend-scout-info-gtrends-landmine` (understand_trends_agent split resolves it), `adk-pipe-work-status`.
+
+---
+
+## Verification (end-to-end)
+
+- **Offline (CI-safe):** `test_retry_agent.py` proves `RetryUntilKeyAgent` retries a `SequentialAgent[searcher, synthesizer]` pair until the synthesizer's key populates, and records the exhaustion marker on total failure.
+- **Structure (creds-gated, deploy host / this session):** for each creative producer — the searcher has `google_search` + `collect_research_sources_callback` + writes `*_raw`; the synthesizer is tool-free/planner-free + reads `{*_raw?}` + writes `*_insights`; the `*_resilient` wrapper watches `*_insights` and wraps a `SequentialAgent[searcher, synthesizer]`; every model agent keeps `log_empty_turn_finish_reason`. For **trend_scout**: `understand_trends_searcher` (google_search, writes `info_gtrends_raw`, no source callback) + `understand_trends_synthesizer` (tool-free, reads `{info_gtrends_raw?}`, writes JSON `info_gtrends`), wrapped by `understand_trends_agent_resilient` (name+description preserved) inside the orchestrator's `AgentTool`.
+- **Degradation path unchanged:** `*_insights` keys + `*__retry_exhausted` markers identical → WS3 warnings / `research_gaps` / HTML banner still fire on exhaustion (`test_observability.py` + `test_creative_eval.py` unchanged).
+- **Live (isolated tag, prod untouched):** a full creative_agent run completes clean, logs two turns per producer, no empty-turn warnings, citations intact, eval + GCS + BQ succeed; a trend_scout run produces `info_gtrends` across two turns, picks trends, and writes to BQ.
+
+## Risks / call-outs
+
+- **`RetryUntilKeyAgent` only runs `sub_agents[0]`.** The split relies on wrapping the pair in a `SequentialAgent` (Task 1 locks this). Do NOT pass `sub_agents=[searcher, synthesizer]` to the wrapper directly — the synthesizer would never run.
+- **Synthesizer must read `{*_raw?}` (optional).** If the searcher empty-turns, `*_raw` is unset; a required `{*_raw}` would raise `KeyError` *inside* the retried sequence and propagate as an exception (crashing the run) instead of leaving `*_insights` empty for a clean retry. The `?` makes an empty searcher degrade to an empty synthesis → the wrapper retries the pair.
+- **Source collection must stay on the searcher.** `collect_research_sources_callback` reads `google_search` grounding metadata; the tool-free synthesizer has none. Keep it as the searcher's `after_agent_callback`; `citation_replacement_callback` stays on `combined_report_composer`. The `{sources}` state flow and `<cite source="src-N"/>` contract are unchanged.
+- **Retrying the pair re-runs `google_search`** (quota cost) on the rare retry — acceptable: post-split retries should be near-zero, and re-running the searcher is the only way to recover a searcher that itself emptied.
+- **Extra model turn per producer** (searcher + synthesizer vs. one combined) — a modest latency/token increase, offset by removing the retry storms and the KeyError crashes.
+- **trend_scout's producer sits in an `AgentTool`, not a `SequentialAgent` parent.** Keep the `understand_trends_agent_resilient` **name + `description`** so `AgentTool` builds the identical tool declaration the orchestrator already calls; the retry runs inside AgentTool's isolated sub-Runner (state-delta timing verified equivalent — see `[[trend-scout-info-gtrends-landmine]]`). Its synthesizer emits JSON (`analyzed_trends`), not markdown, and it has no source-collection callback.
+- **Creds-gating:** `test_pipeline_structure.py` imports build a module-level genai client; run structural tests with ADC. `test_retry_agent.py` is creds-free.
+
+## Out of scope (later)
+- Bounding the searcher's `thinking_budget` — the split is the fix; budget-tuning is a separate lever (and `thinking_budget=0` is a known MALFORMED_FUNCTION_CALL landmine when calling tools).
+- Splitting the non-search producers (`merge_planners`, `combined_web_evaluator`) — they are tool-free and reliable; their required-`{var}` consumers assume they never no-op.
+- Lowering the searcher/synthesizer `temperature` (e.g. trend_scout's `understand_trends_agent` carries `temperature=1.5`) — a separate tuning lever like the `pick_trends_agent` fix, not part of WS2's structural split.

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -49,7 +49,39 @@ def test_combined_research_pipeline_sub_agent_order():
     w = combined_research_pipeline.sub_agents[2]
     assert isinstance(w, RetryUntilKeyAgent)
     assert w.output_key == "refined_web_search_insights"
-    assert w.sub_agents[0].output_key == "refined_web_search_insights"
+
+    from google.adk.agents import SequentialAgent
+
+    pair = w.sub_agents[0]
+    assert isinstance(pair, SequentialAgent)
+    assert pair.sub_agents[0].output_key == "refined_web_search_raw"
+    assert pair.sub_agents[-1].output_key == "refined_web_search_insights"
+
+
+def test_refined_searcher_has_tool_synthesizer_is_tool_free():
+    from google.adk.tools import google_search
+    from creative_agent.agent import (
+        enhanced_combined_searcher,
+        refined_web_synthesizer,
+    )
+
+    assert google_search in enhanced_combined_searcher.tools
+    assert not refined_web_synthesizer.tools
+    assert refined_web_synthesizer.planner is None
+
+
+def test_refined_searcher_keeps_source_collection():
+    from creative_agent import callbacks
+    from creative_agent.agent import (
+        enhanced_combined_searcher,
+        refined_web_synthesizer,
+    )
+
+    assert (
+        enhanced_combined_searcher.after_agent_callback
+        is callbacks.collect_research_sources_callback
+    )
+    assert refined_web_synthesizer.after_agent_callback is None
 
 
 def test_ad_creative_pipeline_sub_agent_order():
@@ -79,10 +111,13 @@ def test_parallel_planner_has_both_researchers():
 
 
 def test_campaign_producer_is_retry_wrapped():
-    """campaign_web_searcher must be wrapped in a RetryUntilKeyAgent so an empty
-    turn (no `campaign_web_search_insights`) retries instead of crashing
-    merge_planners."""
+    """WS2: campaign_web_searcher is split into a tool-using searcher (writes
+    `campaign_web_search_raw`) + a tool-free synthesizer (writes
+    `campaign_web_search_insights`), wrapped as a SequentialAgent inside the
+    existing RetryUntilKeyAgent so an empty turn retries the pair instead of
+    crashing merge_planners."""
     from agent_common import RetryUntilKeyAgent
+    from google.adk.agents import SequentialAgent
     from creative_agent.sub_agents.campaign_researcher.agent import (
         ca_sequential_planner,
     )
@@ -90,13 +125,47 @@ def test_campaign_producer_is_retry_wrapped():
     w = ca_sequential_planner.sub_agents[-1]
     assert isinstance(w, RetryUntilKeyAgent)
     assert w.output_key == "campaign_web_search_insights"
-    assert w.sub_agents[0].output_key == "campaign_web_search_insights"
+
+    pair = w.sub_agents[0]
+    assert isinstance(pair, SequentialAgent)
+    assert pair.sub_agents[0].output_key == "campaign_web_search_raw"
+    assert pair.sub_agents[-1].output_key == "campaign_web_search_insights"
+
+
+def test_campaign_searcher_has_tool_synthesizer_is_tool_free():
+    from google.adk.tools import google_search
+    from creative_agent.sub_agents.campaign_researcher.agent import (
+        campaign_web_searcher,
+        campaign_web_synthesizer,
+    )
+
+    assert google_search in campaign_web_searcher.tools
+    assert not campaign_web_synthesizer.tools
+    assert campaign_web_synthesizer.planner is None
+
+
+def test_campaign_searcher_keeps_source_collection():
+    from creative_agent import callbacks
+    from creative_agent.sub_agents.campaign_researcher.agent import (
+        campaign_web_searcher,
+        campaign_web_synthesizer,
+    )
+
+    assert (
+        campaign_web_searcher.after_agent_callback
+        is callbacks.collect_research_sources_callback
+    )
+    assert campaign_web_synthesizer.after_agent_callback is None
 
 
 def test_trend_producer_is_retry_wrapped():
-    """gs_web_searcher must be wrapped in a RetryUntilKeyAgent so an empty turn
-    (no `gs_web_search_insights`) retries instead of crashing merge_planners."""
+    """WS2: gs_web_searcher is split into a tool-using searcher (writes
+    `gs_web_search_raw`) + a tool-free synthesizer (writes
+    `gs_web_search_insights`), wrapped as a SequentialAgent inside the existing
+    RetryUntilKeyAgent so an empty turn retries the pair instead of crashing
+    merge_planners."""
     from agent_common import RetryUntilKeyAgent
+    from google.adk.agents import SequentialAgent
     from creative_agent.sub_agents.trend_researcher.agent import (
         gs_sequential_planner,
     )
@@ -104,7 +173,41 @@ def test_trend_producer_is_retry_wrapped():
     w = gs_sequential_planner.sub_agents[-1]
     assert isinstance(w, RetryUntilKeyAgent)
     assert w.output_key == "gs_web_search_insights"
-    assert w.sub_agents[0].output_key == "gs_web_search_insights"
+
+    pair = w.sub_agents[0]
+    assert isinstance(pair, SequentialAgent)
+    assert pair.sub_agents[0].output_key == "gs_web_search_raw"
+    assert pair.sub_agents[-1].output_key == "gs_web_search_insights"
+
+
+def test_gs_searcher_has_tool_synthesizer_is_tool_free():
+    """The searcher runs google_search; the synthesizer is tool-free and
+    planner-free (its reliability is the whole point of the split)."""
+    from google.adk.tools import google_search
+    from creative_agent.sub_agents.trend_researcher.agent import (
+        gs_web_searcher,
+        gs_web_synthesizer,
+    )
+
+    assert google_search in gs_web_searcher.tools
+    assert not gs_web_synthesizer.tools
+    assert gs_web_synthesizer.planner is None
+
+
+def test_gs_searcher_keeps_source_collection():
+    """collect_research_sources_callback reads google_search grounding metadata,
+    so it must stay on the searcher (which has the tool), not the synthesizer."""
+    from creative_agent import callbacks
+    from creative_agent.sub_agents.trend_researcher.agent import (
+        gs_web_searcher,
+        gs_web_synthesizer,
+    )
+
+    assert (
+        gs_web_searcher.after_agent_callback
+        is callbacks.collect_research_sources_callback
+    )
+    assert gs_web_synthesizer.after_agent_callback is None
 
 
 def test_merge_planners_inputs_are_optional():
@@ -123,6 +226,7 @@ def test_output_keys_are_set_correctly():
         merge_planners,
         combined_web_evaluator,
         enhanced_combined_searcher,
+        refined_web_synthesizer,
         combined_report_composer,
         ad_copy_drafter,
         ad_copy_critic,
@@ -134,7 +238,8 @@ def test_output_keys_are_set_correctly():
     expected = [
         (merge_planners, "combined_web_search_insights"),
         (combined_web_evaluator, "combined_research_evaluation"),
-        (enhanced_combined_searcher, "refined_web_search_insights"),
+        (enhanced_combined_searcher, "refined_web_search_raw"),
+        (refined_web_synthesizer, "refined_web_search_insights"),
         (combined_report_composer, "combined_final_cited_report"),
         (ad_copy_drafter, "ad_copy_draft"),
         (ad_copy_critic, "ad_copy_critique"),
@@ -184,6 +289,7 @@ def test_creative_model_agents_have_finish_reason_callback():
         ca.merge_planners,
         ca.combined_web_evaluator,
         ca.enhanced_combined_searcher,
+        ca.refined_web_synthesizer,
         ca.combined_report_composer,
         ca.ad_copy_drafter,
         ca.ad_copy_critic,
@@ -200,16 +306,33 @@ def test_creative_model_agents_have_finish_reason_callback():
 
 
 def test_creative_researcher_agents_have_finish_reason_callback():
-    """The planner + searcher sub-agents (the flaky producers) also get the
-    finish_reason callback."""
+    """The planner + searcher + synthesizer sub-agents (both halves of each split
+    producer) all get the finish_reason callback (WS3 log parity)."""
     from creative_agent import callbacks
     from creative_agent.sub_agents.trend_researcher import agent as tr
     from creative_agent.sub_agents.campaign_researcher import agent as cr
 
-    for a in (tr.gs_web_planner, tr.gs_web_searcher):
+    for a in (tr.gs_web_planner, tr.gs_web_searcher, tr.gs_web_synthesizer):
         assert a.after_model_callback is callbacks.log_empty_turn_finish_reason
-    for a in (cr.campaign_web_planner, cr.campaign_web_searcher):
+    for a in (
+        cr.campaign_web_planner,
+        cr.campaign_web_searcher,
+        cr.campaign_web_synthesizer,
+    ):
         assert a.after_model_callback is callbacks.log_empty_turn_finish_reason
+
+
+def test_trend_scout_split_agents_have_finish_reason_callback():
+    """Both halves of trend_scout's split understand_trends producer keep the
+    finish_reason callback (WS3 log parity)."""
+    from agent_common import log_empty_turn_finish_reason
+    from trend_scout.agent import (
+        understand_trends_searcher,
+        understand_trends_synthesizer,
+    )
+
+    for a in (understand_trends_searcher, understand_trends_synthesizer):
+        assert a.after_model_callback is log_empty_turn_finish_reason
 
 
 def test_creative_root_has_final_state_summary():
@@ -256,21 +379,40 @@ def test_trend_scout_root_has_expected_tools():
 
 
 def test_trend_scout_sub_agent_output_keys():
+    """WS2: understand_trends_agent is split into a searcher (writes
+    `info_gtrends_raw`) + a synthesizer (writes JSON `info_gtrends`)."""
     from trend_scout.agent import (
-        understand_trends_agent,
+        understand_trends_searcher,
+        understand_trends_synthesizer,
         pick_trends_agent,
     )
 
-    assert understand_trends_agent.output_key == "info_gtrends"
+    assert understand_trends_searcher.output_key == "info_gtrends_raw"
+    assert understand_trends_synthesizer.output_key == "info_gtrends"
     assert pick_trends_agent.output_key == "selected_gtrends"
 
 
+def test_understand_trends_searcher_has_tool_synthesizer_is_tool_free():
+    """The searcher runs google_search under a thinking planner; the synthesizer
+    is tool-free / planner-free and emits the JSON analyzed_trends structure."""
+    from google.adk.tools import google_search
+    from trend_scout.agent import (
+        understand_trends_searcher,
+        understand_trends_synthesizer,
+    )
+
+    assert google_search in understand_trends_searcher.tools
+    assert not understand_trends_synthesizer.tools
+    assert understand_trends_synthesizer.planner is None
+
+
 def test_understand_trends_is_retry_wrapped():
-    """understand_trends_agent (google_search + thinking) intermittently emits no
-    final text, leaving `info_gtrends` unset and crashing pick_trends_agent. It
-    must be exposed to the orchestrator wrapped in a RetryUntilKeyAgent so an
-    empty turn retries instead of aborting the run."""
+    """WS2: understand_trends is split into searcher + synthesizer, wrapped as a
+    SequentialAgent inside the existing RetryUntilKeyAgent so an empty turn
+    retries the pair instead of crashing pick_trends_agent. The wrapper is still
+    exposed to the orchestrator as an AgentTool."""
     from agent_common import RetryUntilKeyAgent
+    from google.adk.agents import SequentialAgent
     from google.adk.tools.agent_tool import AgentTool
     from trend_scout.agent import root_agent
 
@@ -281,7 +423,11 @@ def test_understand_trends_is_retry_wrapped():
     ]
     matching = [a for a in wrapped if a.output_key == "info_gtrends"]
     assert matching, "no AgentTool wraps a RetryUntilKeyAgent producing info_gtrends"
-    assert matching[0].sub_agents[0].output_key == "info_gtrends"
+
+    pair = matching[0].sub_agents[0]
+    assert isinstance(pair, SequentialAgent)
+    assert pair.sub_agents[0].output_key == "info_gtrends_raw"
+    assert pair.sub_agents[-1].output_key == "info_gtrends"
 
 
 def test_pick_trends_info_gtrends_optional():

--- a/tests/test_retry_agent.py
+++ b/tests/test_retry_agent.py
@@ -19,6 +19,7 @@ from google.adk.agents import BaseAgent
 from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
+from google.adk.agents import SequentialAgent
 from google.adk.runners import InMemoryRunner
 from google.genai import types
 from pydantic import PrivateAttr
@@ -50,6 +51,66 @@ class _FlakyProducer(BaseAgent):
         self._runs += 1
         if self._runs <= self.fail_first:
             # No state_delta → output_key never written (the landmine).
+            yield Event(invocation_id=ctx.invocation_id, author=self.name)
+            return
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            actions=EventActions(state_delta={self.output_key: self.value}),
+        )
+
+
+class _RawSearcher(BaseAgent):
+    """Test double for the tool-using *searcher* half of a split producer.
+
+    Always writes an intermediate ``raw_key`` (simulating a healthy
+    google_search turn that emits raw findings). ``runs`` counts invocations.
+    """
+
+    raw_key: str
+    raw_value: str = "RAW_FINDINGS"
+    _runs: int = PrivateAttr(default=0)
+
+    @property
+    def runs(self) -> int:
+        return self._runs
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        self._runs += 1
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            actions=EventActions(state_delta={self.raw_key: self.raw_value}),
+        )
+
+
+class _FlakySynthesizer(BaseAgent):
+    """Test double for the tool-free *synthesizer* half of a split producer.
+
+    Reads ``raw_key`` from state (asserting the searcher ran first), then for
+    its first ``fail_first`` runs emits no ``output_key`` (the empty-turn
+    landmine), and thereafter writes the real value. ``runs`` counts invocations.
+    """
+
+    raw_key: str
+    output_key: str
+    value: str = "REAL_REPORT"
+    fail_first: int = 0
+    _runs: int = PrivateAttr(default=0)
+
+    @property
+    def runs(self) -> int:
+        return self._runs
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        self._runs += 1
+        # The searcher in the same sequence must have populated raw_key first.
+        assert ctx.session.state.get(self.raw_key) == "RAW_FINDINGS"
+        if self._runs <= self.fail_first:
             yield Event(invocation_id=ctx.invocation_id, author=self.name)
             return
         yield Event(
@@ -126,3 +187,51 @@ def test_bounded_and_observable_when_never_populated(caplog):
     assert session.state.get("report") is None
     assert session.state.get("report__retry_exhausted") is True
     assert any("report" in r.message for r in caplog.records)
+
+
+def test_retries_sequential_pair_until_synthesizer_populates():
+    """WS2: the wrapper watches a SequentialAgent[searcher, synthesizer] pair.
+
+    RetryUntilKeyAgent runs only ``sub_agents[0]``, so the split producer wraps
+    the [searcher, synthesizer] pair in a SequentialAgent and passes THAT as the
+    sole sub_agent. Each retry must re-run the whole sequence (searcher AND
+    synthesizer), not just the synthesizer, until the synthesizer writes the
+    consumer-facing key.
+    """
+    searcher = _RawSearcher(name="searcher", raw_key="report_raw")
+    synth = _FlakySynthesizer(
+        name="synth", raw_key="report_raw", output_key="report", fail_first=2
+    )
+    pair = SequentialAgent(name="search_and_synthesize", sub_agents=[searcher, synth])
+    wrapper = RetryUntilKeyAgent(
+        name="retry_wrapper", sub_agents=[pair], output_key="report", max_attempts=3
+    )
+
+    session = _run(wrapper)
+
+    # The whole pair re-ran three times: searcher runs each attempt too.
+    assert searcher.runs == 3
+    assert synth.runs == 3
+    assert session.state.get("report") == "REAL_REPORT"
+    assert session.state.get("report_raw") == "RAW_FINDINGS"
+
+
+def test_sequential_pair_exhaustion_is_observable():
+    """WS2: when the synthesizer never populates, the wrapped pair stops at
+    max_attempts, leaves the key unset, and records the retry-exhausted marker
+    (so WS3's degradation surfaces still fire on the split producer)."""
+    searcher = _RawSearcher(name="searcher", raw_key="report_raw")
+    synth = _FlakySynthesizer(
+        name="synth", raw_key="report_raw", output_key="report", fail_first=99
+    )
+    pair = SequentialAgent(name="search_and_synthesize", sub_agents=[searcher, synth])
+    wrapper = RetryUntilKeyAgent(
+        name="retry_wrapper", sub_agents=[pair], output_key="report", max_attempts=3
+    )
+
+    session = _run(wrapper)
+
+    assert searcher.runs == 3
+    assert synth.runs == 3
+    assert session.state.get("report") is None
+    assert session.state.get("report__retry_exhausted") is True

--- a/trend_scout/agent.py
+++ b/trend_scout/agent.py
@@ -2,7 +2,7 @@ import logging
 import warnings
 
 from google.genai import types
-from google.adk.agents import Agent
+from google.adk.agents import Agent, SequentialAgent
 from google.adk.planners import BuiltInPlanner
 from google.adk.tools.agent_tool import AgentTool
 from google.adk.tools import google_search
@@ -58,17 +58,21 @@ gather_trends_agent = Agent(
 )
 
 
-understand_trends_agent = Agent(
+# WS2 split — searcher half: filters the raw trends, runs google_search, and
+# emits RAW findings only. Separating tool-use from synthesis is the durable fix
+# for the empty-turn flake: one turn no longer has to think, search, AND author
+# the JSON briefing. trend_scout has no citation flow, so (unlike the creative
+# producers) there is NO source-collection callback here.
+understand_trends_searcher = Agent(
     model=build_gemini(config.worker_model),
-    name="understand_trends_agent",
+    name="understand_trends_searcher",
     include_contents="none",
     description="Conduct initial web research to briefly understand each trending topic",
     planner=BuiltInPlanner(
         thinking_config=types.ThinkingConfig(include_thoughts=False)
     ),
     instruction="""
-    You are a Cultural Trend Researcher. 
-    Your goal is to prepare a structured briefing for a creative strategist. You want to find topics that possess cultural, social, or entertainment value.
+    You are a Cultural Trend Researcher gathering raw material for a creative strategist. You want topics that possess cultural, social, or entertainment value.
 
     <CONTEXT>
         <raw_gtrends>
@@ -78,8 +82,44 @@ understand_trends_agent = Agent(
 
     ### Instructions
     1. **Filter:** Review the list in <raw_gtrends>. Select the top 5-8 terms that appear to be narrative-driven stories (news, memes, celebrity, sports, entertainment). Ignore searches about specific sporting events.
-    2. **Research:** Use the `google_search` tool to investigate *only* these selected terms. 
-    3. **Synthesize:** Create a JSON output summarizing the cultural context of these terms.
+    2. **Research:** Use the `google_search` tool to investigate *only* these selected terms.
+    3. **Report RAW Findings:** For each selected term, list the concrete facts, entities, dates, and the cultural/social angle you found. Do NOT format as final JSON and do NOT omit specifics — the next agent needs the raw material to structure. Plain text grouped by term is fine.
+    """,
+    generate_content_config=types.GenerateContentConfig(
+        temperature=1.5,
+        labels={
+            "agentic_wf": "trend_scout",
+            "agent": "trend_scout",
+            "subagent": "understand_trends_searcher",
+        },
+    ),
+    tools=[google_search],
+    output_key="info_gtrends_raw",
+    before_model_callback=callbacks.rate_limit_callback,
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
+)
+
+
+# WS2 split — synthesizer half: tool-free / planner-free. Reads the raw findings
+# (optional `{...?}` so an empty searcher turn degrades to empty synthesis and the
+# wrapper retries the whole pair rather than raising KeyError inside it) and shapes
+# them into the existing JSON `analyzed_trends` structure pick_trends_agent consumes.
+understand_trends_synthesizer = Agent(
+    model=build_gemini(config.worker_model),
+    name="understand_trends_synthesizer",
+    include_contents="none",
+    description="Synthesizes the raw trend findings into the structured JSON briefing.",
+    instruction="""
+    You are a Cultural Trend Researcher. Turn the raw findings below into a structured briefing for a creative strategist.
+
+    <CONTEXT>
+        <info_gtrends_raw>
+        {info_gtrends_raw?}
+        </info_gtrends_raw>
+    </CONTEXT>
+
+    ### Instructions
+    Synthesize **only** the data in <info_gtrends_raw> into a JSON object summarizing the cultural context of each term.
 
     ### Output Format
     Output *only* a valid JSON object with the list of analyzed trends. Do not output markdown.
@@ -100,29 +140,36 @@ understand_trends_agent = Agent(
         labels={
             "agentic_wf": "trend_scout",
             "agent": "trend_scout",
-            "subagent": "understand_trends_agent",
+            "subagent": "understand_trends_synthesizer",
         },
     ),
-    tools=[google_search],
     output_key="info_gtrends",
     before_model_callback=callbacks.rate_limit_callback,
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
 
+understand_trends_search_and_synthesize = SequentialAgent(
+    name="understand_trends_search_and_synthesize",
+    description="Runs the raw trend search then synthesizes the JSON briefing.",
+    sub_agents=[understand_trends_searcher, understand_trends_synthesizer],
+)
 
-# Retry-on-empty: understand_trends_agent runs google_search under a thinking
-# planner and synthesizes `info_gtrends` in one turn; on gemini-3 it intermittently
-# emits no final text, leaving the key unset and crashing pick_trends_agent with
-# `KeyError: Context variable not found`. Re-run until populated (bounded). It is
+
+# Retry-on-empty: if the searcher OR synthesizer emits no final text (leaving
+# `info_gtrends` unset), re-run the whole pair until populated (bounded), instead
+# of crashing pick_trends_agent with `KeyError: Context variable not found`. The
+# wrapper runs only sub_agents[0], so we wrap the SequentialAgent pair. It is
 # exposed to the orchestrator as an AgentTool, so the retry runs inside AgentTool's
 # isolated sub-Runner — state-delta timing across that boundary is identical to the
 # top-level case the wrapper was verified against (agent_tool.py forwards each inner
-# event's state_delta before our generator resumes). Set `description` so AgentTool
-# builds the same tool declaration the orchestrator already knows.
+# event's state_delta before our generator resumes). Keep the `name` + `description`
+# so AgentTool builds the same tool declaration the orchestrator already knows.
 understand_trends_agent_resilient = RetryUntilKeyAgent(
     name="understand_trends_agent_resilient",
-    description=understand_trends_agent.description,
-    sub_agents=[understand_trends_agent],
+    # Preserve the original tool-facing description so AgentTool builds the same
+    # declaration the orchestrator already calls (the searcher carries it verbatim).
+    description=understand_trends_searcher.description,
+    sub_agents=[understand_trends_search_and_synthesize],
     output_key="info_gtrends",
     max_attempts=3,
 )


### PR DESCRIPTION
## Workstream 2 — Split Research Producers (searcher + synthesizer)

**Durable root-cause fix for the intermittent "empty-turn" flake.** Each research producer used to run `google_search` + `BuiltInPlanner` thinking + full-report synthesis in **one** turn; on gemini-3 that intermittently emits no final text (thinking burns the output budget → `MAX_TOKENS`, or the turn returns only tool-call parts), leaving the `output_key` unset and crashing the next consumer's `{var}` template with `KeyError`.

WS1 (#70) added a bounded retry-on-empty and WS3 (#72) surfaced exhaustion to the user — both mitigations. **WS2 removes the cause:** separate tool-use from synthesis so no single turn has to think, search, and author a long report at once.

### What changed
Each of the **four** producers is split into a tool-using **searcher** (runs `google_search`, writes a new intermediate `*_raw` key) → tool-free / planner-free **synthesizer** (reads `{*_raw?}`, writes the existing consumer-facing key). The pair is wrapped in a `SequentialAgent` inside the **existing** `RetryUntilKeyAgent` (belt-and-suspenders).

| Producer | searcher → `*_raw` | synthesizer → existing key |
|---|---|---|
| trend_researcher | `gs_web_searcher` → `gs_web_search_raw` | `gs_web_synthesizer` → `gs_web_search_insights` |
| campaign_researcher | `campaign_web_searcher` → `campaign_web_search_raw` | `campaign_web_synthesizer` → `campaign_web_search_insights` |
| creative_agent | `enhanced_combined_searcher` → `refined_web_search_raw` | `refined_web_synthesizer` → `refined_web_search_insights` |
| trend_scout | `understand_trends_searcher` → `info_gtrends_raw` | `understand_trends_synthesizer` → `info_gtrends` (JSON) |

**External contract preserved:** same `*_resilient` wrapper names, same `*_insights` / `info_gtrends` keys, same `*__retry_exhausted` markers WS3 consumes. `collect_research_sources_callback` stays on the searcher (where grounding metadata lives); the synthesizer reads `{*_raw?}` optionally so an empty searcher turn degrades to empty synthesis and the wrapper retries the pair rather than raising `KeyError` inside the sequence. trend_scout's producer keeps its name + description so `AgentTool` builds the identical tool declaration.

### Testing
- **Offline (`test_retry_agent.py`):** two new cases prove `RetryUntilKeyAgent` re-runs a `SequentialAgent[searcher, synthesizer]` pair until the synthesizer populates the key, and records the exhaustion marker on total failure.
- **Structure (`test_pipeline_structure.py`):** for every producer — searcher has `google_search` + source-collection; synthesizer is tool-free/planner-free; the `*_resilient` wrapper watches the `*_insights` key and wraps the pair.
- **Full suite:** 235 passed, ruff clean.
- **WS3 surfaces untouched:** `test_observability.py`, `test_creative_eval.py`, `test_trend_scout_logging.py` unchanged and green.

### Live smoke (isolated tagged revision, 0% traffic — prod untouched)
- **trend_scout:** `info_gtrends_raw` (8.5 KB) → `info_gtrends` JSON (4.2 KB) → 3 trends picked → BQ + GCS + file writes OK.
- **creative_agent:** all 3 producers show both `*_raw` and `*_insights` populated; `sources`=79; citations fully resolved (`final_report_with_citations`: 0 raw `<cite>` tags, 39 markdown links); full pipeline research → PDF → ad copy → visuals → eval → GCS → HTML → BQ×2 all succeeded.
- **Both:** zero empty-turn warnings, zero errors, zero `__retry_exhausted` markers.

> **Stacked on `exp/ws3-observability` (#72).** Merge after the #70 → #71 → #72 stack lands; rebase onto `main` at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
