### PR TITLE
docs(deployment): document Cloud Run redeploy + rollback via traffic tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,8 @@ python deployment/deploy_agent.py --version=v1 --agent=creative_agent --create
 ```
 
 **→ Full instructions** — IAM, Pub/Sub topics, eventarc triggers, invoking the fan-out, testing deployed
-agents, and the Cloud Run alternative — **live in [deployment/README.md](deployment/README.md).**
+agents, the Cloud Run alternative, and [redeploy + rollback via traffic tags](deployment/README.md#8-redeploying-a-new-build--rollback-traffic-tags) —
+**live in [deployment/README.md](deployment/README.md).**
 
 
 ## Testing

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -670,6 +670,67 @@ loads the app in a browser, a run progresses via polling, and an artifact loads 
 Never re-add `allUsers`; add non-domain viewers individually with
 `roles/iap.httpsResourceAccessor`.
 
+### 8. Redeploying a new build + rollback (traffic tags)
+
+Both services now **follow `LATEST`** (`status.traffic.latestRevision: true`), so a
+`gcloud run deploy` of either one **auto-routes 100% to the revision it just created** — no
+manual traffic flip needed. (This was not always true: traffic used to be pinned to a
+specific revision, so deploys created a new revision at 0% and required an explicit
+`update-traffic --to-latest`. If you ever see the deploy's final log line naming an *old*
+revision, that pin has returned — verify and re-point as below.)
+
+**Redeploy (from a `main` checkout):**
+
+```bash
+# Backend — MUST re-pass --no-cpu-throttling --min-instances 1 AND all env vars incl.
+# SESSION_SERVICE_URI (a bare --set-env-vars drops anything omitted); see Steps 2 + 6.
+gcloud run deploy trend-trawler-api  --source .        --region $REGION ...   # (Step 2 flags)
+# Frontend — do NOT pass --allow-unauthenticated; IAP + its IAM bindings are service-level
+# and are preserved across new revisions (see Step 7).
+gcloud run deploy trend-trawler-web  --source ./frontend --region $REGION ...  # (Step 4 flags)
+```
+
+**Confirm what's actually live** (a green check in the console = the revision is *healthy*,
+NOT that it serves traffic — read the traffic %, not the checkmark):
+
+```bash
+gcloud run services describe trend-trawler-api --region $REGION --format='value(status.traffic)'
+gcloud run revisions list --service trend-trawler-api --region $REGION \
+  --sort-by="~metadata.creationTimestamp"   # suffixes are NOT monotonic — sort by time
+```
+
+**Rollback.** The previous known-good revision of each service is kept at **0% traffic**
+and reachable by a stable **tag** — a named alias URL pinned to one revision
+(`https://<tag>---<service>-<hash>.run.app`). These are the rollback anchors:
+
+| Service | Rollback tag | (revision at time of writing) |
+|---|---|---|
+| `trend-trawler-api` | `main-clean` | `trend-trawler-api-00036-har` |
+| `trend-trawler-web` | `main-current` | `trend-trawler-web-00011-giv` |
+
+```bash
+# Instant rollback: send 100% of traffic to the tagged known-good revision.
+gcloud run services update-traffic trend-trawler-api --region $REGION --to-tags main-clean=100
+gcloud run services update-traffic trend-trawler-web --region $REGION --to-tags main-current=100
+
+# ...then to return to the newest revision:
+gcloud run services update-traffic trend-trawler-api --region $REGION --to-latest
+```
+
+**After a deploy is confirmed good,** move the rollback tag onto the new revision so the
+anchor tracks "last known-good" (tags don't move on their own):
+
+```bash
+NEW_REV=$(gcloud run services describe trend-trawler-api --region $REGION \
+  --format='value(status.latestReadyRevisionName)')
+gcloud run services update-traffic trend-trawler-api --region $REGION \
+  --set-tags main-clean=$NEW_REV        # re-point the tag; traffic split is unchanged
+```
+
+Old, untagged, 0%-traffic revisions are safe to leave (they cost nothing idle) or prune with
+`gcloud run revisions delete <rev> --region $REGION`. Keep at least the current
+`main-clean` / `main-current` pair as your safety net.
+
 ---
 
 ## Alternative Deployment: deploy to Cloud Run instances


### PR DESCRIPTION
Documents how to redeploy the two Cloud Run services and how to roll back — prompted by a "what are these old green-checked, tagged revisions?" question.

## `deployment/README.md`
New subsection **§8 "Redeploying a new build + rollback (traffic tags)"** under the frontend Cloud Run runbook:
- Clarifies that a console **green checkmark = revision *healthy*, not *serving*** — read the traffic %, not the checkmark.
- Notes both services now **follow `LATEST`** (`latestRevision: true`), so `gcloud run deploy` auto-routes 100% to the new revision — with a caveat for detecting if the old traffic-pin ever returns.
- **Rollback command** via the stable tags:
  ```bash
  gcloud run services update-traffic trend-trawler-api --region $REGION --to-tags main-clean=100
  gcloud run services update-traffic trend-trawler-web --region $REGION --to-tags main-current=100
  ```
- Table mapping each service → rollback tag (`main-clean` / `main-current`) → anchored revision.
- How to re-point a tag onto a confirmed-good revision after a deploy, and pruning idle 0%-traffic revisions.
- Reiterates the redeploy caveats (backend must re-pass `--no-cpu-throttling --min-instances 1` + all env incl. `SESSION_SERVICE_URI`; frontend must not re-add `--allow-unauthenticated` so IAP is preserved).

## `README.md`
Extended the existing "Full instructions" deploy pointer to link straight to the new rollback subsection.

Docs-only; no code or behavior changes.