### PR TITLE
docs(deployment): refresh main-clean rollback tag revision

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -705,7 +705,7 @@ and reachable by a stable **tag** — a named alias URL pinned to one revision
 
 | Service | Rollback tag | (revision at time of writing) |
 |---|---|---|
-| `trend-trawler-api` | `main-clean` | `trend-trawler-api-00036-har` |
+| `trend-trawler-api` | `main-clean` | `trend-trawler-api-00034-hzv` |
 | `trend-trawler-web` | `main-current` | `trend-trawler-web-00011-giv` |
 
 ```bash


### PR DESCRIPTION
One-line doc refresh. After re-baselining `trend-trawler-api` to `main` (new revision `00034-hzv`, built from `main` @ 4c44062), the `main-clean` rollback tag was moved onto that confirmed-good revision. Update the rollback-anchor table in the runbook to match.

- `trend-trawler-api` / `main-clean`: `00036-har` → `00034-hzv`
- `trend-trawler-web` row unchanged (web not redeployed; `main-current` still on `00011-giv`).

No behavior change.