### PR TITLE
perf(creative_agent): gate research refinement round on degraded base research (Lever A)

### DIFF
--- a/agent_common/__init__.py
+++ b/agent_common/__init__.py
@@ -1,5 +1,6 @@
 """Shared building blocks used across the agent packages."""
 
+from agent_common.conditional_agent import RunIfAgent
 from agent_common.config import BaseAgentConfiguration
 from agent_common.locations import MODEL_LOCATION
 from agent_common.models import build_gemini
@@ -22,6 +23,7 @@ __all__ = [
     "build_gemini",
     "build_infra_retry",
     "RetryUntilKeyAgent",
+    "RunIfAgent",
     "collect_degradation_warnings",
     "log_empty_turn_finish_reason",
     "log_run_start",

--- a/agent_common/conditional_agent.py
+++ b/agent_common/conditional_agent.py
@@ -1,0 +1,75 @@
+"""Conditional-block control-flow wrapper for agent pipelines.
+
+Shared across the agent packages; lives in ``agent_common`` so any engine can
+gate an optional stage on session state without pulling in an unrelated agent
+package. Import via ``from agent_common import RunIfAgent``.
+
+## Why this exists
+
+A ``SequentialAgent`` runs every sub-agent unconditionally. Some stages are
+*optional* — their work only pays off in certain states, and each one is an
+extra serial model call (on gemini-3.1-pro-preview that means another draw on a
+5 RPM quota → more server-side 429/503 + retry wait). ``RunIfAgent`` wraps such
+a block and runs it only when a predicate over ``ctx.session.state`` is truthy;
+otherwise the block is skipped entirely — no events, no model calls.
+
+The predicate reads the *live* session state: the runner merges each yielded
+event's ``state_delta`` into the same ``session`` object before this agent is
+resumed, so a gate placed after an upstream producer sees whatever that producer
+wrote (mirrors the state-delta timing ``RetryUntilKeyAgent`` relies on).
+
+## Guard contract
+
+Skipping a block must not strand a downstream consumer on an unset ``{var}``.
+Only wrap stages whose outputs are consumed behind optional ``{var?}`` guards
+(or not consumed downstream at all). This keeps the research-pipeline landmine
+class — missing ``output_key`` → ``KeyError: Context variable not found`` —
+from reappearing when the block is skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import AsyncGenerator, Callable
+
+from google.adk.agents import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event
+from google.adk.utils.context_utils import Aclosing
+from typing_extensions import override
+
+logger = logging.getLogger("google_adk." + __name__)
+
+
+class RunIfAgent(BaseAgent):
+    """Run ``sub_agents`` (in order) only when ``predicate`` is truthy.
+
+    The gated agents are passed as ``sub_agents`` (so they get normal parent
+    wiring). ``predicate`` is called with ``ctx.session.state`` and must return a
+    truthy value to run the block; a falsy value skips it (a clean no-op that
+    yields nothing).
+    """
+
+    predicate: Callable[[object], bool]
+    """Called with ``ctx.session.state``; truthy → run the block, falsy → skip."""
+
+    @override
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        if not self.sub_agents:
+            return
+
+        if not self.predicate(ctx.session.state):
+            logger.info(
+                "%s: predicate false — skipping %d sub-agent(s): %s",
+                self.name,
+                len(self.sub_agents),
+                ", ".join(a.name for a in self.sub_agents),
+            )
+            return
+
+        for sub in self.sub_agents:
+            async with Aclosing(sub.run_async(ctx)) as agen:
+                async for event in agen:
+                    yield event

--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -11,7 +11,7 @@ from google.adk.agents import Agent, SequentialAgent, ParallelAgent
 
 from .sub_agents.campaign_researcher.agent import ca_sequential_planner
 from .sub_agents.trend_researcher.agent import gs_sequential_planner
-from agent_common import build_gemini, RetryUntilKeyAgent
+from agent_common import build_gemini, RetryUntilKeyAgent, RunIfAgent
 from .config import config, INFRA_RETRY
 from . import callbacks
 from . import tools
@@ -341,14 +341,55 @@ combined_report_composer = Agent(
 #     *   (No more than 3 supporting bullets detailing the specific risks/constraints.)
 
 
+# --- CONDITIONAL RESEARCH REFINEMENT GATE (Lever A) --- #
+# The evaluator (gemini-3.1-pro-preview) + follow-up searcher form a SECOND,
+# additive research round: the base brief in `combined_web_search_insights`
+# (two parallel deep researchers → synthesis) already flows straight to
+# `combined_report_composer`, which guards the refined input with the optional
+# `{refined_web_search_insights?}`. So the refinement is only *worth* an extra
+# serial PRO call when the base research came back thin.
+#
+# `_base_research_is_degraded` gates the block on exactly that: run it only when
+# the merged brief is blank/missing, or an upstream producer exhausted its
+# retries (`*__retry_exhausted`, set by the RetryUntilKeyAgent wrappers on the
+# gs/campaign producers). On the healthy common path the gate skips the block —
+# dropping one gemini-3.1-pro-preview call (the 5 RPM quota is the wall-clock
+# bottleneck) plus a google_search + synthesis pass — while keeping the round as
+# a self-healing fallback for degraded runs. No `output_key`/`{var?}` guard is
+# disturbed: the evaluator's output is consumed only inside the block, and the
+# composer already tolerates a missing `refined_web_search_insights`.
+def _base_research_is_degraded(state) -> bool:
+    """True when the base research is thin enough to warrant a refinement round."""
+    brief = state.get("combined_web_search_insights")
+    if not (isinstance(brief, str) and brief.strip()):
+        return True
+    for marker in (
+        "gs_web_search_insights__retry_exhausted",
+        "campaign_web_search_insights__retry_exhausted",
+    ):
+        if state.get(marker):
+            return True
+    return False
+
+
+research_refinement_block = RunIfAgent(
+    name="research_refinement_block",
+    description="Runs the follow-up evaluate+search round only when base research is degraded.",
+    predicate=_base_research_is_degraded,
+    sub_agents=[
+        combined_web_evaluator,
+        enhanced_combined_searcher_resilient,
+    ],
+)
+
+
 # --- COMPLETE RESEARCH PIPELINE SUBAGENT --- #
 combined_research_pipeline = SequentialAgent(
     name="combined_research_pipeline",
     description="Executes a pipeline of web research. It performs iterative research, evaluation, and insight generation.",
     sub_agents=[
         merge_parallel_insights,
-        combined_web_evaluator,
-        enhanced_combined_searcher_resilient,
+        research_refinement_block,
         combined_report_composer,
     ],
 )

--- a/tests/test_conditional_agent.py
+++ b/tests/test_conditional_agent.py
@@ -1,0 +1,151 @@
+"""Tests for RunIfAgent — the conditional-block control-flow wrapper.
+
+Fully offline, same style as tests/test_retry_agent.py: fake sub-agents driven
+through a real ``InMemoryRunner`` so the predicate reads genuine ADK session
+state (the runner merges each yielded event's ``state_delta`` into the session
+the wrapper reads). No model calls, no GCP credentials, no quota.
+
+Coroutines are driven with ``asyncio.run`` (no pytest-asyncio in this project).
+"""
+
+import asyncio
+from typing import AsyncGenerator
+
+from google.adk.agents import BaseAgent, SequentialAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event
+from google.adk.events.event_actions import EventActions
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+from pydantic import PrivateAttr
+
+from agent_common import RunIfAgent
+
+
+class _Marker(BaseAgent):
+    """Records each invocation and writes ``output_key`` into state."""
+
+    output_key: str
+    value: str = "RAN"
+    _runs: int = PrivateAttr(default=0)
+
+    @property
+    def runs(self) -> int:
+        return self._runs
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        self._runs += 1
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            actions=EventActions(state_delta={self.output_key: self.value}),
+        )
+
+
+class _Seeder(BaseAgent):
+    """Writes a fixed key/value so a downstream predicate can read state."""
+
+    key: str
+    value: str
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            actions=EventActions(state_delta={self.key: self.value}),
+        )
+
+
+def _run(agent: BaseAgent):
+    """Drive ``agent`` once through an InMemoryRunner; return the final session."""
+    runner = InMemoryRunner(agent=agent, app_name="runif_test")
+
+    async def _go():
+        session = await runner.session_service.create_session(
+            app_name="runif_test", user_id="u"
+        )
+        async for _ in runner.run_async(
+            user_id="u",
+            session_id=session.id,
+            new_message=types.Content(role="user", parts=[types.Part(text="go")]),
+        ):
+            pass
+        return await runner.session_service.get_session(
+            app_name="runif_test", user_id="u", session_id=session.id
+        )
+
+    return asyncio.run(_go())
+
+
+def test_runs_all_sub_agents_in_order_when_predicate_true():
+    a = _Marker(name="a", output_key="a_out")
+    b = _Marker(name="b", output_key="b_out")
+    gate = RunIfAgent(name="gate", predicate=lambda _s: True, sub_agents=[a, b])
+
+    session = _run(gate)
+
+    assert a.runs == 1
+    assert b.runs == 1
+    assert session.state.get("a_out") == "RAN"
+    assert session.state.get("b_out") == "RAN"
+
+
+def test_skips_all_sub_agents_when_predicate_false():
+    a = _Marker(name="a", output_key="a_out")
+    b = _Marker(name="b", output_key="b_out")
+    gate = RunIfAgent(name="gate", predicate=lambda _s: False, sub_agents=[a, b])
+
+    session = _run(gate)
+
+    assert a.runs == 0
+    assert b.runs == 0
+    assert session.state.get("a_out") is None
+    assert session.state.get("b_out") is None
+
+
+def test_predicate_reads_live_session_state():
+    """The predicate is evaluated against real session state populated upstream.
+
+    A seeder writes ``flag`` before the gate runs; the gate's predicate keys on
+    it, proving the decision reflects state produced earlier in the same run
+    (not just construction-time closure values).
+    """
+    seed = _Seeder(name="seed", key="flag", value="go")
+    inner = _Marker(name="inner", output_key="inner_out")
+    gate = RunIfAgent(
+        name="gate",
+        predicate=lambda s: s.get("flag") == "go",
+        sub_agents=[inner],
+    )
+    pipeline = SequentialAgent(name="pipe", sub_agents=[seed, gate])
+
+    session = _run(pipeline)
+
+    assert inner.runs == 1
+    assert session.state.get("inner_out") == "RAN"
+
+
+def test_predicate_false_from_upstream_state_skips_block():
+    seed = _Seeder(name="seed", key="flag", value="stop")
+    inner = _Marker(name="inner", output_key="inner_out")
+    gate = RunIfAgent(
+        name="gate",
+        predicate=lambda s: s.get("flag") == "go",
+        sub_agents=[inner],
+    )
+    pipeline = SequentialAgent(name="pipe", sub_agents=[seed, gate])
+
+    session = _run(pipeline)
+
+    assert inner.runs == 0
+    assert session.state.get("inner_out") is None
+
+
+def test_empty_sub_agents_is_noop():
+    gate = RunIfAgent(name="gate", predicate=lambda _s: True, sub_agents=[])
+    session = _run(gate)
+    assert session is not None  # completed without error

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -35,27 +35,73 @@ def test_creative_agent_root_output_key_not_set():
 
 
 def test_combined_research_pipeline_sub_agent_order():
-    from creative_agent.agent import combined_research_pipeline
-    from agent_common import RetryUntilKeyAgent
+    """Lever A: the PRO evaluator + follow-up searcher are wrapped in a
+    RunIfAgent gate so they're skipped on the healthy common path (dropping one
+    serial gemini-3.1-pro-preview call) and run only to compensate for degraded
+    base research. The base synthesis and the final composer stay unconditional."""
+    from creative_agent.agent import (
+        combined_research_pipeline,
+        research_refinement_block,
+    )
+    from agent_common import RetryUntilKeyAgent, RunIfAgent
 
     names = [a.name for a in combined_research_pipeline.sub_agents]
     assert names == [
         "merge_parallel_insights",
-        "combined_web_evaluator",
-        "enhanced_combined_searcher_resilient",
+        "research_refinement_block",
         "combined_report_composer",
     ]
 
-    w = combined_research_pipeline.sub_agents[2]
-    assert isinstance(w, RetryUntilKeyAgent)
-    assert w.output_key == "refined_web_search_insights"
+    gate = combined_research_pipeline.sub_agents[1]
+    assert gate is research_refinement_block
+    assert isinstance(gate, RunIfAgent)
+
+    # The gate wraps the evaluator + the resilient follow-up searcher, in order.
+    gated = [a.name for a in gate.sub_agents]
+    assert gated == ["combined_web_evaluator", "enhanced_combined_searcher_resilient"]
 
     from google.adk.agents import SequentialAgent
+
+    w = gate.sub_agents[1]
+    assert isinstance(w, RetryUntilKeyAgent)
+    assert w.output_key == "refined_web_search_insights"
 
     pair = w.sub_agents[0]
     assert isinstance(pair, SequentialAgent)
     assert pair.sub_agents[0].output_key == "refined_web_search_raw"
     assert pair.sub_agents[-1].output_key == "refined_web_search_insights"
+
+
+def test_research_refinement_gate_predicate():
+    """The gate runs the refinement block ONLY when base research is degraded:
+    a blank/missing merged brief, or an upstream producer that exhausted retries.
+    On the healthy common path (brief present, no exhaustion markers) it skips,
+    dropping the PRO evaluator + a search/synth pass."""
+    from creative_agent.agent import _base_research_is_degraded
+
+    # Healthy: substantial brief, no exhaustion → skip refinement.
+    assert (
+        _base_research_is_degraded({"combined_web_search_insights": "A full brief."})
+        is False
+    )
+
+    # Degraded: brief missing entirely → refine to compensate.
+    assert _base_research_is_degraded({}) is True
+
+    # Degraded: brief present but blank/whitespace → refine.
+    assert _base_research_is_degraded({"combined_web_search_insights": "   "}) is True
+
+    # Degraded: brief present but an upstream producer exhausted its retries.
+    for marker in (
+        "gs_web_search_insights__retry_exhausted",
+        "campaign_web_search_insights__retry_exhausted",
+    ):
+        assert (
+            _base_research_is_degraded(
+                {"combined_web_search_insights": "A full brief.", marker: True}
+            )
+            is True
+        )
 
 
 def test_refined_searcher_has_tool_synthesizer_is_tool_free():


### PR DESCRIPTION
## What

Makes the research **evaluate→refine** round conditional. On the healthy common path the merged research brief already exists, so we skip the `combined_web_evaluator` (PRO) turn plus a search+synth pass; the refine round survives only as a self-healing fallback when base research is blank or a `__retry_exhausted` marker is set.

Introduces a small reusable `agent_common.RunIfAgent` (a `BaseAgent` that runs its child only when a predicate over session state is true) gated by `_base_research_is_degraded(state)`.

## Why

This is **Lever A** of the creative_agent latency experiment. Measured against a same-window baseline on isolated `--no-traffic --tag` Cloud Run revisions (3 trials/config, median):

| phase | baseline | fewer_pro | Δ |
|---|---:|---:|---:|
| research | 138.5s | **80.9s** | **−42%** |
| total | 379.5s | **324.4s** | **−14.5%** |

The total drop (−55s) ≈ the research drop (−58s): the removed segment flows straight to the bottom line. It's a pure win — no quality cost.

**Mechanism proof (from session state, noise-free):** on the healthy path the variant skips the block (`refined_web_search_insights` and `combined_research_evaluation` absent) yet still produces a complete brief — the composer's `{…?}` guard absorbs the skip. No `__retry_exhausted` markers in either arm.

**Quality (free signal, same unchanged PRO judge):** avg ad-copy 0.896→0.845, visual 0.929→0.913, **100% pass** — within single-run variance.

## Safety

- No landmine reintroduced: the evaluator's output is consumed only inside the gated block, and the composer already guards `{refined_web_search_insights?}`.
- The refine round still runs as a fallback whenever base research is degraded.
- `tests/test_pipeline_structure.py` extended for the changed topology; new `tests/test_conditional_agent.py` covers `RunIfAgent` (runs/skips on predicate, state passthrough).

Full analysis: `docs/experiments/2026-07-15-creative-latency.md` (lands via the harness/writeup PR).