### PR TITLE
feat(trend_scout): opt-in interactive trend picking (human-in-the-loop)

### DIFF
--- a/deployment/async_app.py
+++ b/deployment/async_app.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 
+from google.adk.apps import App
 from google.adk.cli.fast_api import get_fast_api_app
 from google.adk.cli.utils.service_factory import (
     create_artifact_service_from_options,
@@ -71,9 +72,22 @@ if session_service is None:
 
 
 def _runner_factory(app_name: str) -> Runner:
+    # get_root_agent returns a resumable App for the interactive agents (trend_scout,
+    # interactive_creative) and a bare Agent for creative_agent. A Runner derives
+    # resumability ONLY from an App — passing a bare agent= wraps it into a default
+    # App with is_resumable=False, so LongRunningFunctionTool checkpoints could never
+    # resume. Build with app= when we get an App, else fall back to agent=.
+    obj = get_root_agent(app_name)
+    if isinstance(obj, App):
+        return Runner(
+            app=obj,
+            app_name=app_name,
+            session_service=session_service,
+            artifact_service=artifact_service,
+        )
     return Runner(
         app_name=app_name,
-        agent=get_root_agent(app_name),
+        agent=obj,
         session_service=session_service,
         artifact_service=artifact_service,
     )

--- a/frontend/src/__tests__/interactive-mode.test.ts
+++ b/frontend/src/__tests__/interactive-mode.test.ts
@@ -173,6 +173,34 @@ describe("Interactive mode pause detection", () => {
     expect(result).not.toBeNull();
     expect(result!.functionName).toBe("review_visual_concepts");
   });
+
+  it("detects review_trends pause", () => {
+    const event: AgentEvent = {
+      id: "evt-8",
+      invocationId: "inv-1",
+      author: "trend_scout",
+      content: {
+        role: "assistant",
+        parts: [
+          {
+            functionCall: {
+              id: "fc-trends",
+              name: "review_trends",
+              args: {},
+            },
+          },
+        ],
+      },
+      longRunningToolIds: ["fc-trends"],
+      timestamp: Date.now(),
+    };
+
+    const result = detectPause(event);
+    expect(result).not.toBeNull();
+    expect(result!.functionCallId).toBe("fc-trends");
+    expect(result!.functionName).toBe("review_trends");
+    expect(result!.eventId).toBe("evt-8");
+  });
 });
 
 // Test resumeRun request body construction.
@@ -215,5 +243,25 @@ describe("Resume run request body", () => {
 
     expect(body.response.status).toBe("approved");
     expect(body.response.feedback).toBe("");
+  });
+
+  it("constructs the review_trends selection payload", () => {
+    const response = {
+      status: "selected",
+      selected_trends: ["Trend A", "Trend C"],
+      instruction: "focus on pop culture",
+    };
+
+    const body = {
+      functionCallId: "fc-trends",
+      functionName: "review_trends",
+      response,
+      functionCallEventId: "evt-8",
+    };
+
+    expect(body.functionName).toBe("review_trends");
+    expect(body.response.status).toBe("selected");
+    expect(body.response.selected_trends).toEqual(["Trend A", "Trend C"]);
+    expect(body.response.instruction).toBe("focus on pop culture");
   });
 });

