### PR TITLE
fix(bq): parameterize trend INSERTs (quote-in-trend 400 syntax error)

### DIFF
--- a/creative_agent/tools.py
+++ b/creative_agent/tools.py
@@ -1321,10 +1321,12 @@ def write_trends_to_bq(tool_context: ToolContext) -> dict:
     try:
         # insert a row for the target search trend
         target_trend = tool_context.state["target_search_trends"]
-        # write SQL
+        # write SQL — parameterized (@named) so a trend/brand/field containing a
+        # quote or apostrophe can't break the statement or inject SQL. The table
+        # name is a config-derived identifier (not parameterizable), not user input.
         sql_query = f"""
-        INSERT INTO 
-            `{config.BQ_PROJECT_ID}.{config.BQ_DATASET_ID}.{config.BQ_TABLE_CREATIVES}` (uuid, 
+        INSERT INTO
+            `{config.BQ_PROJECT_ID}.{config.BQ_DATASET_ID}.{config.BQ_TABLE_CREATIVES}` (uuid,
             target_trend,
             datetime,
             creative_gcs,
@@ -1332,21 +1334,42 @@ def write_trends_to_bq(tool_context: ToolContext) -> dict:
             target_audience,
             target_product,
             key_selling_point)
-        VALUES 
+        VALUES
         (
-            "{unique_id}", 
-            "{target_trend}",
-            CURRENT_DATETIME('America/New_York'), 
-            "{creative_gcs}",
-            "{tool_context.state["brand"]}",
-            "{tool_context.state["target_audience"]}",
-            "{tool_context.state["target_product"]}",
-            "{tool_context.state["key_selling_points"]}"
+            @unique_id,
+            @target_trend,
+            CURRENT_DATETIME('America/New_York'),
+            @creative_gcs,
+            @brand,
+            @target_audience,
+            @target_product,
+            @key_selling_points
         );
         """
-        # FORMAT_DATETIME("%Y-%m-%d %H:%M:%S", CURRENT_DATETIME('America/New_York')),
+        query_params = [
+            bigquery.ScalarQueryParameter("unique_id", "STRING", unique_id),
+            bigquery.ScalarQueryParameter("target_trend", "STRING", target_trend),
+            bigquery.ScalarQueryParameter("creative_gcs", "STRING", creative_gcs),
+            bigquery.ScalarQueryParameter(
+                "brand", "STRING", tool_context.state["brand"]
+            ),
+            bigquery.ScalarQueryParameter(
+                "target_audience", "STRING", tool_context.state["target_audience"]
+            ),
+            bigquery.ScalarQueryParameter(
+                "target_product", "STRING", tool_context.state["target_product"]
+            ),
+            bigquery.ScalarQueryParameter(
+                "key_selling_points",
+                "STRING",
+                tool_context.state["key_selling_points"],
+            ),
+        ]
         # make API request
