### PR TITLE
refactor(creative_eval): make judge model/location/workers env-configurable

### DIFF
--- a/creative_eval/config.py
+++ b/creative_eval/config.py
@@ -10,20 +10,29 @@ from agent_common.locations import MODEL_LOCATION
 class EvalConfig:
     """Configuration for the creative evaluation pipeline."""
 
-    # Evaluation model (judge)
-    eval_model: str = "gemini-3.1-pro-preview"
+    # Evaluation model (judge). Overridable via EVAL_MODEL so the judge can be
+    # A/B'd against a regional model (e.g. gemini-2.5-pro @ us-central1) without
+    # a code change. Default stays gemini-3.1-pro-preview (global) until a
+    # validated swap is deliberately shipped.
+    eval_model: str = field(
+        default_factory=lambda: os.getenv("EVAL_MODEL", "gemini-3.1-pro-preview")
+    )
 
     # Score thresholds
     passing_threshold: float = 0.7
     max_retries: int = 3
 
-    # Max concurrent judge calls. Each creative is scored by an independent
-    # gemini-3.1-pro-preview call, but that model is capped at **5 RPM** on the
-    # `global` endpoint (project-wide, shared). Fanning out 12 at once trips
-    # 503 UNAVAILABLE / 429 — a single run's eval alone exceeds the pro quota.
-    # Keep this at/below the pro RPM so a paced run stays under quota; raise it
-    # only if the quota is raised. See docs/notes/ambient-agents-vs-cloud-functions.md.
-    max_eval_workers: int = 3
+    # Max concurrent judge calls. Each creative is scored by an independent judge
+    # call. On the DEFAULT judge (gemini-3.1-pro-preview @ `global`) the base
+    # model is capped at **5 RPM** project-wide/shared, so fanning out 12 at once
+    # trips 503 UNAVAILABLE / 429 — a single run's eval alone exceeds the pro
+    # quota. Keep this at/below the pro RPM there. If the judge is moved to a
+    # DEDICATED regional bucket (EVAL_MODEL_LOCATION=us-central1, an unused pool),
+    # this can be raised via EVAL_MAX_WORKERS for a faster single-wave eval.
+    # See docs/notes/ambient-agents-vs-cloud-functions.md.
+    max_eval_workers: int = field(
+        default_factory=lambda: int(os.getenv("EVAL_MAX_WORKERS", "3"))
+    )
 
     # Scoring dimensions and weights for ad copy
     ad_copy_dimensions: list[str] = field(
@@ -53,9 +62,15 @@ class EvalConfig:
     project_id: str = field(
         default_factory=lambda: os.getenv("GOOGLE_CLOUD_PROJECT", "")
     )
-    # The judge is a gemini-3.x model, only served from the `global` Vertex
-    # location (us-central1 returns 404 NOT_FOUND). MODEL_LOCATION (default
-    # `global`, driven by the non-reserved MODEL_LOCATION env var) is decoupled
-    # from GOOGLE_CLOUD_LOCATION on purpose: the latter is reserved by Agent
-    # Engine and injected as the regional value, which would 404 the judge.
-    location: str = field(default_factory=lambda: MODEL_LOCATION)
+    # Judge serving location. The DEFAULT judge (gemini-3.1-pro-preview) is a
+    # gemini-3.x model served ONLY from `global` (us-central1 returns 404), so
+    # this defaults to MODEL_LOCATION (`global`, driven by the non-reserved
+    # MODEL_LOCATION env var — deliberately decoupled from GOOGLE_CLOUD_LOCATION,
+    # which Agent Engine reserves/regionalizes and which would 404 the judge).
+    # Overridable via EVAL_MODEL_LOCATION: gemini-2.5-* models ARE served
+    # regionally, so pairing EVAL_MODEL=gemini-2.5-pro with
+    # EVAL_MODEL_LOCATION=us-central1 lands the judge in a dedicated regional
+    # per-base-model bucket, separate from the agents' global pools.
+    location: str = field(
+        default_factory=lambda: os.getenv("EVAL_MODEL_LOCATION", MODEL_LOCATION)
+    )


### PR DESCRIPTION
## What

Makes three `EvalConfig` fields in `creative_eval/config.py` environment-configurable:

| Field | Env var | Default (unchanged) |
|---|---|---|
| `eval_model` | `EVAL_MODEL` | `gemini-3.1-pro-preview` |
| `location` | `EVAL_MODEL_LOCATION` | `MODEL_LOCATION` (`global`) |
| `max_eval_workers` | `EVAL_MAX_WORKERS` | `3` |

Defaults are unchanged, so **production behavior is identical** — this only adds a config seam.

## Why

This is the seam that let me A/B the LLM judge against a regional `gemini-2.5-pro` @ `us-central1` (a dedicated per-base-model quota bucket) with more workers, purely via env.

**The model swap itself is rejected:** an offline A/B (8 real creatives, 2 passes each) showed `gemini-2.5-pro` grades systematically softer than `gemini-3.1-pro-preview` — overall pass rate 0.50 → 0.75, with inflation concentrated in the discriminating dimensions (trend_authenticity, trend_visual_connection, prompt_technical_quality). That breaks the 0.7-threshold calibration, and the latency gain was only ~13%. So the default stays put.

The **knob** is independently worth keeping: a future *validated* judge swap, or a worker bump if the shared global-pro quota is ever raised, becomes a config change instead of a code edit.

## Test plan

- `uvx ruff format --check`, `ruff check`, `ty check` on `creative_eval/config.py` — all clean.
- Verified default resolves to `gemini-3.1-pro-preview` / `global` / `3`; env override resolves to `gemini-2.5-pro` / `us-central1` / `7`.