### PR TITLE
fix(trend_scout): enforce 3-trend pick, lower temperature, drop safety filter

### DIFF
--- a/trend_scout/agent.py
+++ b/trend_scout/agent.py
@@ -205,8 +205,10 @@ pick_trends_agent = Agent(
            Do NOT invent trends — output a single line noting that no trend
            research was available, and stop.
         1. Analyze the <trend_research> JSON.
-        2. Select the top 3 trends that offer the strongest narrative alignment with the <campaign_data>.
-        *   *Filter:* Discard trends that are too tragic, controversial, or irrelevant to be safe for brand association.
+        2. Select exactly 3 trends that offer the strongest narrative alignment
+           with the <campaign_data>. You MUST return 3. Only return fewer if
+           <trend_research> contains fewer than 3 distinct trends, in which case
+           return every trend available.
         3. For each selected trend, define the "Strategic Bridge"—the specific angle that connects the trend's cultural mood to the product's unique selling points.
 
         Output your findings in the requested format.
@@ -225,7 +227,7 @@ pick_trends_agent = Agent(
     **Constraint:** Do not repeat campaign metadata. Focus 100% on the analysis.
     """,
     generate_content_config=types.GenerateContentConfig(
-        temperature=1.5,
+        temperature=0.4,
         labels={
             "agentic_wf": "trend_scout",
             "agent": "trend_scout",


### PR DESCRIPTION
## Summary

`pick_trends_agent` was emitting a **variable** number of trends (as few as 1 in a live run), which under-sizes the entire downstream creative fan-out — the number of BQ rows written equals the number of selected trends, so a short pick starves Phase 2.

Two root causes:
- **`temperature=1.5`** — too hot for what is fundamentally a selection/format task.
- A **soft "top 3" target** whose discretionary "too tragic/controversial/irrelevant" filter could silently shrink the set below 3.

## What changed (`trend_scout/agent.py`, prompt + config only)
- `temperature` **1.5 → 0.4** on `pick_trends_agent`.
- "Select the top 3" → **"Select exactly 3; you MUST return 3"**, with a fallback to "return every trend available" only when `<trend_research>` holds fewer than 3 distinct trends.
- **Removed** the "Discard trends that are too tragic, controversial, or irrelevant" clause.

The WS1 "don't invent trends if research is empty" guard (`{info_gtrends?}`) is preserved above the change, so the empty-research path still degrades safely.

## Testing
- Prompt/config-only change; `import trend_scout.agent` loads clean (`root_agent.name == "trend_scout"`). Rebased onto current `main` (post WS1/WS2/WS3 stack) with no conflicts — the change is isolated to `pick_trends_agent` and does not touch WS2's `understand_trends` split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
