### PR TITLE
fix(agents): use thinking_level instead of deprecated thinking_budget

### DIFF
--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -812,14 +812,21 @@ visual_generator = Agent(
     retry_config=INFRA_RETRY,
     include_contents="none",  # new
     description="Generate final visuals using image generation tools",
-    # thinking_budget=0: this is a mechanical single-tool step, not a reasoning task.
-    # Without it, gemini-3 would emit MULTIPLE parallel `generate_image` calls in one
-    # turn — and parallel calls all read state before any commits, so the tool's
-    # idempotency guard (_images_generated) can't dedupe them, causing every image to
-    # be rendered 2x (double the image-gen cost). One call is all that's needed:
-    # generate_image itself loops over every concept in final_visual_concepts.
+    # thinking_level=LOW: this is a mechanical single-tool step, not a reasoning task,
+    # so we constrain thinking to keep the model from emitting MULTIPLE parallel
+    # `generate_image` calls in one turn — parallel calls all read state before any
+    # commits, so the tool's idempotency guard (_images_generated) can't dedupe them,
+    # causing every image to be rendered 2x (double the image-gen cost). One call is
+    # all that's needed: generate_image loops over every concept in
+    # final_visual_concepts. (The real dedup safeguard is _images_generated + the
+    # "call EXACTLY ONCE" instruction; the low thinking level is belt-and-suspenders.)
+    # NOTE: gemini-3.x deprecated the numeric thinking_budget; thinking_budget=0 also
+    # never disabled thinking on gemini-3 (that only worked on 2.5). LOW is the lowest
+    # level Pro supports — MINIMAL is Flash/Flash-Lite only and 400s on Pro.
     planner=BuiltInPlanner(
-        thinking_config=types.ThinkingConfig(thinking_budget=0, include_thoughts=False)
+        thinking_config=types.ThinkingConfig(
+            thinking_level=types.ThinkingLevel.LOW, include_thoughts=False
+        )
     ),
     instruction="""You are a visual content producer generating image creatives.
     Call the `generate_image` tool EXACTLY ONCE — a single function call, never in

--- a/deployment/headless_run.py
+++ b/deployment/headless_run.py
@@ -5,7 +5,7 @@ api_server SSE/HTTP request timeout that kills UI runs during the ~5-min eval
 phase. Uses the same file artifact service directory (.adk/artifacts) the
 api_server uses so save_artifact calls persist identically. Verifies:
 
-  - each visual is rendered exactly once (visual_generator thinking_budget=0 fix)
+  - each visual is rendered exactly once (visual_generator thinking_level=LOW fix)
   - creative_evaluation_report is produced and eval_report_gcs_uri is set
   - the HTML gallery is built
   - a BigQuery row is written

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -440,19 +440,26 @@ def test_pick_trends_info_gtrends_optional():
     assert "{info_gtrends}" not in pick_trends_agent.instruction
 
 
-def test_trend_scout_orchestrator_thinking_budget_is_bounded_nonzero():
-    """The orchestrator's thinking budget must be a small POSITIVE number.
+def test_trend_scout_orchestrator_thinking_level_is_bounded_low():
+    """The orchestrator's thinking must be bounded to LOW — not off, not HIGH.
 
-    thinking_budget=0 makes gemini-3.5-flash emit MALFORMED_FUNCTION_CALL when
-    invoking an AgentTool with a structured argument (e.g. understand_trends_agent),
-    aborting the pipeline right after gather_trends so nothing is ever persisted to
-    BigQuery/GCS. An unbounded budget hits MAX_TOKENS. It must stay in between.
+    Disabled thinking (legacy thinking_budget=0, and its thinking_level analog
+    MINIMAL) makes gemini-3.5-flash emit MALFORMED_FUNCTION_CALL when invoking an
+    AgentTool with a structured argument (e.g. understand_trends_agent), aborting the
+    pipeline right after gather_trends so nothing is ever persisted to BigQuery/GCS.
+    HIGH (the default) hits MAX_TOKENS. LOW is the bounded middle. gemini-3.x
+    deprecated the numeric thinking_budget, so we pin thinking_level instead.
     """
+    from google.genai import types
+
     from trend_scout.agent import root_agent
 
-    budget = root_agent.planner.thinking_config.thinking_budget
-    assert budget is not None and budget > 0, (
-        f"orchestrator thinking_budget must be > 0 (was {budget})"
+    tc = root_agent.planner.thinking_config
+    assert tc.thinking_budget is None, (
+        "use thinking_level (not the deprecated numeric thinking_budget) on gemini-3"
+    )
+    assert tc.thinking_level == types.ThinkingLevel.LOW, (
+        f"orchestrator thinking_level must be LOW (was {tc.thinking_level})"
     )
 
 

--- a/trend_scout/agent.py
+++ b/trend_scout/agent.py
@@ -246,16 +246,18 @@ trend_scout = Agent(
     retry_config=INFRA_RETRY,
     description="Determines culturally relevant Search trends to use for ad creatives.",
     # Bounded thinking: the orchestrator's job is mechanical tool sequencing, not deep
-    # reasoning. On gemini-3 models, unbounded default thinking burned the entire output
-    # budget "thinking" and hit MAX_TOKENS before emitting a tool call — but the opposite
-    # extreme, thinking_budget=0, made gemini-3.5-flash emit MALFORMED_FUNCTION_CALL when
-    # invoking an AgentTool with a structured argument (e.g. understand_trends_agent), so
-    # the pipeline aborted right after gather_trends and never persisted anything. A small
-    # bounded budget gives the model just enough room to format tool calls correctly while
-    # still capping thinking well short of MAX_TOKENS.
+    # reasoning. On gemini-3 models, unbounded default thinking (HIGH) burned the entire
+    # output budget "thinking" and hit MAX_TOKENS before emitting a tool call — but the
+    # opposite extreme (thinking off) made gemini-3.5-flash emit MALFORMED_FUNCTION_CALL
+    # when invoking an AgentTool with a structured argument (e.g. understand_trends_agent),
+    # so the pipeline aborted right after gather_trends and never persisted anything. LOW
+    # gives the model just enough room to format tool calls correctly while capping
+    # thinking well short of MAX_TOKENS. NOTE: gemini-3.x deprecated the numeric
+    # thinking_budget in favour of thinking_level; MINIMAL ("no thinking" for most
+    # queries) reintroduces the MALFORMED_FUNCTION_CALL landmine, so LOW is the floor here.
     planner=BuiltInPlanner(
         thinking_config=types.ThinkingConfig(
-            thinking_budget=512, include_thoughts=False
+            thinking_level=types.ThinkingLevel.LOW, include_thoughts=False
         )
     ),
     instruction="""You are the Lead Campaign Orchestrator.


### PR DESCRIPTION
## What

Replaces the deprecated numeric `thinking_budget` with the `thinking_level` enum on the two agents that still used it. gemini-3.x deprecated `thinking_budget`; both sites were riding the backwards-compat path (accepted but "may result in unexpected performance"), and `thinking_budget=0` specifically **never disabled thinking on gemini-3** (that only worked on 2.5).

| Site | Was | Now | Why LOW |
|---|---|---|---|
| `visual_generator` (`creative_agent/agent.py`, Pro model) | `thinking_budget=0` | `thinking_level=LOW` | `=0` never zeroed thinking on gemini-3; **MINIMAL 400s on Pro** (Flash/Flash-Lite only), so LOW is the floor |
| trend_scout orchestrator (`trend_scout/agent.py`, 3.5-flash) | `thinking_budget=512` | `thinking_level=LOW` | MINIMAL ≈ "no thinking" → reintroduces the `MALFORMED_FUNCTION_CALL` landmine on structured AgentTool calls; LOW is the bounded middle |

Also: refreshed both explanatory comments, updated the `headless_run.py` docstring reference, and rewrote the structure test to assert `thinking_level == LOW` **and** `thinking_budget is None` (renamed `test_trend_scout_orchestrator_thinking_level_is_bounded_low`).

## Why

`thinking_budget` is deprecated for all gemini-3.x models — the intended knob is `thinking_level`. Keeping the deprecated int is a latent risk: a future genai/Vertex release could drop the compat mapping, and for `visual_generator` that would resurrect the double-render bug (the `=0` was load-bearing for the single-`generate_image`-call behavior). Moving to `thinking_level` puts both agents on the supported path.

## Testing

**Offline:** 235 pytest passed; `ruff check` + `ruff format --check` clean.

**Live smoke** on an isolated no-traffic tagged revision (`trend-trawler-api-00020-mel`, prod untouched at 100%):

- **trend_scout** — `MALFORMED_FUNCTION_CALL`: **0** (orchestrator formats the structured `understand_trends_agent_resilient` call correctly at LOW); two-turn split intact (`info_gtrends_raw` → `info_gtrends`); exactly 3 trends; `write_trends_to_bq` → success.
- **creative_agent** — full pipeline ran (research → ad copy → visual concepts → image gen → eval → GCS → BQ). **No double-render**: 4 concepts → 4 image-save log lines, each key exactly once. Research PDF + eval JSON + HTML gallery saved to GCS; BQ eval row written. **0** landmine hits (malformed / 429 / empty-turn / retry-exhausted / MAX_TOKENS) across the run.

## Deploy note

Not yet on prod — after merge, redeploy `trend-trawler-api` from main and migrate traffic (same flow as the prior round). The Agent Engine instances backing the CRF fan-out should also be redeployed from main to pick up this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)