-        job = bq_client.query(sql_query)
+        job = bq_client.query(
+            sql_query,
+            job_config=bigquery.QueryJobConfig(query_parameters=query_params),
+        )
         job.result()  # wait for job to complete
         if job.errors:
             logging.error(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -157,22 +157,48 @@ class TestBuildTrendInsertSql:
         params.update(overrides)
         return _build_trend_insert_sql(**params)
 
+    @staticmethod
+    def _param_value(params, name):
+        for p in params:
+            if p.name == name:
+                return p.value
+        raise AssertionError(f"query parameter {name!r} not found")
+
     def test_includes_research_gaps_column_and_trend(self):
-        sql = self._sql()
+        sql, params = self._sql()
+        # column names live in the SQL; the trend value is a bound parameter,
+        # never interpolated into the statement text.
         assert "research_gaps" in sql
         assert "target_trends_crf" in sql
-        assert "Golden Dip" in sql
+        assert "Golden Dip" not in sql
+        assert self._param_value(params, "trend") == "Golden Dip"
 
-    def test_research_gaps_value_interpolated(self):
+    def test_research_gaps_value_bound_as_parameter(self):
         note = "Step 'info_gtrends' exhausted retries and produced no output."
-        sql = self._sql(research_gaps=note)
-        assert note in sql
+        sql, params = self._sql(research_gaps=note)
+        # the apostrophe in the note must not appear (unescaped) in the SQL text
+        assert note not in sql
+        assert self._param_value(params, "research_gaps") == note
 
-    def test_empty_research_gaps_still_valid(self):
-        # empty note is written as an empty string literal, not omitted
-        sql = self._sql(research_gaps="")
-        assert "research_gaps)" in sql or "research_gaps)" in sql
-        assert '""' in sql
+    def test_empty_research_gaps_still_bound(self):
+        sql, params = self._sql(research_gaps="")
+        assert "research_gaps)" in sql
+        assert self._param_value(params, "research_gaps") == ""
+
+    def test_values_are_parameter_placeholders_not_literals(self):
+        # regression: values must be @named placeholders, so quotes/apostrophes
+        # in a trend can't terminate a string literal early (the "Prophetic" bug).
+        sql, _ = self._sql()
+        assert "@trend" in sql
+        assert "@brand" in sql
+
+    def test_trend_with_quotes_does_not_leak_into_sql(self):
+        # regression for the 400 "Expected ) or , but got identifier" error: a
+        # trend containing a double quote used to break the INSERT literal.
+        tricky = 'The "Prophetic" Trend'
+        sql, params = self._sql(trend=tricky)
+        assert tricky not in sql
+        assert self._param_value(params, "trend") == tricky
 
 
 # --- save_search_trends_to_session_state logic ---
@@ -355,8 +381,12 @@ class TestWriteTrendsUuidStash:
             def result(self):
                 return None
 
+        captured = {}
+
         class _BQ:
-            def query(self, sql):
+            def query(self, sql, job_config=None):
+                captured["sql"] = sql
+                captured["job_config"] = job_config
                 return _Job()
 
         monkeypatch.setattr(t, "_get_bigquery_client", lambda: _BQ())
@@ -377,3 +407,7 @@ class TestWriteTrendsUuidStash:
         assert result["status"] == "success"
         assert ctx.state["creative_row_uuid"]  # non-empty 8-char id
         assert len(ctx.state["creative_row_uuid"]) == 8
+        # the trend value must be a bound parameter, not interpolated into SQL
+        assert "tswift engaged" not in captured["sql"]
+        param_names = {p.name for p in captured["job_config"].query_parameters}
+        assert "target_trend" in param_names

--- a/trend_scout/tools.py
+++ b/trend_scout/tools.py
@@ -294,15 +294,21 @@ def _build_trend_insert_sql(
     target_product: str,
     key_selling_points: str,
     research_gaps: str,
-) -> str:
+) -> tuple[str, list[bigquery.ScalarQueryParameter]]:
     """Build the single-row INSERT for `target_trends_crf` (pure, unit-testable).
+
+    Returns the parameterized SQL plus its bound query parameters. Values are
+    passed as `@named` BigQuery query parameters (never string-interpolated) so a
+    trend/brand/field containing a quote or apostrophe can't break the statement
+    or inject SQL. Only `table` is interpolated — it is a config-derived identifier
+    (BigQuery cannot parameterize table names), not user input.
 
     `research_gaps` mirrors `creative_evals.research_gaps`: an empty string on a
     clean run, or the `collect_degradation_warnings` note(s) when the resilient
     research wrapper exhausted its retries. The `research_gaps` column must already
     exist (additive `ALTER TABLE ... ADD COLUMN research_gaps STRING`).
     """
