### PR TITLE
fix(trend_scout): spread agents across 5 quota buckets to end UI 429s

### DIFF
--- a/agent_common/models.py
+++ b/agent_common/models.py
@@ -13,13 +13,20 @@ from google.adk.models import Gemini
 from agent_common import locations
 
 
-def build_gemini(model_name: str) -> Gemini:
-    """Return an ADK ``Gemini`` model pinned to the model-serving location.
+def build_gemini(model_name: str, location: str | None = None) -> Gemini:
+    """Return an ADK ``Gemini`` model pinned to a model-serving location.
 
     Use this everywhere an agent would otherwise take a bare model-name string,
     so gemini-3.x models resolve to their `global`-serving endpoint even inside a
     regional Agent Engine deployment.
+
+    ``location`` defaults to :data:`agent_common.locations.MODEL_LOCATION`
+    (``global``, the only endpoint that serves gemini-3.x). Pass an explicit
+    region (e.g. ``us-central1``) for models that are served regionally — this
+    also lands their calls in the *regional* per-base-model quota bucket, which
+    is a separate pool from the ``global`` one the gemini-3.x models draw from.
     """
     return Gemini(
-        model=model_name, client_kwargs={"location": locations.MODEL_LOCATION}
+        model=model_name,
+        client_kwargs={"location": location or locations.MODEL_LOCATION},
     )

--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -55,8 +55,6 @@ merge_planners = Agent(
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
 
-# 5.  **Risk & Constraint:** (A final, integrated summary of any cultural risks (from the trend) or market constraints (from the campaign) the creative team must avoid.)
-# </REPORT_STRUCTURE>
 
 merge_parallel_insights = SequentialAgent(
     name="merge_parallel_insights",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,7 +126,7 @@ class TestBaseAgentConfiguration:
         assert isinstance(ca.config, BaseAgentConfiguration)
 
     def test_agent_configs_share_model_names(self):
-        """Dedup proof: both agents expose identical model-name values."""
+        """Dedup proof: both agents expose identical base model-name values."""
         import trend_scout.config as tt
         import creative_agent.config as ca
 
@@ -140,6 +140,19 @@ class TestBaseAgentConfiguration:
         ):
             assert getattr(tt.config, name) == getattr(ca.config, name)
         assert tt.config.critic_model == "gemini-3.1-pro-preview"
+
+    def test_trend_scout_regional_model_spread(self):
+        """trend_scout fans its 5 agents across separate quota buckets.
+
+        The two gemini-2.5 agents are pinned to a region (us-central1) so they
+        land in the regional per-base-model quota, separate from the global
+        buckets the gemini-3.x agents use.
+        """
+        import trend_scout.config as tt
+
+        assert tt.config.gather_model == "gemini-2.5-flash-lite"
+        assert tt.config.picker_model == "gemini-2.5-pro"
+        assert tt.config.regional_model_location == "us-central1"
 
 
 class TestBuildInfraRetry:

--- a/trend_scout/agent.py
+++ b/trend_scout/agent.py
@@ -33,7 +33,8 @@ warnings.filterwarnings("ignore")
 
 # --- TREND SUBAGENTS ---
 gather_trends_agent = Agent(
-    model=build_gemini(config.worker_model),
+    # Trivial tool-output formatting; runs on its own regional gemini-2.5 bucket.
+    model=build_gemini(config.gather_model, location=config.regional_model_location),
     name="gather_trends_agent",
     include_contents="none",
     description="Get top 25 trending terms from Google Search.",
@@ -61,6 +62,8 @@ gather_trends_agent = Agent(
 # the JSON briefing. trend_scout has no citation flow, so (unlike the creative
 # producers) there is NO source-collection callback here.
 understand_trends_searcher = Agent(
+    # google_search + retry-wrapped (call-heavy); kept on gemini-3.5-flash but
+    # now the sole occupant of that global bucket, so its retries can't 429.
     model=build_gemini(config.worker_model),
     name="understand_trends_searcher",
     include_contents="none",
@@ -89,7 +92,8 @@ understand_trends_searcher = Agent(
 # wrapper retries the whole pair rather than raising KeyError inside it) and shapes
 # them into the existing JSON `analyzed_trends` structure pick_trends_agent consumes.
 understand_trends_synthesizer = Agent(
-    model=build_gemini(config.worker_model),
+    # Tool-free synthesis into structured JSON; its own global flash-lite bucket.
+    model=build_gemini(config.lite_planner_model),
     name="understand_trends_synthesizer",
     include_contents="none",
     description="Synthesizes the raw trend findings into the structured JSON briefing.",
@@ -135,7 +139,9 @@ understand_trends_agent_resilient = RetryUntilKeyAgent(
 
 
 pick_trends_agent = Agent(
-    model=build_gemini(config.worker_model),
+    # The 25->3 strategic judgment step: gemini-2.5-pro on its own regional
+    # bucket — both quota isolation and a quality upgrade for the pick.
+    model=build_gemini(config.picker_model, location=config.regional_model_location),
     name="pick_trends_agent",
     include_contents="none",
     description="Determine subset of Search trends most culturally relevant to the target audience.",
@@ -158,7 +164,10 @@ pick_trends_agent = Agent(
 
 
 trend_scout = Agent(
-    model=build_gemini(config.worker_model),
+    # Root orchestrator: mechanical tool sequencing that must call AgentTools
+    # reliably. gemini-3.1-pro-preview on its own global bucket (thinking_level
+    # LOW is valid on gemini-3.x — see the note below).
+    model=build_gemini(config.critic_model),
     name="trend_scout",
     retry_config=INFRA_RETRY,
     description="Determines culturally relevant Search trends to use for ad creatives.",

--- a/trend_scout/config.py
+++ b/trend_scout/config.py
@@ -13,7 +13,33 @@ INFRA_RETRY = build_infra_retry()
 
 @dataclass
 class ResearchConfiguration(BaseAgentConfiguration):
-    """Research config for trend_scout — all fields shared via the base."""
+    """Research config for trend_scout.
+
+    Quota spread: all 5 trend_scout agents used to drive off ``worker_model``,
+    funneling into the single ``gemini-3.5-flash`` default quota bucket (5 RPM,
+    project-wide/shared on ``hybrid-vertex``). One UI run overshoots it →
+    ``429 RESOURCE_EXHAUSTED``, and waiting doesn't help (the 5/min is shared and
+    a single run bursts past it). Vertex quota is **per-base-model** (and, off
+    ``global``, **per-region**), so we fan the 5 agents across five separate
+    buckets instead of one:
+
+    - searcher      → ``worker_model``       gemini-3.5-flash        @ global
+    - synthesizer   → ``lite_planner_model`` gemini-3.1-flash-lite   @ global
+    - root          → ``critic_model``       gemini-3.1-pro-preview  @ global
+    - gather        → ``gather_model``       gemini-2.5-flash-lite   @ us-central1
+    - pick          → ``picker_model``       gemini-2.5-pro          @ us-central1
+
+    The two gemini-2.5 agents run at ``regional_model_location`` (us-central1),
+    landing in the *regional* per-base-model quota — a pool entirely separate
+    from the ``global`` buckets the gemini-3.x agents use, and unused elsewhere
+    in the pipeline. ``pick`` on gemini-2.5-pro is also a deliberate quality
+    upgrade for the 25→3 judgment step. creative_agent is untouched.
+    """
+
+    # gemini-2.5 models are served regionally; global 404s them.
+    regional_model_location: str = "us-central1"
+    gather_model: str = "gemini-2.5-flash-lite"
+    picker_model: str = "gemini-2.5-pro"
 
 
 config = ResearchConfiguration()


### PR DESCRIPTION
## Problem

All 5 `trend_scout` agents drove off `worker_model=gemini-3.5-flash`, funneling one UI
run's burst into a single shared per-base-model quota bucket (5 RPM, project-wide on
`hybrid-vertex`). A single interactive run overshoots it → **`429 RESOURCE_EXHAUSTED`**,
and waiting doesn't help (the 5/min is shared and one run bursts past it).

Vertex generate_content quota is **per-base-model** and, off `global`, **per-region**.

## Fix

Fan the 5 agents across five separate quota buckets instead of one:

| Agent | Model | Location |
|---|---|---|
| searcher | `gemini-3.5-flash` (`worker_model`) | global |
| synthesizer | `gemini-3.1-flash-lite` (`lite_planner_model`) | global |
| root orchestrator | `gemini-3.1-pro-preview` (`critic_model`) | global |
| gather | `gemini-2.5-flash-lite` (`gather_model`) | **us-central1** |
| pick | `gemini-2.5-pro` (`picker_model`) | **us-central1** |

- `build_gemini(name, location=None)` gains a `location` arg so specific agents pin to a
  region. The two gemini-2.5 models are served **regionally** (they 404 at `global`), so
  they land in the *regional* per-base-model quota — a pool entirely separate from the
  `global` buckets the gemini-3.x agents use, and unused elsewhere in the pipeline.
- `pick` on `gemini-2.5-pro` is also a deliberate **quality upgrade** for the 25→3
  strategic judgment step.
- `creative_agent` is untouched; `trend_scout/config.ResearchConfiguration` adds
  `regional_model_location` / `gather_model` / `picker_model`.

## Validation

- Local headless harness across all execution paths (bare `Runner`, resumable `App`, and
  the real Agent Engine `VertexAiSessionService`) populates `raw_gtrends` (25) at the
  `review_trends` pause and completes the full pipeline.
- **Live-tested on Cloud Run** (`trend-trawler-api` rev `00033-tbd`): interactive
  trend-pick run rendered cards, resumed cleanly, and completed with `raw_gtrends`,
  `info_gtrends`, `selected_gtrends` all populated and 3 trends written to BigQuery —
  **zero 429s**, all five buckets exercised.

## Also

- Removes an orphaned `REPORT_STRUCTURE` comment fragment in `creative_agent/agent.py`
  (dead lines between two agents; no behavior change).

## Tests

`tests/test_config.py`: `test_agent_configs_share_model_names` restored (worker_model back
in sync with creative_agent) + new `test_trend_scout_regional_model_spread` asserting the
regional 2.5 placements.