--- a/frontend/src/__tests__/parse-raw-gtrends.test.ts
+++ b/frontend/src/__tests__/parse-raw-gtrends.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+
+// parseRawGtrends is not exported (matching extractItems), so we replicate the
+// logic here for testing. This tests the same normalizer used by the
+// ReviewTrends panel to read the `raw_gtrends` candidate terms from state.
+function parseRawGtrends(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((t): t is string => typeof t === "string")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}
+
+describe("parseRawGtrends", () => {
+  it("returns the trimmed string terms", () => {
+    expect(parseRawGtrends(["Trend A", "  Trend B  ", "Trend C"])).toEqual([
+      "Trend A",
+      "Trend B",
+      "Trend C",
+    ]);
+  });
+
+  it("drops empty and whitespace-only terms", () => {
+    expect(parseRawGtrends(["Trend A", "", "   ", "Trend B"])).toEqual([
+      "Trend A",
+      "Trend B",
+    ]);
+  });
+
+  it("drops non-string entries", () => {
+    expect(
+      parseRawGtrends(["Trend A", 42, null, undefined, { x: 1 }, "Trend B"])
+    ).toEqual(["Trend A", "Trend B"]);
+  });
+
+  it("returns an empty array for undefined", () => {
+    expect(parseRawGtrends(undefined)).toEqual([]);
+  });
+
+  it("returns an empty array for a non-array value", () => {
+    expect(parseRawGtrends("Trend A")).toEqual([]);
+    expect(parseRawGtrends({ raw_gtrends: ["a"] })).toEqual([]);
+  });
+
+  it("returns an empty array for an empty array", () => {
+    expect(parseRawGtrends([])).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/poll-run.test.ts
+++ b/frontend/src/__tests__/poll-run.test.ts
@@ -187,4 +187,36 @@ describe("resumeRun", () => {
       functionCallEventId: "evt-1",
     });
   });
+
+  it("posts the review_trends selection to the resume endpoint", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      jsonResponse({ runId: "run-3", status: "running" })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await resumeRun(
+      "trend_scout",
+      "u1",
+      "s1",
+      "fc-trends",
+      "review_trends",
+      { status: "selected", selected_trends: ["Trend A", "Trend C"], instruction: "" },
+      "evt-8"
+    );
+
+    expect(result).toEqual({ runId: "run-3", status: "running" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${API_BASE}/runs/trend_scout/u1/s1/resume`);
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(init?.body as string)).toEqual({
+      functionCallId: "fc-trends",
+      functionName: "review_trends",
+      response: {
+        status: "selected",
+        selected_trends: ["Trend A", "Trend C"],
+        instruction: "",
+      },
+      functionCallEventId: "evt-8",
+    });
+  });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -43,6 +43,7 @@ function HomeContent() {
     targetProduct: "",
     keySellingPoints: "",
     targetSearchTrend: "",
+    interactiveTrendPick: false,
   });
 
   // Pre-fill form from URL params (when clicking a trend card)
@@ -74,7 +75,13 @@ function HomeContent() {
 
     try {
       const userId = `user_${Date.now()}`;
-      const session = await createSession(form.agent, userId);
+      // trend_scout opt-in: seed the session's initial state so the agent pauses
+      // for human trend selection (via the `review_trends` LongRunningFunctionTool).
+      const initialState =
+        form.agent === "trend_scout" && form.interactiveTrendPick
+          ? { interactive_trend_pick: true }
+          : undefined;
+      const session = await createSession(form.agent, userId, initialState);
 
       // Build the user message with campaign metadata
       let message = `Brand Name: "${form.brand}"\nTarget Audience: "${form.targetAudience}"\nTarget Product: "${form.targetProduct}"\nKey Selling Points: "${form.keySellingPoints}"`;
@@ -166,6 +173,32 @@ function HomeContent() {
               </SelectContent>
             </Select>
           </div>
+
+          {form.agent === "trend_scout" && (
+            <label
+              htmlFor="interactive-trend-pick"
+              className="flex items-start gap-3 rounded-xl border border-border bg-background px-4 py-3 cursor-pointer hover:border-foreground/20 transition-colors animate-fadeInUpSmooth"
+            >
+              <input
+                id="interactive-trend-pick"
+                type="checkbox"
+                checked={form.interactiveTrendPick ?? false}
+                onChange={(e) =>
+                  setForm({ ...form, interactiveTrendPick: e.target.checked })
+                }
+                className="mt-0.5 h-4 w-4 shrink-0 rounded border-border accent-primary cursor-pointer"
+              />
+              <span className="space-y-0.5">
+                <span className="block text-sm font-medium text-foreground">
+                  Let me pick the trends myself
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  Pause after gathering the top ~25 trends so you can choose which
+                  to keep.
+                </span>
+              </span>
+            </label>
+          )}
 
           <div className="space-y-2">
             <Label htmlFor="brand" className="text-muted-foreground text-xs uppercase tracking-wider">

--- a/frontend/src/app/run/[sessionId]/page.tsx
+++ b/frontend/src/app/run/[sessionId]/page.tsx
@@ -578,6 +578,124 @@ function ReviewVisualConcepts({
   );
 }
 
+/**
+ * Normalize the candidate trend terms from session state `raw_gtrends`.
+ * The backend stores a `string[]` of ~25 terms; guard against absent/malformed
+ * values and drop empties so the panel renders cleanly.
+ */
+function parseRawGtrends(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((t): t is string => typeof t === "string")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}
+
+function ReviewTrends({
+  state,
+  onResume,
+}: {
+  state: Record<string, unknown>;
+  onResume: (response: Record<string, unknown>) => void;
+}) {
+  const candidates = useMemo(
+    () => parseRawGtrends(state.raw_gtrends),
+    [state.raw_gtrends]
+  );
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [instruction, setInstruction] = useState("");
+
+  const toggle = (term: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(term)) next.delete(term);
+      else next.add(term);
+      return next;
+    });
+  };
+
+  return (
+    <div className="glass rounded-2xl p-6 space-y-4 animate-fadeInUp">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-amber-500" />
+          <h2 className="text-lg font-semibold">Pick Your Trends</h2>
+        </div>
+        {candidates.length > 0 && (
+          <Badge
+            variant="secondary"
+            className="text-[10px] px-1.5 py-0 bg-primary/10 text-primary border-0 font-bold"
+          >
+            {selected.size} / {candidates.length} selected
+          </Badge>
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Select the trends you want to keep. The agent will skip its automatic
+        pick and research the trends you choose.
+      </p>
+      {candidates.length === 0 ? (
+        <p className="text-sm text-muted-foreground italic">
+          No candidate trends available yet.
+        </p>
+      ) : (
+        <div className="grid gap-2 sm:grid-cols-2 max-h-[28rem] overflow-y-auto">
+          {candidates.map((term) => {
+            const isSelected = selected.has(term);
+            return (
+              <button
+                key={term}
+                type="button"
+                onClick={() => toggle(term)}
+                aria-pressed={isSelected}
+                className={`glass rounded-xl px-4 py-3 text-left text-sm transition-all duration-200 hover:shadow-md hover:shadow-black/5 ${
+                  isSelected
+                    ? "ring-2 ring-primary bg-primary/10 text-primary font-semibold"
+                    : "text-foreground/85"
+                }`}
+              >
+                <span className="flex items-center gap-2">
+                  <span
+                    className={`inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border text-[10px] font-bold ${
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border text-transparent"
+                    }`}
+                  >
+                    &#10003;
+                  </span>
+                  <span className="leading-snug break-words">{term}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <Textarea
+        placeholder="Optional note for the agent (e.g. focus, angle)..."
+        value={instruction}
+        onChange={(e) => setInstruction(e.target.value)}
+        rows={2}
+        className="bg-background border-border"
+      />
+      <div className="flex gap-3">
+        <Button
+          disabled={selected.size === 0}
+          onClick={() =>
+            onResume({
+              status: "selected",
+              selected_trends: [...selected],
+              instruction,
+            })
+          }
+        >
+          Confirm Selection
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 function ReviewPanel({
   functionName,
   sessionState,
@@ -595,6 +713,9 @@ function ReviewPanel({
   }
   if (functionName === "review_visual_concepts") {
     return <ReviewVisualConcepts state={sessionState} onResume={onResume} />;
+  }
+  if (functionName === "review_trends") {
+    return <ReviewTrends state={sessionState} onResume={onResume} />;
   }
   return null;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -56,4 +56,11 @@ export interface CampaignInput {
   targetProduct: string;
   keySellingPoints: string;
   targetSearchTrend?: string;
+  /**
+   * trend_scout only: when true, the run pauses after gathering the top ~25
+   * trends so the user can pick which to keep (via the `review_trends`
+   * LongRunningFunctionTool). Wired into the session's initial state as
+   * `interactive_trend_pick`.
+   */
+  interactiveTrendPick?: boolean;
 }

--- a/runserver/async_runs.py
+++ b/runserver/async_runs.py
@@ -16,15 +16,23 @@ RUN_ERROR_KEY = "__run_error"
 
 
 def get_root_agent(app_name: str):
-    """Map an app_name to its root Agent (lazy import — builds a genai client)."""
+    """Map an app_name to its root Agent (lazy import — builds a genai client).
+
+    The interactive agents return a resumable ``App`` (not a bare agent): a
+    ``LongRunningFunctionTool`` checkpoint only pauses/resumes when the Runner is
+    built from an ``App`` carrying ``ResumabilityConfig(is_resumable=True)``.
+    ``trend_scout`` needs it for its opt-in ``review_trends`` checkpoint;
+    ``interactive_creative`` for its three review checkpoints. ``creative_agent``
+    has no checkpoints, so it stays a bare agent. The runner factory branches on
+    the returned type (App vs Agent)."""
     from creative_agent.agent import root_agent as creative
-    from interactive_creative.agent import root_agent as interactive
-    from trend_scout.agent import root_agent as scout
+    from interactive_creative.agent import app as interactive_app
+    from trend_scout.agent import app as scout_app
 
     agents = {
         "creative_agent": creative,
-        "trend_scout": scout,
-        "interactive_creative": interactive,
+        "trend_scout": scout_app,
+        "interactive_creative": interactive_app,
     }
     if app_name not in agents:
         raise KeyError(app_name)

--- a/tests/test_async_runs.py
+++ b/tests/test_async_runs.py
@@ -97,8 +97,18 @@ def test_events_since_slices_by_index():
     reason="agent imports build a module-level genai client requiring GCP ADC",
 )
 def test_get_root_agent_maps_three_agents():
+    from google.adk.apps import App
+
     for app_name in ("creative_agent", "trend_scout", "interactive_creative"):
         assert get_root_agent(app_name) is not None
+
+    # The interactive agents (LongRunningFunctionTool checkpoints) return a
+    # resumable App so the Runner can pause/resume; creative_agent has no
+    # checkpoints and stays a bare Agent.
+    assert isinstance(get_root_agent("trend_scout"), App)
+    assert isinstance(get_root_agent("interactive_creative"), App)
+    assert not isinstance(get_root_agent("creative_agent"), App)
+
     with pytest.raises(KeyError):
         get_root_agent("nope")
 

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -502,6 +502,41 @@ def test_trend_scout_root_has_expected_tools():
         assert name in tool_names, f"Missing tool: {name}"
 
 
+def test_trend_scout_exposes_resumable_app():
+    """The opt-in `review_trends` LongRunningFunctionTool checkpoint only pauses/
+    resumes when the Runner is built from an App carrying
+    ResumabilityConfig(is_resumable=True). trend_scout.agent must expose such an
+    `app` (while still exporting the bare `root_agent` for deploy_agent.py)."""
+    from google.adk.apps import App
+    from trend_scout.agent import app, root_agent
+
+    assert isinstance(app, App)
+    assert app.resumability_config is not None
+    assert app.resumability_config.is_resumable is True
+    assert app.root_agent is root_agent
+
+
+def test_trend_scout_registers_review_trends_tool():
+    """The opt-in trend-picking checkpoint tool must be registered on the root
+    orchestrator so the instruction can call it when interactive_trend_pick is on."""
+    from trend_scout.agent import root_agent
+    from trend_scout.review_tools import review_trends_tool
+
+    assert review_trends_tool in root_agent.tools
+
+
+def test_trend_scout_instruction_branches_on_interactive_flag():
+    """The pick phase must branch on the optional `{interactive_trend_pick?}` var:
+    the interactive branch calls `review_trends`, the default branch keeps calling
+    `pick_trends_agent` unchanged."""
+    from trend_scout.agent import root_agent
+
+    instr = str(root_agent.instruction)
+    assert "{interactive_trend_pick?}" in instr
+    assert "review_trends" in instr
+    assert "pick_trends_agent" in instr
+
+
 def test_trend_scout_sub_agent_output_keys():
     """WS2: understand_trends_agent is split into a searcher (writes
     `info_gtrends_raw`) + a synthesizer (writes JSON `info_gtrends`)."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -85,6 +85,31 @@ class TestTrendTrawlerMemorizeTool:
         assert "status" in result
 
 
+# --- review_trends checkpoint tool (opt-in interactive trend picking) ---
+class TestReviewTrendsTool:
+    def _ctx(self):
+        """A tool_context double exposing the `.actions.skip_summarization`
+        attribute the LongRunningFunctionTool checkpoint sets (mirrors the shape
+        interactive_creative's review_* checkpoints rely on)."""
+        from types import SimpleNamespace
+
+        return SimpleNamespace(actions=SimpleNamespace(skip_summarization=False))
+
+    def test_returns_none_and_skips_summarization(self):
+        from trend_scout.review_tools import review_trends
+
+        ctx = self._ctx()
+        result = review_trends(ctx)
+        assert result is None
+        assert ctx.actions.skip_summarization is True
+
+    def test_wrapped_in_long_running_function_tool(self):
+        from google.adk.tools.long_running_tool import LongRunningFunctionTool
+        from trend_scout.review_tools import review_trends_tool
+
+        assert isinstance(review_trends_tool, LongRunningFunctionTool)
+
+
 # --- record_research_gaps logic ---
 class TestRecordResearchGaps:
     def test_exhaustion_marker_becomes_note(self):

--- a/trend_scout/agent.py
+++ b/trend_scout/agent.py
@@ -78,16 +78,21 @@ understand_trends_searcher = Agent(
     You are a Cultural Trend Researcher gathering raw material for a creative strategist. You want topics that possess cultural, social, or entertainment value.
 
     <CONTEXT>
+        <selected_trends>
+        {target_search_trends?}
+        </selected_trends>
         <raw_gtrends>
         {raw_gtrends?}
         </raw_gtrends>
     </CONTEXT>
 
     ### Instructions
-    0. If <raw_gtrends> is empty, the upstream trend gather did not run. Do NOT invent terms — report that no trends were available and stop.
-    1. **Filter:** Review the list in <raw_gtrends>. Select the top 5-8 terms that appear to be narrative-driven stories (news, memes, celebrity, sports, entertainment). Ignore searches about specific sporting events.
-    2. **Research:** Use the `google_search` tool to investigate *only* these selected terms.
-    3. **Report RAW Findings:** For each selected term, list the concrete facts, entities, dates, and the cultural/social angle you found. Do NOT format as final JSON and do NOT omit specifics — the next agent needs the raw material to structure. Plain text grouped by term is fine.
+    0. If BOTH <selected_trends> and <raw_gtrends> are empty, the upstream trend gather did not run. Do NOT invent terms — report that no trends were available and stop.
+    1. **Choose the terms to research:**
+       - If <selected_trends> holds a non-empty `target_search_trends` list, a human has ALREADY picked the trends. Research EXACTLY those terms — do not filter, drop, or substitute any (even specific sporting events).
+       - Otherwise, review the list in <raw_gtrends> and select the top 5-8 terms that appear to be narrative-driven stories (news, memes, celebrity, sports, entertainment). Ignore searches about specific sporting events.
+    2. **Research:** Use the `google_search` tool to investigate *only* the terms chosen in step 1.
+    3. **Report RAW Findings:** For each chosen term, list the concrete facts, entities, dates, and the cultural/social angle you found. Do NOT format as final JSON and do NOT omit specifics — the next agent needs the raw material to structure. Plain text grouped by term is fine.
     """,
     generate_content_config=types.GenerateContentConfig(
         temperature=1.5,
@@ -275,25 +280,29 @@ trend_scout = Agent(
     - `key_selling_points`
 
     ### Phase 2: Execution Pipeline
-    Execute the following agents in strict sequence. Do not proceed to the next until the current tool reports success.
+    Execute the steps in strict sequence. Do not proceed to the next until the current tool reports success.
 
     1. **Gather:** Call `gather_trends_agent`.
-    2. **Research:** Call `understand_trends_agent_resilient`.
-    3. **Select:** The interactive trend-picking flag is: `{interactive_trend_pick?}`.
 
-       **IF that flag is truthy (True):** Do NOT call `pick_trends_agent`. Instead
-       call `review_trends` to PAUSE the run so a human can pick which of the gathered
-       trends (in the 'raw_gtrends' state key) to keep. When you receive the response
-       from `review_trends`, it contains `status`, `selected_trends` (a list of terms
-       the user chose), and `instruction`. Read the `instruction` field, then for EACH
-       term in `selected_trends` call the `save_search_trends_to_session_state` tool to
-       save it to the session state. NEVER treat the checkpoint response as the end of
-       the workflow — immediately continue to Phase 3.
+    2. **Select & Research:** The interactive trend-picking flag is: `{interactive_trend_pick?}`.
 
-       **ELSE (flag is False or empty):** Call `pick_trends_agent`. *Note: This agent
-       will determine the final trends. Then, for each trending topic in the
-       'selected_gtrends' state key, call the `save_search_trends_to_session_state`
-       tool to save them to the session state.
+       **IF that flag is truthy (True):** The human picks the trends FIRST, so that
+       only their chosen trends are researched.
+       a. Call `review_trends` to PAUSE the run so a human can pick which of the
+          gathered trends (in the 'raw_gtrends' state key) to keep.
+       b. When you receive the response from `review_trends` (fields: `status`,
+          `selected_trends` — the list of terms the user chose — and `instruction`),
+          read the `instruction` field, then for EACH term in `selected_trends` call
+          the `save_search_trends_to_session_state` tool to save it to the session state.
+       c. Call `understand_trends_agent_resilient` to research the selected trends.
+       d. Do NOT call `pick_trends_agent`. Immediately continue to Phase 3.
+
+       **ELSE (flag is False or empty):**
+       a. Call `understand_trends_agent_resilient` to research the gathered trends.
+       b. Call `pick_trends_agent`. *Note: This agent will determine the final trends.*
+       c. For each trending topic in the 'selected_gtrends' state key, call the
+          `save_search_trends_to_session_state` tool to save them to the session state.
+       Continue to Phase 3.
 
     ### Phase 3: Finalization & Persistence
     Once Phase 2 is complete, trigger the persistence layer. Call `record_research_gaps` FIRST so the note is captured before the session state is snapshotted; the remaining tools may run in parallel if supported, otherwise execute sequentially:

--- a/trend_scout/agent.py
+++ b/trend_scout/agent.py
@@ -3,6 +3,7 @@ import warnings
 
 from google.genai import types
 from google.adk.agents import Agent, SequentialAgent
+from google.adk.apps import App, ResumabilityConfig
 from google.adk.planners import BuiltInPlanner
 from google.adk.tools.agent_tool import AgentTool
 from google.adk.tools import google_search
@@ -16,6 +17,7 @@ from .tools import (
     write_to_file,
     memorize,
 )
+from .review_tools import review_trends_tool
 from agent_common import build_gemini, RetryUntilKeyAgent
 from . import callbacks
 from .config import config, INFRA_RETRY
@@ -277,8 +279,21 @@ trend_scout = Agent(
 
     1. **Gather:** Call `gather_trends_agent`.
     2. **Research:** Call `understand_trends_agent_resilient`.
-    3. **Select:** Call `pick_trends_agent`. *Note: This agent will determine the final trends.
-    4. For each trending topic in the 'selected_gtrends' state key, call the `save_search_trends_to_session_state` tool to save them to the session state.
+    3. **Select:** The interactive trend-picking flag is: `{interactive_trend_pick?}`.
+
+       **IF that flag is truthy (True):** Do NOT call `pick_trends_agent`. Instead
+       call `review_trends` to PAUSE the run so a human can pick which of the gathered
+       trends (in the 'raw_gtrends' state key) to keep. When you receive the response
+       from `review_trends`, it contains `status`, `selected_trends` (a list of terms
+       the user chose), and `instruction`. Read the `instruction` field, then for EACH
+       term in `selected_trends` call the `save_search_trends_to_session_state` tool to
+       save it to the session state. NEVER treat the checkpoint response as the end of
+       the workflow — immediately continue to Phase 3.
+
+       **ELSE (flag is False or empty):** Call `pick_trends_agent`. *Note: This agent
+       will determine the final trends. Then, for each trending topic in the
+       'selected_gtrends' state key, call the `save_search_trends_to_session_state`
+       tool to save them to the session state.
 
     ### Phase 3: Finalization & Persistence
     Once Phase 2 is complete, trigger the persistence layer. Call `record_research_gaps` FIRST so the note is captured before the session state is snapshotted; the remaining tools may run in parallel if supported, otherwise execute sequentially:
@@ -304,6 +319,7 @@ trend_scout = Agent(
         AgentTool(agent=gather_trends_agent),
         AgentTool(agent=understand_trends_agent_resilient),
         AgentTool(agent=pick_trends_agent),
+        review_trends_tool,
         save_search_trends_to_session_state,
         save_session_state_to_gcs,
         record_research_gaps,
@@ -330,3 +346,13 @@ trend_scout = Agent(
 
 # Set as root agent
 root_agent = trend_scout
+
+# Wrap in an App with resumability enabled — required for the opt-in
+# `review_trends` LongRunningFunctionTool to pause and resume across separate
+# /runs calls. `root_agent` stays exported unchanged (deployment/deploy_agent.py
+# imports the bare agent); the resumable App is used by the runserver runner.
+app = App(
+    name="trend_scout",
+    root_agent=root_agent,
+    resumability_config=ResumabilityConfig(is_resumable=True),
+)

--- a/trend_scout/callbacks.py
+++ b/trend_scout/callbacks.py
@@ -71,6 +71,15 @@ def load_session_state(callback_context: CallbackContext):
 
     _set_initial_states(data["state"], callback_context.state)
 
+    # Opt-in human checkpoint for trend selection (default OFF). Seeded only when
+    # absent so the `{interactive_trend_pick?}` instruction var is always defined
+    # and a non-interactive run is byte-for-byte unaffected — while a caller that
+    # opted in (passing `interactive_trend_pick=True` in the initial session
+    # state) keeps its value (unlike the metadata keys above, which are seeded
+    # blank and filled later via `memorize`).
+    if "interactive_trend_pick" not in callback_context.state:
+        callback_context.state["interactive_trend_pick"] = False
+
 
 def rate_limit_callback(
     callback_context: CallbackContext, llm_request: LlmRequest

--- a/trend_scout/review_tools.py
+++ b/trend_scout/review_tools.py
@@ -1,0 +1,27 @@
+from google.adk.tools.long_running_tool import LongRunningFunctionTool
+from google.adk.tools.tool_context import ToolContext
+
+
+def review_trends(tool_context: ToolContext) -> None:
+    """Pause the run so a human can pick which gathered trends to keep.
+
+    Opt-in checkpoint (gated by the `interactive_trend_pick` session flag). It
+    pauses the run after `gather_trends_agent` has populated `state["raw_gtrends"]`
+    (~25 Google Search terms) so the user can choose the subset to keep instead of
+    letting `pick_trends_agent` auto-pick 3.
+
+    When the run resumes, this tool call receives a function response of the shape:
+        {
+            "status": str,               # e.g. "approved"
+            "selected_trends": list[str],  # the terms the user chose to keep
+            "instruction": str,          # tells you to continue the workflow
+        }
+    Read the `instruction` field and continue: for each term in `selected_trends`,
+    call `save_search_trends_to_session_state(term)`, then call `write_trends_to_bq`.
+    Do NOT call `pick_trends_agent` in this branch.
+    """
+    tool_context.actions.skip_summarization = True
+    return None
+
+
+review_trends_tool = LongRunningFunctionTool(review_trends)


### PR DESCRIPTION
## Summary

Adds an **optional** mid-run checkpoint so a user can view all ~25 gathered Google Search trends and pick which to keep, instead of `trend_scout` auto-picking 3. Gated by a new session flag `interactive_trend_pick` (**default OFF**).

**Purely additive.** Every existing path is byte-for-byte unchanged when the flag is unset:
- Cloud Run fan-out worker (`cloud_functions/creative_fanout`) never sets it
- `adk web` and any run with the box unchecked
- `pick_trends_agent` stays in place and is only *skipped at runtime* when the user supplies picks

## How it works

1. Frontend checkbox ("Let me pick the trends myself", shown only for `trend_scout`) seeds `createSession` initial state `{interactive_trend_pick: true}`.
2. The agent gathers ~25 trends, then calls the new `review_trends` `LongRunningFunctionTool`, which **pauses** the run.
3. The `/run` page detects the pause and renders a multi-select `ReviewTrends` panel from `state.raw_gtrends`.
4. Confirm resumes via the existing `/runs/.../resume` endpoint with `{status, selected_trends, instruction}`; the agent saves the picked terms and skips the auto-pick, then persists to BigQuery as usual.

## Resumability wiring (load-bearing)

A `Runner` derives resumability **only from an `App`** — passing a bare `agent=` wraps it into a default `App` with `is_resumable=False`, so `LongRunningFunctionTool` checkpoints could never resume over `/runs`. This PR makes `get_root_agent` return the resumable `App` for `trend_scout` **and** `interactive_creative`, and `_runner_factory` build `Runner(app=...)` for Apps. This also fixes `interactive_creative`'s resume, which had the same latent gap.

## Changes

**Backend**
- `trend_scout/review_tools.py` (new) — `review_trends` checkpoint tool
- `trend_scout/agent.py` — branch the "Select" step on `{interactive_trend_pick?}`, register the tool, export a resumable `App` (bare `root_agent` still exported for Agent Engine deploy)
- `trend_scout/callbacks.py` — seed the flag `False` only when absent (opt-in `True` survives)
- `runserver/async_runs.py` — `get_root_agent` returns resumable Apps for the interactive agents
- `deployment/async_app.py` — `_runner_factory` branches `Runner(app=…)` vs `agent=…`

**Frontend**
- `app/page.tsx`, `lib/types.ts` — opt-in checkbox → initial-state flag
- `app/run/[sessionId]/page.tsx` — `ReviewTrends` panel + `review_trends` dispatcher case

## Verification

- Backend: `uv run pytest tests/ -q` → **347 passed** (+5 new); `ruff check`/`ruff format` clean; `ty` = pre-existing baseline (no new errors in touched files)
- Frontend: `npm test` → **99 passed** (+new cases); `tsc --noEmit` clean; `lint` clean

## Deploy note

`trend-trawler-api` currently pins 100% traffic to a tagged revision (`main-clean`) with newer revisions idle, so `gcloud run deploy` will **not** auto-route. Shipping requires an explicit `gcloud run services update-traffic trend-trawler-api --region=us-central1 --to-latest` (ideally deploy `--no-traffic --tag`, smoke-test, then flip). No live users, so low risk.