### PR TITLE
fix(creative_agent): tolerate lone Unicode surrogates in ad-copy JSON output

### DIFF
--- a/agent_common/__init__.py
+++ b/agent_common/__init__.py
@@ -11,6 +11,10 @@ from agent_common.observability import (
 )
 from agent_common.retry import build_infra_retry
 from agent_common.retry_agent import RetryUntilKeyAgent
+from agent_common.sanitize import (
+    scrub_lone_surrogates,
+    scrub_surrogates_in_response,
+)
 
 __all__ = [
     "BaseAgentConfiguration",
@@ -22,4 +26,6 @@ __all__ = [
     "log_empty_turn_finish_reason",
     "log_run_start",
     "make_final_state_summary",
+    "scrub_lone_surrogates",
+    "scrub_surrogates_in_response",
 ]

--- a/agent_common/sanitize.py
+++ b/agent_common/sanitize.py
@@ -1,0 +1,91 @@
+"""Sanitize model text output before strict JSON parsing.
+
+Gemini occasionally emits a bare (lone) Unicode surrogate code unit
+(U+D800–U+DFFF that is NOT part of a valid high+low pair) inside its JSON text
+output — typically from a truncated emoji or hashtag. When an ADK agent sets
+`output_schema=`, ADK validates the model's raw text with Pydantic's
+`model_validate_json`, which rejects lone surrogates:
+
+    Invalid JSON: lone leading surrogate in hex escape
+
+crashing the ad-copy step of a `creative_agent` run.
+
+`scrub_lone_surrogates` removes ONLY lone surrogates. Valid surrogate PAIRS
+(real astral-plane emoji that happen to arrive as two code units) are combined
+into their single code point — the pair form itself does not parse as JSON, so
+combining is required to preserve, not corrupt, the emoji. `scrub_surrogates_in_response`
+is an `after_model_callback` that applies the scrubber to an `LlmResponse`'s text
+parts in place BEFORE ADK validates them against the schema. It mutates and
+returns `None`, so it composes cleanly with other `after_model_callback`s.
+
+This module imports `google.adk`/`google.genai` types but builds no genai
+client, so it stays non-creds-gated and unit-testable offline.
+"""
+
+from google.adk.models.llm_response import LlmResponse
+from google.adk.agents.callback_context import CallbackContext
+
+_HIGH_MIN, _HIGH_MAX = 0xD800, 0xDBFF
+_LOW_MIN, _LOW_MAX = 0xDC00, 0xDFFF
+
+
+def scrub_lone_surrogates(text: str) -> str:
+    """Return ``text`` with lone Unicode surrogates removed.
+
+    A lone surrogate is a code unit in U+D800–U+DFFF that is not part of a valid
+    high+low pair. Lone surrogates are dropped; valid pairs are combined into
+    their astral code point (which round-trips through JSON); all other
+    characters pass through unchanged.
+    """
+    if not text:
+        return text
+
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        code = ord(text[i])
+        if _HIGH_MIN <= code <= _HIGH_MAX:
+            # High surrogate: keep only if immediately followed by a low one.
+            if i + 1 < n and _LOW_MIN <= ord(text[i + 1]) <= _LOW_MAX:
+                low = ord(text[i + 1])
+                combined = 0x10000 + ((code - _HIGH_MIN) << 10) + (low - _LOW_MIN)
+                out.append(chr(combined))
+                i += 2
+                continue
+            # Lone high surrogate -> drop.
+            i += 1
+            continue
+        if _LOW_MIN <= code <= _LOW_MAX:
+            # Lone low surrogate -> drop.
+            i += 1
+            continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+
+def scrub_surrogates_in_response(
+    callback_context: CallbackContext, llm_response: LlmResponse
+) -> None:
+    """`after_model_callback` that scrubs lone surrogates from text parts.
+
+    Set on agents that use `output_schema=` so lone surrogates are removed from
+    the model's raw text BEFORE ADK validates it with `model_validate_json`.
+    Mutates the response in place and returns `None`, so it composes with other
+    `after_model_callback`s (e.g. the empty-turn logger).
+    """
+    # pylint: disable=unused-argument
+    if (
+        llm_response is None
+        or not llm_response.content
+        or not llm_response.content.parts
+    ):
+        return None
+    for part in llm_response.content.parts:
+        text = getattr(part, "text", None)
+        if text:
+            cleaned = scrub_lone_surrogates(text)
+            if cleaned != text:
+                part.text = cleaned
+    return None

--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -435,7 +435,10 @@ ad_copy_drafter = Agent(
     ),
     output_schema=AdCopyList,
     output_key="ad_copy_draft",
-    after_model_callback=callbacks.log_empty_turn_finish_reason,
+    after_model_callback=[
+        callbacks.scrub_surrogates_in_response,
+        callbacks.log_empty_turn_finish_reason,
+    ],
 )
 
 
