### PR TITLE
exp(trend_scout): retry-wrap understand_trends + debugging logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,10 @@ Fan-out pattern using two Cloud Run Function deployments from the same source (`
 
 ### Configuration
 
-Shared config lives in **`agent_common/`** (a lightweight, ADK-free package bundled into every deployed engine):
+Shared building blocks live in **`agent_common/`** (a lightweight package bundled into every deployed engine; it depends on `google-adk` but is deliberately free of any per-agent business logic, and no cloud function imports it):
 - `agent_common/config.py` — `BaseAgentConfiguration`, the single source of truth for the model names, rate-limit knobs, and GCP/BigQuery env vars. Each agent's `config.py` subclasses it (`ResearchConfiguration(BaseAgentConfiguration)`) and adds only its genuine differences (e.g. `trend_scout`'s `SetupConfiguration`), which is why the two agent configs no longer drift.
 - `agent_common/retry.py` — `build_infra_retry(extra_exceptions=(), max_attempts=3)`, the one place the ADK `RetryConfig` transient-exception list is defined (`creative_agent` passes the genai `ServerError`).
+- `agent_common/retry_agent.py` — `RetryUntilKeyAgent`, the retry-on-empty producer wrapper (re-runs a flaky `google_search`+thinking producer until its `output_key` is populated, bounded; degrades observably on exhaustion). Shared here so both `creative_agent` and `trend_scout` wrap producers without cross-importing each other's package.
 - `agent_common/locations.py` + `agent_common/models.py` — `MODEL_LOCATION` (default `global`) and `build_gemini(name)`, which pin every gemini-3.x call's serving location in code (Agent Engine *reserves* `GOOGLE_CLOUD_LOCATION`, so it can't be forced via deploy env vars).
 
 The bucket name comes from `GOOGLE_CLOUD_STORAGE_BUCKET` (the var deploy actually ships) — not the local-only `GCS_BUCKET_NAME`. Key settings:

--- a/agent_common/__init__.py
+++ b/agent_common/__init__.py
@@ -4,10 +4,12 @@ from agent_common.config import BaseAgentConfiguration
 from agent_common.locations import MODEL_LOCATION
 from agent_common.models import build_gemini
 from agent_common.retry import build_infra_retry
+from agent_common.retry_agent import RetryUntilKeyAgent
 
 __all__ = [
     "BaseAgentConfiguration",
     "MODEL_LOCATION",
     "build_gemini",
     "build_infra_retry",
+    "RetryUntilKeyAgent",
 ]

--- a/agent_common/retry_agent.py
+++ b/agent_common/retry_agent.py
@@ -1,11 +1,15 @@
 """Retry-on-empty wrapper for research producer agents.
 
+Shared across the agent packages (``creative_agent``, ``trend_scout``, …); lives
+in ``agent_common`` so any engine can wrap a flaky producer without pulling in an
+unrelated agent package. Import via ``from agent_common import RetryUntilKeyAgent``.
+
 ## Why this exists
 
-creative_agent's research pipeline is brittle: a producer agent that finishes
-*without* writing its ``output_key`` makes the next consumer's ``{var}``
-instruction template raise ``KeyError: Context variable not found`` and abort
-the whole run. google_search + thinking agents on gemini-3 hit this
+The research pipelines are brittle: a producer agent that finishes *without*
+writing its ``output_key`` makes the next consumer's ``{var}`` instruction
+template raise ``KeyError: Context variable not found`` and abort the whole run.
+google_search + thinking agents on gemini-3 hit this
 intermittently — they can burn the output budget "thinking" (MAX_TOKENS),
 return only tool-call parts, or emit a MALFORMED_FUNCTION_CALL, any of which
 leaves the final text (and thus the ``output_key``) empty.

--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -11,11 +11,10 @@ from google.adk.agents import Agent, SequentialAgent, ParallelAgent
 
 from .sub_agents.campaign_researcher.agent import ca_sequential_planner
 from .sub_agents.trend_researcher.agent import gs_sequential_planner
-from agent_common import build_gemini
+from agent_common import build_gemini, RetryUntilKeyAgent
 from .config import config, INFRA_RETRY
 from . import callbacks
 from . import tools
-from .retry_agent import RetryUntilKeyAgent
 from creative_eval.agent import creative_eval_agent
 
 

--- a/creative_agent/sub_agents/campaign_researcher/agent.py
+++ b/creative_agent/sub_agents/campaign_researcher/agent.py
@@ -7,10 +7,9 @@ from google.adk.tools import google_search
 from google.adk.planners import BuiltInPlanner
 from google.adk.agents import Agent, SequentialAgent
 
-from agent_common import build_gemini
+from agent_common import build_gemini, RetryUntilKeyAgent
 from ...config import config
 from ... import callbacks
-from ...retry_agent import RetryUntilKeyAgent
 
 
 # --- config ---

--- a/creative_agent/sub_agents/trend_researcher/agent.py
+++ b/creative_agent/sub_agents/trend_researcher/agent.py
@@ -7,10 +7,9 @@ from google.adk.tools import google_search
 from google.adk.planners import BuiltInPlanner
 from google.adk.agents import Agent, SequentialAgent
 
-from agent_common import build_gemini
+from agent_common import build_gemini, RetryUntilKeyAgent
 from ...config import config
 from ... import callbacks
-from ...retry_agent import RetryUntilKeyAgent
 
 
 # --- config ---

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -36,7 +36,7 @@ def test_creative_agent_root_output_key_not_set():
 
 def test_combined_research_pipeline_sub_agent_order():
     from creative_agent.agent import combined_research_pipeline
-    from creative_agent.retry_agent import RetryUntilKeyAgent
+    from agent_common import RetryUntilKeyAgent
 
     names = [a.name for a in combined_research_pipeline.sub_agents]
     assert names == [
@@ -82,7 +82,7 @@ def test_campaign_producer_is_retry_wrapped():
     """campaign_web_searcher must be wrapped in a RetryUntilKeyAgent so an empty
     turn (no `campaign_web_search_insights`) retries instead of crashing
     merge_planners."""
-    from creative_agent.retry_agent import RetryUntilKeyAgent
+    from agent_common import RetryUntilKeyAgent
     from creative_agent.sub_agents.campaign_researcher.agent import (
         ca_sequential_planner,
     )
@@ -96,7 +96,7 @@ def test_campaign_producer_is_retry_wrapped():
 def test_trend_producer_is_retry_wrapped():
     """gs_web_searcher must be wrapped in a RetryUntilKeyAgent so an empty turn
     (no `gs_web_search_insights`) retries instead of crashing merge_planners."""
-    from creative_agent.retry_agent import RetryUntilKeyAgent
+    from agent_common import RetryUntilKeyAgent
     from creative_agent.sub_agents.trend_researcher.agent import (
         gs_sequential_planner,
     )
@@ -180,7 +180,7 @@ def test_trend_scout_root_has_expected_tools():
     ]
     expected = [
         "gather_trends_agent",
-        "understand_trends_agent",
+        "understand_trends_agent_resilient",
         "pick_trends_agent",
         "save_search_trends_to_session_state",
         "save_session_state_to_gcs",
@@ -200,6 +200,35 @@ def test_trend_scout_sub_agent_output_keys():
 
     assert understand_trends_agent.output_key == "info_gtrends"
     assert pick_trends_agent.output_key == "selected_gtrends"
+
+
+def test_understand_trends_is_retry_wrapped():
+    """understand_trends_agent (google_search + thinking) intermittently emits no
+    final text, leaving `info_gtrends` unset and crashing pick_trends_agent. It
+    must be exposed to the orchestrator wrapped in a RetryUntilKeyAgent so an
+    empty turn retries instead of aborting the run."""
+    from agent_common import RetryUntilKeyAgent
+    from google.adk.tools.agent_tool import AgentTool
+    from trend_scout.agent import root_agent
+
+    wrapped = [
+        t.agent
+        for t in root_agent.tools
+        if isinstance(t, AgentTool) and isinstance(t.agent, RetryUntilKeyAgent)
+    ]
+    matching = [a for a in wrapped if a.output_key == "info_gtrends"]
+    assert matching, "no AgentTool wraps a RetryUntilKeyAgent producing info_gtrends"
+    assert matching[0].sub_agents[0].output_key == "info_gtrends"
+
+
+def test_pick_trends_info_gtrends_optional():
+    """pick_trends_agent must tolerate a missing info_gtrends (orchestrator-skip
+    or retry-exhaustion) via the optional `{info_gtrends?}` template syntax rather
+    than raising KeyError: Context variable not found."""
+    from trend_scout.agent import pick_trends_agent
+
+    assert "{info_gtrends?}" in pick_trends_agent.instruction
+    assert "{info_gtrends}" not in pick_trends_agent.instruction
 
 
 def test_trend_scout_orchestrator_thinking_budget_is_bounded_nonzero():

--- a/tests/test_retry_agent.py
+++ b/tests/test_retry_agent.py
@@ -23,7 +23,7 @@ from google.adk.runners import InMemoryRunner
 from google.genai import types
 from pydantic import PrivateAttr
 
-from creative_agent.retry_agent import RetryUntilKeyAgent
+from agent_common import RetryUntilKeyAgent
 
 
 class _FlakyProducer(BaseAgent):

--- a/tests/test_trend_scout_logging.py
+++ b/tests/test_trend_scout_logging.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 
 from google.genai import types
 from google.adk.models.llm_response import LlmResponse
+from google.adk.sessions.state import State
 
 from trend_scout import callbacks
 
@@ -87,9 +88,15 @@ def test_partial_streaming_chunk_is_ignored(caplog):
 
 
 def test_final_state_summary_flags_missing_key(caplog):
+    # Use a real ADK State, not a plain dict: State supports .get()/__contains__
+    # but NOT iteration, so `for k in state` raises `KeyError: 0`. A dict here
+    # would be a false oracle (it was — this crashed live on 2026-07-14).
     ctx = SimpleNamespace(
         invocation_id="inv-2",
-        state={"raw_gtrends": ["a", "b"], "info_gtrends__retry_exhausted": True},
+        state=State(
+            value={"raw_gtrends": ["a", "b"], "info_gtrends__retry_exhausted": True},
+            delta={},
+        ),
     )
     with caplog.at_level(logging.INFO):
         callbacks.log_final_state_summary(ctx)

--- a/tests/test_trend_scout_logging.py
+++ b/tests/test_trend_scout_logging.py
@@ -1,0 +1,100 @@
+"""Tests for trend_scout's debugging-observability callbacks.
+
+These lock in the *predicate* behind `log_empty_turn_finish_reason` — the line
+between a healthy turn (stay quiet) and a pathological empty/abnormal turn
+(warn). A wrong predicate is silently costly: too loose spams the logs on every
+normal tool call, too tight misses the exact MAX_TOKENS/MALFORMED empty turns
+that cause the producer-empty landmine. `log_final_state_summary` is checked for
+the skip-vs-empty signal it exists to provide.
+"""
+
+import logging
+from types import SimpleNamespace
+
+from google.genai import types
+from google.adk.models.llm_response import LlmResponse
+
+from trend_scout import callbacks
+
+
+def _ctx():
+    return SimpleNamespace(agent_name="understand_trends_agent", invocation_id="inv-1")
+
+
+def _resp(*, parts=None, finish_reason=None, partial=None):
+    content = types.Content(role="model", parts=parts) if parts is not None else None
+    return LlmResponse(
+        content=content,
+        finish_reason=finish_reason,
+        partial=partial,
+        usage_metadata=types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=100,
+            candidates_token_count=0,
+            thoughts_token_count=200,
+        ),
+    )
+
+
+def test_normal_text_turn_is_silent(caplog):
+    resp = _resp(
+        parts=[types.Part(text="some analysis")],
+        finish_reason=types.FinishReason.STOP,
+    )
+    with caplog.at_level(logging.WARNING):
+        callbacks.log_empty_turn_finish_reason(_ctx(), resp)
+    assert not caplog.records
+
+
+def test_tool_call_turn_is_silent(caplog):
+    """A google_search tool call (STOP + function_call, no text) is normal."""
+    resp = _resp(
+        parts=[
+            types.Part(function_call=types.FunctionCall(name="google_search", args={}))
+        ],
+        finish_reason=types.FinishReason.STOP,
+    )
+    with caplog.at_level(logging.WARNING):
+        callbacks.log_empty_turn_finish_reason(_ctx(), resp)
+    assert not caplog.records
+
+
+def test_max_tokens_empty_turn_warns(caplog):
+    """Thinking budget exhausted: MAX_TOKENS, no text, no tool call -> warn."""
+    resp = _resp(parts=[], finish_reason=types.FinishReason.MAX_TOKENS)
+    with caplog.at_level(logging.WARNING):
+        callbacks.log_empty_turn_finish_reason(_ctx(), resp)
+    assert len(caplog.records) == 1
+    msg = caplog.records[0].getMessage()
+    assert "MAX_TOKENS" in msg
+    assert "understand_trends_agent" in msg
+    assert "thoughts_tokens=200" in msg
+
+
+def test_stop_but_empty_turn_warns(caplog):
+    """A 'successful' STOP that produced neither text nor a tool call is the
+    exact failure that leaves output_key unset -> warn."""
+    resp = _resp(parts=[], finish_reason=types.FinishReason.STOP)
+    with caplog.at_level(logging.WARNING):
+        callbacks.log_empty_turn_finish_reason(_ctx(), resp)
+    assert len(caplog.records) == 1
+
+
+def test_partial_streaming_chunk_is_ignored(caplog):
+    resp = _resp(parts=[], finish_reason=types.FinishReason.MAX_TOKENS, partial=True)
+    with caplog.at_level(logging.WARNING):
+        callbacks.log_empty_turn_finish_reason(_ctx(), resp)
+    assert not caplog.records
+
+
+def test_final_state_summary_flags_missing_key(caplog):
+    ctx = SimpleNamespace(
+        invocation_id="inv-2",
+        state={"raw_gtrends": ["a", "b"], "info_gtrends__retry_exhausted": True},
+    )
+    with caplog.at_level(logging.INFO):
+        callbacks.log_final_state_summary(ctx)
+    msg = caplog.records[-1].getMessage()
+    assert "'raw_gtrends': 'present" in msg
+    assert "'info_gtrends': 'MISSING'" in msg
+    assert "'selected_gtrends': 'MISSING'" in msg
+    assert "retry_exhausted=['info_gtrends__retry_exhausted']" in msg

--- a/trend_scout/agent.py
+++ b/trend_scout/agent.py
@@ -15,7 +15,7 @@ from .tools import (
     write_to_file,
     memorize,
 )
-from agent_common import build_gemini
+from agent_common import build_gemini, RetryUntilKeyAgent
 from . import callbacks
 from .config import config, INFRA_RETRY
 
@@ -54,6 +54,7 @@ gather_trends_agent = Agent(
     ),
     # output_key="start_gtrends",
     before_model_callback=callbacks.rate_limit_callback,
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
 
 
@@ -105,6 +106,25 @@ understand_trends_agent = Agent(
     tools=[google_search],
     output_key="info_gtrends",
     before_model_callback=callbacks.rate_limit_callback,
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
+)
+
+
+# Retry-on-empty: understand_trends_agent runs google_search under a thinking
+# planner and synthesizes `info_gtrends` in one turn; on gemini-3 it intermittently
+# emits no final text, leaving the key unset and crashing pick_trends_agent with
+# `KeyError: Context variable not found`. Re-run until populated (bounded). It is
+# exposed to the orchestrator as an AgentTool, so the retry runs inside AgentTool's
+# isolated sub-Runner — state-delta timing across that boundary is identical to the
+# top-level case the wrapper was verified against (agent_tool.py forwards each inner
+# event's state_delta before our generator resumes). Set `description` so AgentTool
+# builds the same tool declaration the orchestrator already knows.
+understand_trends_agent_resilient = RetryUntilKeyAgent(
+    name="understand_trends_agent_resilient",
+    description=understand_trends_agent.description,
+    sub_agents=[understand_trends_agent],
+    output_key="info_gtrends",
+    max_attempts=3,
 )
 
 
@@ -129,11 +149,14 @@ pick_trends_agent = Agent(
         </campaign_data>
 
         <trend_research>
-        {info_gtrends}
+        {info_gtrends?}
         </trend_research>
     </CONTEXT>
 
     <INSTRUCTIONS>
+        0. If <trend_research> is empty, the upstream trend research did not run.
+           Do NOT invent trends — output a single line noting that no trend
+           research was available, and stop.
         1. Analyze the <trend_research> JSON.
         2. Select the top 3 trends that offer the strongest narrative alignment with the <campaign_data>.
         *   *Filter:* Discard trends that are too tragic, controversial, or irrelevant to be safe for brand association.
@@ -164,6 +187,7 @@ pick_trends_agent = Agent(
     ),
     output_key="selected_gtrends",
     before_model_callback=callbacks.rate_limit_callback,
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
 
 
@@ -199,7 +223,7 @@ trend_scout = Agent(
     Execute the following agents in strict sequence. Do not proceed to the next until the current tool reports success.
 
     1. **Gather:** Call `gather_trends_agent`.
-    2. **Research:** Call `understand_trends_agent`.
+    2. **Research:** Call `understand_trends_agent_resilient`.
     3. **Select:** Call `pick_trends_agent`. *Note: This agent will determine the final trends.
     4. For each trending topic in the 'selected_gtrends' state key, call the `save_search_trends_to_session_state` tool to save them to the session state.
 
@@ -221,7 +245,7 @@ trend_scout = Agent(
     """,
     tools=[
         AgentTool(agent=gather_trends_agent),
-        AgentTool(agent=understand_trends_agent),
+        AgentTool(agent=understand_trends_agent_resilient),
         AgentTool(agent=pick_trends_agent),
         save_search_trends_to_session_state,
         save_session_state_to_gcs,
@@ -242,6 +266,8 @@ trend_scout = Agent(
         callbacks.load_session_state,
     ],
     before_model_callback=callbacks.rate_limit_callback,
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
+    after_agent_callback=callbacks.log_final_state_summary,
 )
 
 # Set as root agent

--- a/trend_scout/callbacks.py
+++ b/trend_scout/callbacks.py
@@ -5,8 +5,10 @@ import warnings
 import pandas as pd
 from typing import Dict, Any
 
+from google.genai import types
 from google.adk.sessions.state import State
 from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
 from google.adk.agents.callback_context import CallbackContext
 
 from .config import config
@@ -48,6 +50,17 @@ def load_session_state(callback_context: CallbackContext):
     Args:
         callback_context: The callback context.
     """
+    # Correlation line: ties this run to a session transcript. The frontend mints
+    # a throwaway user_id per submission, so without this a UI failure can't be
+    # traced back to a specific session for post-mortem inspection.
+    logging.info(
+        "run start: agent=%s invocation=%s session=%s user=%s",
+        callback_context.agent_name,
+        callback_context.invocation_id,
+        callback_context.session.id,
+        callback_context.user_id,
+    )
+
     data = {}
     data["state"] = {
         "brand": "",  # BRAND,
@@ -101,3 +114,84 @@ def rate_limit_callback(
         callback_context.state["request_count"] = request_count
 
     return
+
+
+def _describe_state_value(value: Any) -> str:
+    """Compact, non-verbose description of a state value's presence."""
+    if value is None:
+        return "MISSING"
+    if isinstance(value, str):
+        return f"present(len={len(value)})" if value.strip() else "empty"
+    if isinstance(value, (list, dict)):
+        return f"present({type(value).__name__}, n={len(value)})"
+    return "present"
+
+
+def log_final_state_summary(callback_context: CallbackContext):
+    """Log the presence of trend_scout's load-bearing state keys at end of run.
+
+    Set as the root agent's `after_agent_callback`. Makes it trivial to see
+    *where* a run stalled: e.g. `raw_gtrends` present but `info_gtrends` MISSING
+    means the understand step was skipped or emitted an empty turn — the exact
+    ambiguity that was impossible to resolve from logs alone during the
+    2026-07-14 incident. Also surfaces any `*__retry_exhausted` markers left by
+    RetryUntilKeyAgent.
+    """
+    state = callback_context.state
+    keys = ("raw_gtrends", "info_gtrends", "selected_gtrends")
+    summary = {k: _describe_state_value(state.get(k)) for k in keys}
+    exhausted = sorted(k for k in state if k.endswith("__retry_exhausted"))
+    logging.info(
+        "trend_scout final state [invocation=%s]: %s%s",
+        callback_context.invocation_id,
+        summary,
+        f" retry_exhausted={exhausted}" if exhausted else "",
+    )
+
+
+def log_empty_turn_finish_reason(
+    callback_context: CallbackContext, llm_response: LlmResponse
+) -> None:
+    """Log finish_reason + token usage when a model turn produced no usable output.
+
+    Set as `after_model_callback` on the thinking/tool agents. This is the
+    root-cause signal for the producer-empty landmine: a thinking agent that
+    burns its output budget returns finish_reason=MAX_TOKENS (or
+    MALFORMED_FUNCTION_CALL) with no text and no tool call, silently leaving its
+    `output_key` unset. Normal text turns (STOP + text) and tool-call turns
+    (STOP + function_call) are NOT logged, so this stays quiet on the happy path.
+    """
+    if llm_response is None or llm_response.partial:
+        return None
+
+    parts = (
+        llm_response.content.parts
+        if llm_response.content and llm_response.content.parts
+        else []
+    )
+    has_text = any(getattr(p, "text", None) for p in parts)
+    has_func = any(getattr(p, "function_call", None) for p in parts)
+    finish_reason = llm_response.finish_reason
+
+    is_normal = finish_reason in (
+        None,
+        types.FinishReason.STOP,
+    ) and (has_text or has_func)
+    if is_normal:
+        return None
+
+    usage = llm_response.usage_metadata
+    logging.warning(
+        "empty/abnormal model turn in %s [invocation=%s]: finish_reason=%s "
+        "has_text=%s has_func_call=%s prompt_tokens=%s candidates_tokens=%s "
+        "thoughts_tokens=%s",
+        callback_context.agent_name,
+        callback_context.invocation_id,
+        finish_reason,
+        has_text,
+        has_func,
+        getattr(usage, "prompt_token_count", None) if usage else None,
+        getattr(usage, "candidates_token_count", None) if usage else None,
+        getattr(usage, "thoughts_token_count", None) if usage else None,
+    )
+    return None

--- a/trend_scout/callbacks.py
+++ b/trend_scout/callbacks.py
@@ -137,10 +137,14 @@ def log_final_state_summary(callback_context: CallbackContext):
     2026-07-14 incident. Also surfaces any `*__retry_exhausted` markers left by
     RetryUntilKeyAgent.
     """
+    # CallbackContext.state is an ADK State: it supports .get()/__contains__ but
+    # NOT iteration — `for k in state` falls back to integer indexing and raises
+    # `KeyError: 0`. Snapshot to a plain dict before scanning for markers.
     state = callback_context.state
+    snapshot = state.to_dict() if isinstance(state, State) else dict(state)
     keys = ("raw_gtrends", "info_gtrends", "selected_gtrends")
-    summary = {k: _describe_state_value(state.get(k)) for k in keys}
-    exhausted = sorted(k for k in state if k.endswith("__retry_exhausted"))
+    summary = {k: _describe_state_value(snapshot.get(k)) for k in keys}
+    exhausted = sorted(k for k in snapshot if k.endswith("__retry_exhausted"))
     logging.info(
         "trend_scout final state [invocation=%s]: %s%s",
         callback_context.invocation_id,


### PR DESCRIPTION
> Replaces #71 (auto-closed when its stacked base branch was deleted on merge of #70). Now targets main directly.

## Summary

Extends the WS1 retry-on-empty hardening (PR #70) to **trend_scout**, which has the same producer-empty landmine — `understand_trends_agent` (a `google_search` + thinking turn) intermittently emits no final text, leaving `info_gtrends` unset and crashing `pick_trends_agent` with `KeyError: Context variable not found`. Observed live 2026-07-14.

> **Stacked on #70** (`exp/retry-until-key-prototype`) — it depends on the relocated `RetryUntilKeyAgent`. Merge #70 first.

## What changed

**Hardening**
- Wrap `understand_trends_agent` in `RetryUntilKeyAgent` → `understand_trends_agent_resilient`, exposed as the orchestrator's AgentTool.
- Guard the consumer: `pick_trends_agent` `{info_gtrends}` → `{info_gtrends?}` + a don't-invent-trends clause. The wrapper covers the empty-turn case; the optional guard covers the orchestrator-skip case.
- **AgentTool boundary verified**: `AgentTool` runs the wrapped agent in an isolated sub-`Runner` and forwards each event's `state_delta` back to the parent, so the retry check reads `output_key` correctly — identical timing to the top-level path the wrapper was verified against.

**Relocation (prerequisite)**
- Moved `RetryUntilKeyAgent` `creative_agent/` → `agent_common/retry_agent.py` (re-exported from `agent_common`). Otherwise trend_scout importing it would force bundling the whole creative pipeline into trend_scout's Agent Engine. `agent_common` already depends on `google-adk` and no cloud function imports it; corrected the stale "ADK-free" wording in CLAUDE.md.

**Debugging observability** (`trend_scout/callbacks.py`)
- Run-start correlation line (`invocation` / `session` / `user`) — ties a UI failure to a session transcript.
- End-of-run state-key summary (`raw_gtrends` / `info_gtrends` / `selected_gtrends` presence + `*__retry_exhausted` markers) — resolves *skip vs empty-turn*.
- `finish_reason`-on-empty `after_model_callback` on all four LlmAgents — logs MAX_TOKENS / MALFORMED / empty-STOP turns with token counts, silent on the happy path.

## Testing
- `202 passed`, `ruff check` clean. 8 new tests: 2 structural (`test_understand_trends_is_retry_wrapped`, `test_pick_trends_info_gtrends_optional`) + 6 logging-predicate tests (`tests/test_trend_scout_logging.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