-    return f"""
+    sql = f"""
     INSERT INTO
       `{table}` (uuid,
         -- processed_status, -- omitting will make it NULL
@@ -318,19 +324,34 @@ def _build_trend_insert_sql(
         research_gaps)
     VALUES
     (
-        "{unique_id}",
-        "{trend}",
-        PARSE_DATE('%m/%d/%Y', '{max_date}'),
-        PARSE_DATE('%m/%d/%Y', '{current_date}'),
+        @unique_id,
+        @trend,
+        PARSE_DATE('%m/%d/%Y', @max_date),
+        PARSE_DATE('%m/%d/%Y', @current_date),
         CURRENT_TIMESTAMP(),
-        "{trawler_gcs}",
-        "{brand}",
-        "{target_audience}",
-        "{target_product}",
-        "{key_selling_points}",
-        "{research_gaps}"
+        @trawler_gcs,
+        @brand,
+        @target_audience,
+        @target_product,
+        @key_selling_points,
+        @research_gaps
     );
     """
+    params = [
+        bigquery.ScalarQueryParameter("unique_id", "STRING", unique_id),
+        bigquery.ScalarQueryParameter("trend", "STRING", trend),
+        bigquery.ScalarQueryParameter("max_date", "STRING", max_date),
+        bigquery.ScalarQueryParameter("current_date", "STRING", current_date),
+        bigquery.ScalarQueryParameter("trawler_gcs", "STRING", trawler_gcs),
+        bigquery.ScalarQueryParameter("brand", "STRING", brand),
+        bigquery.ScalarQueryParameter("target_audience", "STRING", target_audience),
+        bigquery.ScalarQueryParameter("target_product", "STRING", target_product),
+        bigquery.ScalarQueryParameter(
+            "key_selling_points", "STRING", key_selling_points
+        ),
+        bigquery.ScalarQueryParameter("research_gaps", "STRING", research_gaps),
+    ]
+    return sql, params
 
 
 # refresh_date: str = max_date
@@ -372,8 +393,8 @@ def write_trends_to_bq(tool_context: ToolContext) -> dict:
         # insert a row for each selected target search trend
         target_trends = tool_context.state.get("target_search_trends")
         for trend in target_trends["target_search_trends"]:
-            # write SQL
-            sql_query = _build_trend_insert_sql(
+            # write SQL (parameterized — see _build_trend_insert_sql)
+            sql_query, query_params = _build_trend_insert_sql(
                 table=table,
                 unique_id=unique_id,
                 trend=trend,
@@ -387,7 +408,10 @@ def write_trends_to_bq(tool_context: ToolContext) -> dict:
                 research_gaps=research_gaps,
             )
             # make API request
-            job = bq_client.query(sql_query)
+            job = bq_client.query(
+                sql_query,
+                job_config=bigquery.QueryJobConfig(query_parameters=query_params),
+            )
             job.result()  # wait for job to complete
             if job.errors:
                 logging.error(


### PR DESCRIPTION
## Problem

Running `trend_scout` failed during `write_trends_to_bq()` with:

> `400 Syntax error: Expected ")" or "," but got identifier "Prophetic"` (`invalidQuery`)

**Root cause:** `write_trends_to_bq` in **both** `trend_scout/tools.py` and `creative_agent/tools.py` built the `INSERT` by f-string-interpolating trend/brand/audience/product strings directly into double-quoted SQL literals (`"{trend}"`). A trend containing a double quote — e.g. `The "Prophetic" Trend` — closed the string literal early, leaving `Prophetic` as a bare identifier and breaking the statement. This was also a SQL-injection hole.

## Fix

Bind every value as a `@named` BigQuery query parameter via `QueryJobConfig(query_parameters=[...])`, matching the existing precedent already in `trend_scout/tools.py` (`_get_gtrends_max_date`). Only the config-derived table identifier stays interpolated — BigQuery cannot parameterize table names, and it is not user input.

- `trend_scout/tools.py` — `_build_trend_insert_sql` now returns `(sql, params)`; caller passes a `QueryJobConfig`.
- `creative_agent/tools.py` — same parameterization for its `write_trends_to_bq` (same latent bug).

## Tests

- Updated the pure `_build_trend_insert_sql` tests for the new tuple return.
- Added regression tests: values are `@placeholder`s (not literals), and a trend containing `"` is bound as a parameter and never appears in the SQL text.
- Full suite: **349 passed**. `ruff check`/`format` and `ty check` clean.