### PR TITLE
fix(frontend): surface SSE error events (e.g. model 429) in the run UI

### DIFF
--- a/frontend/src/__tests__/event-error.test.ts
+++ b/frontend/src/__tests__/event-error.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { getEventError } from "@/lib/api";
+import type { AgentEvent } from "@/lib/types";
+
+// An error event as emitted by the ADK api_server run_sse stream when a model
+// call fails (e.g. Vertex 429). It carries errorCode/errorMessage (and often a
+// separate final event with a top-level `error`), and has no `content`, so the
+// run page's content-only loop used to drop it silently.
+
+function makeEvent(overrides: Partial<AgentEvent>): AgentEvent {
+  return {
+    id: "e1",
+    invocationId: "inv1",
+    author: "root_agent",
+    timestamp: 1,
+    ...overrides,
+  } as AgentEvent;
+}
+
+describe("getEventError", () => {
+  it("returns null for a normal content event", () => {
+    const ev = makeEvent({
+      content: { role: "model", parts: [{ text: "hello" }] },
+    });
+    expect(getEventError(ev)).toBeNull();
+  });
+
+  it("returns null for a state-delta-only event", () => {
+    const ev = makeEvent({ actions: { stateDelta: { brand: "PRS" } } });
+    expect(getEventError(ev)).toBeNull();
+  });
+
+  it("detects errorCode + errorMessage events", () => {
+    const ev = makeEvent({
+      errorCode: "_SomeError",
+      errorMessage: "something broke",
+    });
+    expect(getEventError(ev)).toBe("something broke");
+  });
+
+  it("falls back to errorCode when errorMessage is absent", () => {
+    const ev = makeEvent({ errorCode: "_MalformedFunctionCall" });
+    expect(getEventError(ev)).toBe("_MalformedFunctionCall");
+  });
+
+  it("detects a top-level error field (final error event)", () => {
+    const ev = makeEvent({ id: "", error: "boom happened" } as Partial<AgentEvent>);
+    expect(getEventError(ev)).toBe("boom happened");
+  });
+
+  it("gives a friendly message for a 429 RESOURCE_EXHAUSTED quota error", () => {
+    const ev = makeEvent({
+      errorCode: "_ResourceExhaustedError",
+      errorMessage:
+        '429 Too Many Requests. {"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}}',
+    });
+    const msg = getEventError(ev);
+    expect(msg).toMatch(/quota/i);
+    expect(msg).toMatch(/429/);
+  });
+
+  it("detects a 429 carried only in a top-level error string", () => {
+    const ev = makeEvent({
+      id: "",
+      error: "_ResourceExhaustedError: 429 RESOURCE_EXHAUSTED",
+    } as Partial<AgentEvent>);
+    expect(getEventError(ev)).toMatch(/quota/i);
+  });
+});

--- a/frontend/src/app/run/[sessionId]/page.tsx
+++ b/frontend/src/app/run/[sessionId]/page.tsx
@@ -10,7 +10,7 @@ import { GcsWidget } from "@/components/gcs-widget";
 import { Textarea } from "@/components/ui/textarea";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { streamRun, resumeRun, getSession } from "@/lib/api";
+import { streamRun, resumeRun, getSession, getEventError } from "@/lib/api";
 import { formatStateValue } from "@/lib/utils";
 import type { AgentEvent } from "@/lib/types";
 
@@ -623,6 +623,16 @@ export default function RunPage({
           if (event.id && seenEventIds.current.has(event.id)) continue;
           if (event.id) seenEventIds.current.add(event.id);
 
+          // Surface backend failure events (e.g. a model 429) — these arrive as
+          // data events with no content, so a content-only loop would drop them
+          // and the run would look like a silent stall.
+          const evErr = getEventError(event);
+          if (evErr) {
+            setStatus("error");
+            setErrorMsg(evErr);
+            return;
+          }
+
           setEvents((prev) => [...prev, event]);
 
           if (event.actions?.stateDelta) {
@@ -697,6 +707,14 @@ export default function RunPage({
         if (event.id && seenEventIds.current.has(event.id)) continue;
         if (event.id) seenEventIds.current.add(event.id);
         eventCount++;
+
+        // Surface backend failure events (e.g. a model 429) during resume too.
+        const evErr = getEventError(event);
+        if (evErr) {
+          setStatus("error");
+          setErrorMsg(evErr);
+          return;
+        }
 
         setEvents((prev) => [...prev, event]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,24 @@ import type { Session, AgentEvent } from "./types";
 // Override with NEXT_PUBLIC_API_BASE to call an api_server directly if needed.
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "/api/adk";
 
+/**
+ * Extract a human-readable error from a streamed run event, or null if the
+ * event is not an error. The ADK run_sse stream reports model/agent failures
+ * as data events (errorCode/errorMessage, or a terminal bare `error`) that
+ * carry no `content`, so a content-only consumer would drop them silently and
+ * the run would appear to stall. Callers should surface the returned message.
+ */
+export function getEventError(event: AgentEvent): string | null {
+  const raw = event.errorMessage || event.errorCode || event.error;
+  if (!raw) return null;
+  // A model 429 is the common case on the shared per-minute Vertex quota —
+  // give an actionable message instead of a raw stack-trace fragment.
+  if (/429|RESOURCE_EXHAUSTED|ResourceExhausted/.test(raw)) {
+    return "Vertex AI quota exhausted (429): the shared per-minute request quota was hit. Wait a minute and retry, and avoid running multiple agents at once.";
+  }
+  return raw;
+}
+
 export async function listApps(): Promise<string[]> {
   const res = await fetch(`${API_BASE}/list-apps`);
   if (!res.ok) throw new Error(`Failed to list apps: ${res.statusText}`);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -33,6 +33,12 @@ export interface AgentEvent {
   longRunningToolIds?: string[];
   partial?: boolean;
   timestamp: number;
+  // Present on failure events emitted by the ADK run_sse stream (e.g. a model
+  // 429). `errorCode`/`errorMessage` ride on a normal event envelope; some
+  // terminal failures instead arrive as a bare `{ error, error_details }`.
+  errorCode?: string;
+  errorMessage?: string;
+  error?: string;
 }
 
 export interface Session {


### PR DESCRIPTION
## Summary

Fixes silent stalls in the run UI: when a run failed on the backend (a model **429 / RESOURCE_EXHAUSTED** on the shared Vertex quota being the common case), the frontend showed **nothing** — no error, no status change — so the run just appeared to hang.

**Root cause:** the ADK `run_sse` stream reports failures as `data:` events carrying `errorCode`/`errorMessage` (and sometimes a terminal bare `{ error, error_details }`) with **no `content`**. The run page's loop only reads `event.content`/`stateDelta`, so it dropped these events; the stream then ended normally (no thrown exception), leaving `errorMsg` unset. Confirmed live: server logs showed `429 Too Many Requests` while the UI displayed nothing.

## What changed
- `AgentEvent`: add optional `errorCode` / `errorMessage` / `error` fields.
- `getEventError(event)` — a pure, tested helper in `lib/api.ts` that returns a human-readable message (or `null`), with a friendly, actionable note for the 429 quota case.
- Wire the check into **both** SSE loops (initial run + resume): on an error event, set `status="error"` and the message, which the existing red banner renders.

## Testing
- New `event-error.test.ts` (7 cases: normal events → null; errorCode/errorMessage; errorCode-only fallback; top-level `error`; 429 friendly message from both shapes).
- Full frontend suite **81 passed**, `tsc --noEmit` clean, `eslint` 0 errors (1 pre-existing unrelated `exhaustive-deps` warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
