### PR TITLE
fix(trend_scout): restore trend→creative handoff after interactive trend pick

### DIFF
--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -527,14 +527,29 @@ def test_trend_scout_registers_review_trends_tool():
 
 def test_trend_scout_instruction_branches_on_interactive_flag():
     """The pick phase must branch on the optional `{interactive_trend_pick?}` var:
-    the interactive branch calls `review_trends`, the default branch keeps calling
-    `pick_trends_agent` unchanged."""
+    the interactive branch calls `review_trends`, and BOTH branches call
+    `pick_trends_agent` (the interactive branch repurposes it to narrate the
+    human's already-chosen trends into `selected_gtrends` for the handoff UI)."""
     from trend_scout.agent import root_agent
 
     instr = str(root_agent.instruction)
     assert "{interactive_trend_pick?}" in instr
     assert "review_trends" in instr
     assert "pick_trends_agent" in instr
+    # regression: the interactive branch must NOT skip pick_trends_agent, or the
+    # frontend handoff (gated on selected_gtrends) never renders.
+    assert "Do NOT call `pick_trends_agent`" not in instr
+
+
+def test_pick_trends_agent_enriches_human_selected_trends():
+    """In interactive mode pick_trends_agent must narrate the human's already-chosen
+    trends (from target_search_trends) into selected_gtrends instead of re-selecting,
+    so the trend->creative_agent handoff cards render. It therefore reads the picks
+    via the optional `{target_search_trends?}` context var."""
+    from trend_scout.agent import pick_trends_agent
+
+    assert "{target_search_trends?}" in pick_trends_agent.instruction
+    assert pick_trends_agent.output_key == "selected_gtrends"
 
 
 def test_trend_scout_sub_agent_output_keys():

--- a/trend_scout/agent.py
+++ b/trend_scout/agent.py
@@ -207,18 +207,28 @@ pick_trends_agent = Agent(
         <trend_research>
         {info_gtrends?}
         </trend_research>
+
+        <human_selected_trends>
+        {target_search_trends?}
+        </human_selected_trends>
     </CONTEXT>
 
     <INSTRUCTIONS>
         0. If <trend_research> is empty, the upstream trend research did not run.
            Do NOT invent trends — output a single line noting that no trend
            research was available, and stop.
-        1. Analyze the <trend_research> JSON.
-        2. Select exactly 3 trends that offer the strongest narrative alignment
-           with the <campaign_data>. You MUST return 3. Only return fewer if
-           <trend_research> contains fewer than 3 distinct trends, in which case
-           return every trend available.
-        3. For each selected trend, define the "Strategic Bridge"—the specific angle that connects the trend's cultural mood to the product's unique selling points.
+        1. Analyze the <trend_research> JSON, then decide WHICH trends to write up:
+           - **If <human_selected_trends> contains a NON-EMPTY `target_search_trends`
+             list**, a human has ALREADY chosen the trends. Do NOT re-select, add,
+             drop, or reorder them. Write up EXACTLY those trends — one section per
+             chosen term — and use the SAME term text VERBATIM as each `### ` heading
+             (the downstream handoff matches on it). Draw the Context from
+             <trend_research>.
+           - **Otherwise**, select exactly 3 trends from <trend_research> that offer
+             the strongest narrative alignment with <campaign_data>. You MUST return
+             3. Only return fewer if <trend_research> contains fewer than 3 distinct
+             trends, in which case return every trend available.
+        2. For each trend in the chosen set, define the "Strategic Bridge"—the specific angle that connects the trend's cultural mood to the product's unique selling points.
 
         Output your findings in the requested format.
     </INSTRUCTIONS>
@@ -295,7 +305,12 @@ trend_scout = Agent(
           read the `instruction` field, then for EACH term in `selected_trends` call
           the `save_search_trends_to_session_state` tool to save it to the session state.
        c. Call `understand_trends_agent_resilient` to research the selected trends.
-       d. Do NOT call `pick_trends_agent`. Immediately continue to Phase 3.
+       d. Call `pick_trends_agent`. Because the human already chose the trends
+          (saved in 'target_search_trends'), this agent will NOT re-select — it
+          writes the strategic narrative for EXACTLY those chosen trends into the
+          'selected_gtrends' state key. Do NOT call
+          `save_search_trends_to_session_state` again (the picks are already saved).
+          Continue to Phase 3.
 
        **ELSE (flag is False or empty):**
        a. Call `understand_trends_agent_resilient` to research the gathered trends.


### PR DESCRIPTION
## Problem

After running `trend_scout` in **interactive trend-pick** mode, the run completes and artifacts land in GCS, but the UI never shows the **"Recommended Trends"** cards with the **"Generate Creatives →"** button that hands off the selected trend(s) to `creative_agent`.

**Root cause:** those cards (`frontend/.../run/[sessionId]/page.tsx` → `TrendCards`) are gated on the session state key **`selected_gtrends`** — the rich per-trend markdown (Hook / Context / Why it fits / Strategic Bridge) written by `pick_trends_agent` (its `output_key`). The interactive path deliberately **skipped `pick_trends_agent`** (the human does the picking), so `selected_gtrends` was never populated. Picks were still researched and written to BigQuery (`target_search_trends`), but the handoff UI had nothing to render.

## Fix — repurpose `pick_trends_agent` as an enricher (full parity)

- `pick_trends_agent` now also reads the human's picks via `{target_search_trends?}`. **When that list is non-empty**, it does **not** re-select — it writes the strategic narrative for **exactly** those trends into `selected_gtrends`, using each picked term **verbatim** as the `### ` heading (so the handoff matches on it). Context is drawn from the trend research.
- The orchestrator's interactive branch now **calls `pick_trends_agent`** after research (previously "Do NOT call"), and does not re-save the already-saved picks.
- **Default (auto-pick) path is unchanged:** the picks list is empty when `pick_trends_agent` runs, so it selects 3 as before.

Net effect: interactive runs now produce the same `selected_gtrends` content, so the trend→`creative_agent` handoff cards render exactly as in the non-interactive flow.

## Tests

- Updated `test_trend_scout_instruction_branches_on_interactive_flag` — asserts the interactive branch no longer skips `pick_trends_agent`.
- Added `test_pick_trends_agent_enriches_human_selected_trends` — asserts it reads `{target_search_trends?}` and still writes `selected_gtrends`.
- Full suite: **350 passed**; `ruff check`/`format` clean. (Pre-existing `SequentialAgent` deprecation warnings only.)

Backend-only change; no frontend changes needed (the handoff already consumes `selected_gtrends`).