@@ -528,7 +531,10 @@ ad_copy_critic = Agent(
     ),
     output_schema=FinalAdCopyList,
     output_key="ad_copy_critique",
-    after_model_callback=callbacks.log_empty_turn_finish_reason,
+    after_model_callback=[
+        callbacks.scrub_surrogates_in_response,
+        callbacks.log_empty_turn_finish_reason,
+    ],
 )
 
 

--- a/creative_agent/callbacks.py
+++ b/creative_agent/callbacks.py
@@ -11,7 +11,7 @@ from google.adk.sessions.state import State
 from google.adk.models.llm_request import LlmRequest
 from google.adk.agents.callback_context import CallbackContext
 
-from agent_common import observability
+from agent_common import observability, sanitize
 
 from .config import config
 
@@ -26,6 +26,7 @@ warnings.filterwarnings("ignore")
 # Shared debugging-observability callbacks (agent_common, WS3). Re-exported here
 # so creative_agent/agent.py references `callbacks.<name>`, matching trend_scout.
 log_empty_turn_finish_reason = observability.log_empty_turn_finish_reason
+scrub_surrogates_in_response = sanitize.scrub_surrogates_in_response
 log_final_state_summary = observability.make_final_state_summary(
     "creative_agent",
     (

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -317,8 +317,27 @@ def test_creative_model_agents_have_finish_reason_callback():
         ca.root_agent,
     ]
     for a in agents:
-        assert a.after_model_callback is callbacks.log_empty_turn_finish_reason, (
+        cbs = a.canonical_after_model_callbacks
+        assert callbacks.log_empty_turn_finish_reason in cbs, (
             f"{a.name} missing log_empty_turn_finish_reason after_model_callback"
+        )
+
+
+def test_ad_copy_agents_scrub_lone_surrogates():
+    """The two ad-copy agents parse model text against an output_schema, so they
+    must carry the surrogate scrubber as an after_model_callback (before the
+    empty-turn logger) to survive lone Unicode surrogates in the JSON output."""
+    from creative_agent import agent as ca
+    from creative_agent import callbacks
+
+    for a in (ca.ad_copy_drafter, ca.ad_copy_critic):
+        cbs = a.canonical_after_model_callbacks
+        assert callbacks.scrub_surrogates_in_response in cbs, (
+            f"{a.name} missing scrub_surrogates_in_response after_model_callback"
+        )
+        # Scrubber must run BEFORE the empty-turn logger.
+        assert cbs.index(callbacks.scrub_surrogates_in_response) < cbs.index(
+            callbacks.log_empty_turn_finish_reason
         )
 
 

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,127 @@
+"""Tests for the lone-surrogate scrubber in `agent_common.sanitize`.
+
+Gemini occasionally emits a bare (lone) Unicode surrogate code unit
+(U+D800–U+DFFF not part of a high+low pair) inside its JSON text output — e.g.
+a truncated emoji or hashtag. Pydantic's `model_validate_json` (used by ADK when
+an agent sets `output_schema=`) rejects lone surrogates with
+"Invalid JSON: lone leading surrogate in hex escape", crashing an ad-copy run.
+
+These lock in that:
+- `scrub_lone_surrogates` drops ONLY lone surrogates and leaves valid content
+  intact (including real astral-plane emoji, which must round-trip through JSON).
+- The `scrub_surrogates_in_response` `after_model_callback` cleans an
+  `LlmResponse`'s text parts in place BEFORE ADK validates them against the
+  schema, without disturbing the happy path.
+"""
+
+from types import SimpleNamespace
+
+from google.genai import types
+from google.adk.models.llm_response import LlmResponse
+from pydantic import BaseModel
+
+from agent_common import sanitize
+
+
+class _Copy(BaseModel):
+    headline: str
+
+
+class _CopyList(BaseModel):
+    ad_copies: list[_Copy]
+
+
+def _ctx():
+    return SimpleNamespace(agent_name="ad_copy_drafter", invocation_id="inv-1")
+
+
+def _resp(*, parts=None):
+    content = types.Content(role="model", parts=parts) if parts is not None else None
+    return LlmResponse(content=content)
+
+
+# --- scrub_lone_surrogates --------------------------------------------------
+
+
+def test_lone_high_surrogate_scrubbed_output_parses():
+    """The exact reported crash payload: a lone high surrogate in JSON text."""
+    payload = '{"ad_copies": [{"headline": "Buy now \ud83d"}]}'
+    cleaned = sanitize.scrub_lone_surrogates(payload)
+    # Scrubbed text must now validate against the schema (no lone surrogate).
+    parsed = _CopyList.model_validate_json(cleaned)
+    assert parsed.ad_copies[0].headline == "Buy now "
+
+
+def test_lone_low_surrogate_scrubbed():
+    payload = '{"ad_copies": [{"headline": "x' + chr(0xDE00) + 'y"}]}'
+    cleaned = sanitize.scrub_lone_surrogates(payload)
+    parsed = _CopyList.model_validate_json(cleaned)
+    assert parsed.ad_copies[0].headline == "xy"
+
+
+def test_valid_surrogate_pair_preserved_as_real_emoji():
+    """A valid high+low pair (two code units) is real astral content and must NOT
+    be corrupted — it is combined into its code point and still parses as JSON."""
+    hi, lo = chr(0xD83D), chr(0xDE00)  # -> 😀 (U+1F600)
+    payload = '{"ad_copies": [{"headline": "grin ' + hi + lo + '"}]}'
+    cleaned = sanitize.scrub_lone_surrogates(payload)
+    parsed = _CopyList.model_validate_json(cleaned)
+    assert parsed.ad_copies[0].headline == "grin \U0001f600"
+
+
+def test_real_astral_emoji_untouched():
+    """A real emoji arriving already as a single code point passes through."""
+    payload = '{"ad_copies": [{"headline": "party \U0001f389"}]}'
+    assert sanitize.scrub_lone_surrogates(payload) == payload
+
+
+def test_plain_text_unchanged():
+    text = "no surrogates here #trending"
+    assert sanitize.scrub_lone_surrogates(text) == text
+
+
+def test_empty_string():
+    assert sanitize.scrub_lone_surrogates("") == ""
+
+
+# --- scrub_surrogates_in_response (after_model_callback) ---------------------
+
+
+def test_callback_cleans_lone_surrogate_in_response_text():
+    resp = _resp(parts=[types.Part(text='{"headline": "Buy \ud83d"}')])
+    ret = sanitize.scrub_surrogates_in_response(
+        callback_context=_ctx(), llm_response=resp
+    )
+    # Mutates in place and returns None so it composes with other callbacks.
+    assert ret is None
+    cleaned = resp.content.parts[0].text
+    assert cleaned == '{"headline": "Buy "}'
+    # And the scrubbed text is valid JSON again.
+    _Copy.model_validate_json(cleaned)
+
+
+def test_callback_leaves_clean_text_untouched():
+    resp = _resp(parts=[types.Part(text='{"headline": "clean"}')])
+    sanitize.scrub_surrogates_in_response(callback_context=_ctx(), llm_response=resp)
+    assert resp.content.parts[0].text == '{"headline": "clean"}'
+
+
+def test_callback_handles_response_without_content():
+    resp = _resp(parts=None)
+    assert (
+        sanitize.scrub_surrogates_in_response(
+            callback_context=_ctx(), llm_response=resp
+        )
+        is None
+    )
+
+
+def test_callback_ignores_none_and_non_text_parts():
+    resp = _resp(
+        parts=[
+            types.Part(function_call=types.FunctionCall(name="x", args={})),
+            types.Part(text="ok \ud83d"),
+        ]
+    )
+    sanitize.scrub_surrogates_in_response(callback_context=_ctx(), llm_response=resp)
+    assert resp.content.parts[1].text == "ok "


### PR DESCRIPTION
## What

Makes `creative_agent`'s ad-copy stages tolerant of **lone Unicode surrogates** in model output, which otherwise crash the `output_schema` JSON parse.

- New pure helper `agent_common/sanitize.py`:
  - `scrub_lone_surrogates(text)` — drops unpaired high/low surrogates (U+D800–U+DFFF) that break strict JSON, while **combining valid high+low pairs into their real code point** so genuine emoji survive.
  - `scrub_surrogates_in_response(callback_context, llm_response)` — an `after_model_callback` that scrubs text parts in place and returns `None` so it composes with other callbacks.
- Wired into `ad_copy_drafter` and `ad_copy_critic` (the two `output_schema=`-bearing ad-copy agents) as an ordered callback list — scrubber **before** the empty-turn logger — so scrubbing happens before ADK's `model_validate_json`.
- Exported from `agent_common/__init__.py`.

## Why

ADK runs `after_model_callback` **before** it parses the raw model text against the Pydantic `output_schema`. When a model emits a lone surrogate (e.g. a truncated emoji), the strict JSON parse raises and kills the run. Scrubbing at that injection point fixes it without touching the schema, and combining valid pairs preserves real emoji rather than mangling them.

## Test plan

- `tests/test_sanitize.py` — 6 scrubber cases (lone high, lone low, valid pair→emoji, real astral untouched, plain text, empty) + 4 callback cases (cleans dirty text, leaves clean text, no-content, ignores non-text parts).
- `tests/test_pipeline_structure.py` — asserts the scrubber is present in `canonical_after_model_callbacks` and ordered before the logger on both ad-copy agents.
- `uvx ruff check` / `uvx ruff format --check` / `uvx ty check` clean.
