### PR TITLE
perf(creative_agent): Lever C — downgrade ad_copy/visual critics to flash (-10.8% wall-clock)

### DIFF
--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -526,7 +526,10 @@ class FinalAdCopyList(BaseModel):
 
 # --- AD COPY CRITIC AGENT ---
 ad_copy_critic = Agent(
-    model=build_gemini(config.critic_model),
+    # Lever C: critique/narrow-down of already-generated ad copies is a low-
+    # quality-dependence step, so run it on worker_model (flash) instead of
+    # critic_model (pro) to drop one serial 5-RPM PRO turn from the ad_copy phase.
+    model=build_gemini(config.worker_model),
     name="ad_copy_critic",
     include_contents="none",
     description="Critique and narrow down ad copies based on product, audience, and trends",
@@ -705,7 +708,9 @@ class VisualConceptCritiqueList(BaseModel):
 
 # --- VISUAL CONCEPT CRITIQUE AGENT ---
 visual_concept_critic = Agent(
-    model=build_gemini(config.critic_model),
+    # Lever C: same rationale as ad_copy_critic — narrowing existing visual
+    # concepts is low-quality-dependence, so use worker_model (flash) not pro.
+    model=build_gemini(config.worker_model),
     name="visual_concept_critic",
     include_contents="none",
     description="Critique and narrow down visual concepts",

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -340,6 +340,21 @@ def test_output_schemas_assigned():
     assert visual_concept_finalizer.output_schema == VisualConceptFinalList
 
 
+def test_lever_c_critics_run_on_worker_model():
+    """Lever C: ad_copy_critic and visual_concept_critic are downgraded from
+    critic_model (pro) to worker_model (flash) — narrowing already-generated
+    creatives is low-quality-dependence, and dropping the two serial 5-RPM PRO
+    turns is the latency win being measured. The pro-tier stages that DO carry
+    quality weight (drafters' critic, report composer) stay on critic_model."""
+    from creative_agent import agent as ca
+    from creative_agent.config import ResearchConfiguration
+
+    config = ResearchConfiguration()
+    assert config.worker_model != config.critic_model  # guard the test's premise
+    assert ca.ad_copy_critic.model.model == config.worker_model
+    assert ca.visual_concept_critic.model.model == config.worker_model
+
+
 def test_creative_model_agents_have_finish_reason_callback():
     """Every creative model agent must carry the empty-turn finish_reason
     after_model_callback so a MAX_TOKENS/empty producer turn is logged (WS3 log


### PR DESCRIPTION
## What

**Lever C** from the creative_agent latency experiment: downgrade the two critic stages with the weakest quality dependence — `ad_copy_critic` and `visual_concept_critic` — from `gemini-3.1-pro-preview` to the `worker_model` (`gemini-3.5-flash`).

## Why

The pipeline is quota-bound: ~15–20 serial `pro` (5 RPM) calls dominate wall-clock. Moving two low-value critic turns off the `pro` quota removes serial `pro` waits from the common path.

## Measured result (harness, 3 trials/config)

- **Total wall-clock: −10.8%** vs. baseline (see `docs/experiments/2026-07-15-creative-latency.md`, shipped in #83).
- **Quality gate (ADK eval, cool-window run):** both eval cases **PASSED 1.0/1.0** on the pipeline rubrics (order, all-tools-called, GCS URI present). Free-signal creative-quality dip was small (~5% on judge scores) with **100% pass rate** retained.

Trade-off reported explicitly in the writeup; recommended to ship alongside Lever A.

## Test plan

- `tests/test_pipeline_structure.py::test_lever_c_critics_run_on_worker_model` — asserts both critics now use `worker_model`.
- Full `tests/test_pipeline_structure.py` green; `uvx ruff`/`ty` clean.
- Live ADK eval passed (above).

## Notes

Depends conceptually on the harness/writeup in #83 (measurement + numbers live there). Touches `creative_agent/agent.py` + `tests/test_pipeline_structure.py`, which overlap with the surrogate fix (#85) and Lever A (#82) — will rebase in dependency order at merge time.
