### PR TITLE
feat(creative_agent): image-prompting overhaul — style-diverse images, art-director, ImageConfig, reference image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ Agent `instruction=` strings live in the package's `prompts.py` (as `<AGENT_VAR>
 
 Agent `output_schema=` Pydantic models live in the package's `schemas.py` (re-imported into `agent.py`, which keeps them importable from the agent module), not inline in `agent.py`.
 
+Image-generation prompt guidance lives in `creative_agent/prompts.py` as `IMAGE_PROMPT_GUIDE` (the still-image analog of `VEO3_INSTR`); visual agents must select a `visual_style` per concept rather than defaulting to photorealism. It is spliced into the drafter/critic instructions by string concatenation and must contain no `{...}` braces (ADK would treat them as state tokens — fill-in slots use `[square brackets]`).
+
 ### Data Flow
 
 - **BigQuery**: Stores trend recommendations (`target_trends_crf`), creative results (`trend_creatives`), all trends (`all_trends`), per-run evaluation summaries (`creative_evals` — one row per run, joins `trend_creatives` via `creative_uuid`, links to the full report JSON in GCS)

--- a/agent_common/config.py
+++ b/agent_common/config.py
@@ -60,6 +60,16 @@ class BaseAgentConfiguration:
     video_gen_model: str = "veo-3.1-generate-001"  # "veo-3.0-generate-001"
     max_results_yt_trends: int = 45
 
+    # Image generation ImageConfig knobs (env-overridable). The default 9:16 is
+    # the vertical social-reel framing (the model otherwise defaults to 1:1); the
+    # allowed set is the social-safe subset of the SDK's supported aspect ratios
+    # that the visual agents may choose from per concept.
+    image_size: str = os.environ.get("IMAGE_SIZE", "2K")
+    image_aspect_ratio_default: str = os.environ.get(
+        "IMAGE_ASPECT_RATIO_DEFAULT", "9:16"
+    )
+    image_aspect_ratios_allowed: tuple[str, ...] = ("9:16", "1:1", "3:4")
+
     # Adjust these values to limit the rate at which the agent queries the LLM API.
     rate_limit_seconds: int = 60
     rpm_quota: int = 1000

--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -278,6 +278,33 @@ ad_creative_pipeline = SequentialAgent(
 )
 
 
+# --- ART DIRECTOR AGENT ---
+# Sets the campaign-wide visual direction (mood, palette, motifs, brand cues,
+# recommended diverse style families) BEFORE individual concepts are drafted, so the
+# concepts are cohesive and on-brand. Plain-text output (no output_schema) → the brief
+# is prose guidance, consumed by the drafter via {visual_direction}.
+art_director = Agent(
+    model=build_gemini(config.worker_model),
+    name="art_director",
+    include_contents="none",
+    description="Set the campaign-wide visual direction before concept drafting",
+    planner=BuiltInPlanner(
+        thinking_config=types.ThinkingConfig(include_thoughts=False)
+    ),
+    instruction=prompts.ART_DIRECTOR_INSTR,
+    generate_content_config=types.GenerateContentConfig(
+        temperature=0.9,
+        labels={
+            "agentic_wf": "trend_scout",
+            "agent": "creative_agent",
+            "subagent": "art_director",
+        },
+    ),
+    output_key="visual_direction",
+    after_model_callback=callbacks.log_empty_turn_finish_reason,
+)
+
+
 # --- VISUAL CONCEPT DRAFT AGENT ---
 visual_concept_drafter = Agent(
     model=build_gemini(config.worker_model),
@@ -416,6 +443,7 @@ visual_generation_pipeline = SequentialAgent(
     name="visual_generation_pipeline",
     description="Generates visual concepts with an actor-critic workflow.",
     sub_agents=[
+        art_director,
         visual_concept_drafter,
         visual_concept_critic,
         visual_concept_finalizer,

--- a/creative_agent/callbacks.py
+++ b/creative_agent/callbacks.py
@@ -57,6 +57,13 @@ def _set_initial_states(source: Dict[str, Any], target: State | dict[str, Any]):
 
         target.update(source)
 
+        # Optional product/brand reference image for image generation, supplied
+        # by the caller via createSession initialState (same mechanism as
+        # interactive_trend_pick). Use setdefault so the key always exists for
+        # downstream .get() reads WITHOUT clobbering a caller-provided value —
+        # it is deliberately NOT in `source` above, which would overwrite it.
+        target.setdefault("reference_image_uri", "")
+
 
 def load_session_state(callback_context: CallbackContext):
     """

--- a/creative_agent/image_tools.py
+++ b/creative_agent/image_tools.py
@@ -111,11 +111,30 @@ async def generate_image(
     artifact_keys_list = []
     for entry in final_visual_concepts_list:
         try:
+            # Per-concept aspect ratio: the LLM may pick one from the allowed set;
+            # anything else (or unset) falls back to the configured default so a
+            # bad/empty value never reaches the SDK. .get() keeps concepts that
+            # only carry image_generation_prompt working (see test_tools_retry).
+            aspect_ratio = (
+                entry.get("aspect_ratio") or config.image_aspect_ratio_default
+            )
+            if aspect_ratio not in config.image_aspect_ratios_allowed:
+                logging.warning(
+                    f"Aspect ratio '{aspect_ratio}' not in allowed set "
+                    f"{config.image_aspect_ratios_allowed}; "
+                    f"falling back to '{config.image_aspect_ratio_default}'"
+                )
+                aspect_ratio = config.image_aspect_ratio_default
+
             response = await _generate_image_with_backoff(
                 model=config.image_gen_model,
                 contents=entry["image_generation_prompt"],
                 config=types.GenerateContentConfig(
                     response_modalities=["IMAGE"],
+                    image_config=types.ImageConfig(
+                        aspect_ratio=aspect_ratio,
+                        image_size=config.image_size,
+                    ),
                 ),
             )
 

--- a/creative_agent/image_tools.py
+++ b/creative_agent/image_tools.py
@@ -8,6 +8,8 @@ import asyncio
 import random
 import logging
 import functools
+import urllib.request
+from urllib.parse import urlparse
 
 from google import genai
 from google.genai import types
@@ -16,7 +18,67 @@ from google.adk.tools import ToolContext
 
 from agent_common.locations import MODEL_LOCATION
 from .config import config
-from .gcs_tools import _save_to_gcs, artifact_key_for
+from .gcs_tools import _save_to_gcs, _download_blob, artifact_key_for
+
+# Fetch timeout for an http(s) reference image (stdlib urllib, no new dep).
+_REFERENCE_FETCH_TIMEOUT_SECS = 20
+
+# Map a reference-image extension to a mime type (default image/png).
+_REFERENCE_MIME_BY_EXT = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
+
+def _reference_mime_for(path: str) -> str:
+    """Best-effort mime type from a reference-image path/URL extension."""
+    lower = path.lower()
+    for ext, mime in _REFERENCE_MIME_BY_EXT.items():
+        if lower.endswith(ext):
+            return mime
+    return "image/png"
+
+
+def _fetch_reference_image(uri: str) -> types.Part | None:
+    """Fetch a product/brand reference image as a genai Part, or None on failure.
+
+    Supports ``gs://bucket/object`` (via the GCS client) and ``http(s)://`` URLs
+    (via stdlib urllib). Any failure is logged and swallowed so image generation
+    always falls back to the text-only path rather than aborting the run.
+    """
+    uri = (uri or "").strip()
+    if not uri:
+        return None
+    try:
+        if uri.startswith("gs://"):
+            without_scheme = uri[len("gs://") :]
+            bucket, _, obj = without_scheme.partition("/")
+            if not bucket or not obj:
+                logging.warning(f"Malformed gs:// reference_image_uri: '{uri}'")
+                return None
+            data = _download_blob(bucket, obj)
+            mime = _reference_mime_for(obj)
+        elif uri.startswith("http://") or uri.startswith("https://"):
+            with urllib.request.urlopen(
+                uri, timeout=_REFERENCE_FETCH_TIMEOUT_SECS
+            ) as resp:
+                data = resp.read()
+            mime = _reference_mime_for(urlparse(uri).path)
+        else:
+            logging.warning(
+                f"Unsupported reference_image_uri scheme (want gs:// or http(s)://): '{uri}'"
+            )
+            return None
+        return types.Part.from_bytes(data=data, mime_type=mime)
+    except Exception as exc:
+        logging.warning(
+            f"Failed to fetch reference image '{uri}'; "
+            f"falling back to text-only prompt: {exc}"
+        )
+        return None
 
 
 @functools.cache
@@ -108,6 +170,16 @@ async def generate_image(
     final_visual_concepts_dict = tool_context.state.get("final_visual_concepts")
     final_visual_concepts_list = final_visual_concepts_dict["visual_concepts"]
 
+    # Optional product/brand reference image, applied to every concept for
+    # likeness/consistency. Fetched ONCE (off the event loop) before the loop; a
+    # None result (unset or fetch failure) means the text-only path is used.
+    reference_uri = tool_context.state.get("reference_image_uri")
+    reference_part = None
+    if reference_uri:
+        reference_part = await asyncio.to_thread(_fetch_reference_image, reference_uri)
+        if reference_part is not None:
+            logging.info(f"Using product reference image: {reference_uri}")
+
     artifact_keys_list = []
     for entry in final_visual_concepts_list:
         try:
@@ -126,9 +198,15 @@ async def generate_image(
                 )
                 aspect_ratio = config.image_aspect_ratio_default
 
+            prompt_text = entry["image_generation_prompt"]
+            contents = (
+                [prompt_text, reference_part]
+                if reference_part is not None
+                else prompt_text
+            )
             response = await _generate_image_with_backoff(
                 model=config.image_gen_model,
-                contents=entry["image_generation_prompt"],
+                contents=contents,
                 config=types.GenerateContentConfig(
                     response_modalities=["IMAGE"],
                     image_config=types.ImageConfig(

--- a/creative_agent/prompts.py
+++ b/creative_agent/prompts.py
@@ -400,6 +400,33 @@ AD_COPY_CRITIC_INSTR = """Role: You are a strategic marketing critic and convers
     <OUTPUT_FORMAT>
     """
 
+ART_DIRECTOR_INSTR = """Role: You are the Art Director. Before any individual visual concepts are drafted, you set the overall visual direction for the campaign so the concepts feel cohesive, on-brand, and culturally tuned to the trend.
+
+    <INSTRUCTIONS>
+    Using the <CONTEXT> (research report, brand, audience, trend, and approved ad copy), write a concise **Visual Direction Brief** (roughly 150-250 words, plain prose + short bullet lists — NOT JSON). Cover:
+    1.  **Mood & tone:** the overall emotional register the imagery should hit for this audience.
+    2.  **Colour palette:** 3-5 colours (with rough usage) that fit the brand and trend.
+    3.  **Recurring visual motifs:** concrete imagery/symbols drawn from the trend and its cultural context that can recur across concepts.
+    4.  **Brand visual cues:** how the product/brand should consistently appear (framing, treatment, any in-image branding).
+    5.  **Recommended style families:** for the mix of ad-copy tones present, recommend a DIVERSE set of style families (e.g. photoreal, flat cartoon, 3D character, meme/sticker, minimalist) — explicitly avoid making everything photorealistic.
+    This brief is guidance for the drafter; it does not select final concepts.
+    </INSTRUCTIONS>
+
+    <CONTEXT>
+        <brand>{brand}</brand>
+        <target_audience>{target_audience}</target_audience>
+        <target_search_trends>{target_search_trends}</target_search_trends>
+
+        <research_report>
+        {combined_final_cited_report?}
+        </research_report>
+
+        <ad_copy_critique>
+        {ad_copy_critique}
+        </ad_copy_critique>
+    </CONTEXT>
+    """
+
 VISUAL_CONCEPT_DRAFTER_INSTR = (
     """Role: You are a visionary visual creative director and prompt engineer specializing in high-impact social media advertising (Instagram/TikTok).
     Your task is to translate approved ad copy into executable visual concepts, each in a deliberately chosen visual style.
@@ -411,12 +438,23 @@ VISUAL_CONCEPT_DRAFTER_INSTR = (
         *   Leverage or subtly reference the trending topic: {target_search_trends}.
         *   Be optimized for quick consumption on a social media feed (e.g., strong composition, clear focus).
         *   Cleverly market the target product: {target_product}.
-    3.  **Choose the Style (do NOT default to photorealism):** Using the <IMAGE_PROMPT_GUIDE> below, select the `visual_style` family that best fits each ad copy's TONE and AUDIENCE via the tone→style mapping. Across the set, VARY the styles — cartoons, memes, stickers, 3D, anime, minimalist, and photoreal are all fair game. Record the chosen family in the `visual_style` field.
-    4.  **Prompt Engineering:** For each concept, write the `image_generation_prompt` following the <IMAGE_PROMPT_GUIDE>: name the chosen style first, then build the scene. Also choose and record the `aspect_ratio` per concept.
+    3.  **Choose the Style (do NOT default to photorealism):** Using the <IMAGE_PROMPT_GUIDE> below and the <visual_direction> brief, select the `visual_style` family that best fits each ad copy's TONE and AUDIENCE via the tone→style mapping. Across the set, VARY the styles — cartoons, memes, stickers, 3D, anime, minimalist, and photoreal are all fair game. Record the chosen family in the `visual_style` field.
+    4.  **Prompt Engineering:** For each concept, write the `image_generation_prompt` following the <IMAGE_PROMPT_GUIDE> and honouring the <visual_direction> brief's mood, palette, motifs, and brand cues. Name the chosen style first, then build the scene. Also choose and record the `aspect_ratio` per concept.
     5.  **Strict Output Format:** Ensure the entire output is a single JSON object containing all generated concepts, strictly following the schema in the <OUTPUT_FORMAT> block (including `visual_style` and `aspect_ratio` for each).
     </INSTRUCTIONS>
 
     <CONTEXT>
+        <visual_direction>
+        {visual_direction}
+        </visual_direction>
+
+        <brand>{brand}</brand>
+        <target_audience>{target_audience}</target_audience>
+
+        <research_report>
+        {combined_final_cited_report?}
+        </research_report>
+
         <ad_copy_critique>
         {ad_copy_critique}
         </ad_copy_critique>

--- a/creative_agent/prompts.py
+++ b/creative_agent/prompts.py
@@ -93,8 +93,75 @@ Rhythm: "Pulsating light", "Rhythmic movement."
 <AUDIO>
 Sound Effects: Individual, distinct sounds that occur within the scene (e.g., "the sound of a phone ringing" , "water splashing in the background" , "soft house sounds, the creak of a closet door, and a ticking clock" ).   
 Ambient Noise: The general background noise that makes a location feel real (e.g., "the sounds of city traffic and distant sirens" , "waves crashing on the shore" , "the quiet hum of an office" ).   
-Dialogue: Spoken words from characters or a narrator (e.g., "The man in the red hat says: 'Where is the rabbit?'" , "A voiceover with a polished British accent speaks in a serious, urgent tone" , "Two people discuss a movie" ).   
+Dialogue: Spoken words from characters or a narrator (e.g., "The man in the red hat says: 'Where is the rabbit?'" , "A voiceover with a polished British accent speaks in a serious, urgent tone" , "Two people discuss a movie" ).
 </AUDIO>
+"""
+
+# The still-image analog of VEO3_INSTR: a prompting "grammar" for the
+# gemini-3.1-flash-image model (Nano Banana). Deliberately STYLE-FIRST and
+# template-driven rather than a flat menu, and deliberately NOT photoreal-biased —
+# the goal is to accommodate many styles (cartoon, meme, sticker, 3D, anime,
+# minimalist, photoreal, …). It is spliced into the drafter/critic instructions at
+# author time, so it MUST NOT contain any `{...}` curly braces (ADK would treat
+# them as session-state tokens). Fill-in slots use [square brackets].
+IMAGE_PROMPT_GUIDE = """Here are best practices for writing prompts for a modern text-to-image model (Nano Banana). This is for a SINGLE STILL IMAGE used as a social-media ad creative (Instagram / TikTok feed & reels).
+
+<CORE_PRINCIPLES>
+- Be hyper-specific and concrete. Describe the scene as one coherent, vivid noun-phrase, not a keyword soup. "A [style] image of [subject] [doing action] in [setting], [lighting], [color/mood]" beats "product, nice, high quality".
+- NAME THE STYLE EXPLICITLY at the very start of the prompt (e.g. "A flat 2D vector cartoon of…", "A candid 35mm film photo of…", "A diecut sticker of…"). Do NOT default to photorealism — choose the style that fits the ad's tone and audience.
+- Use POSITIVE, present-what-you-want framing. To exclude something, describe the desired alternative ("a clean empty background") rather than negatives ("no clutter"). If you must exclude, phrase it as a "semantic negative" ("the street is empty and quiet"), not "no cars".
+- State that it is a social-media advertisement and who it targets — the model composes framing/negative space differently for an ad than for a stock photo.
+- The model renders LEGIBLE IN-IMAGE TEXT. When it strengthens the ad, put the headline, a short caption, a call-to-action button, or the brand name directly in the image and specify the exact words in quotes, plus font vibe and placement (e.g. bold sans-serif caption top-and-bottom for a meme).
+- Length follows the style: a minimalist or sticker prompt should be short and clean; a cinematic photoreal scene should be long and layered. Detail where detail matters — do not pad to a word count.
+</CORE_PRINCIPLES>
+
+<STYLE_PALETTE>
+Pick ONE primary style family per concept. Each has a when-to-use and a fill-in template.
+- Photoreal / editorial: aspirational, premium, trust. "A photorealistic editorial photograph of [subject], [camera + lens e.g. 85mm], [studio or natural lighting], shallow depth of field, [color palette]."
+- Cinematic film still: dramatic, story-driven, emotive. "A cinematic film still of [subject], anamorphic widescreen feel, [dramatic lighting e.g. golden-hour rim light], moody [color grade], shot on 35mm."
+- 3D character render (Pixar/Blender-ish): playful, friendly, mascot-driven. "A charming 3D-rendered character of [subject], soft global illumination, rounded shapes, glossy [colors], Pixar-like."
+- 2D flat / vector cartoon: clean, modern, explainer, tech. "A flat 2D vector illustration of [subject], bold outlines, simple geometric shapes, limited [2-3 color] palette, generous negative space."
+- Anime / manga: youthful, energetic, fandom. "An anime-style illustration of [subject], cel shading, expressive eyes, dynamic pose, [vibrant palette]."
+- Comic panel: narrative, humorous, bold. "A comic-book panel of [subject], halftone shading, bold ink outlines, [speech bubble reading '…']."
+- Meme aesthetic: relatable, viral, humor-led. Choose a sub-form: bold Impact-caption meme ("[subject] with top caption '…' and bottom caption '…' in white Impact font with black outline"), faux-screenshot, or reaction-image. Keep it scrappy and authentic, not polished.
+- Diecut sticker: fun, collectible, playful branding. "A diecut sticker of [subject], thick white border, glossy finish, simple bold shading, plain background."
+- Watercolor / gouache: warm, artisanal, human. "A soft watercolor painting of [subject], visible paper texture, gentle washes, [muted palette]."
+- Collage / mixed-media: edgy, zine, culturally-savvy. "A cut-paper collage of [subject], mixed textures, torn edges, [bold accent color]."
+- Retro / vaporwave: nostalgic, music/lifestyle. "An [era e.g. 1980s vaporwave] poster of [subject], neon gradients, grid horizon, chrome type."
+- Isometric: product/system/how-it-works. "A clean isometric illustration of [subject], 2:1 iso grid, soft shadows, [tidy palette]."
+- Minimalist negative-space: premium, calm, single-message. "A minimalist image of [subject] against a large [solid color] field, lots of negative space, one focal element, room for text."
+</STYLE_PALETTE>
+
+<TONE_TO_STYLE_MAPPING>
+Use the ad copy's tone + audience + trend to pick the style (this is the selection rule, not a suggestion):
+- Meme-based / irreverent tone -> meme aesthetic, diecut sticker, or flat cartoon.
+- Humorous tone -> 3D character or comic panel.
+- Aspirational / premium tone -> cinematic photoreal or minimalist negative-space.
+- Emotional / authentic tone -> candid 35mm film photo or watercolor.
+- Educational / how-it-works tone -> minimalist with legible text, or isometric.
+- Problem–solution / direct-response tone -> clean studio product shot (photoreal) with in-image CTA.
+Diversity rule: across a set of concepts, vary the style family — do not render every concept in the same look.
+</TONE_TO_STYLE_MAPPING>
+
+<BUILDING_BLOCKS>
+Assemble the prompt from these, in roughly this order:
+- Style declaration (family from the palette, named first).
+- Subject: the hero — product, person, or character — described concretely.
+- Composition / framing: focal point, rule-of-thirds, close-up vs wide, where negative space sits for text.
+- Setting: where the scene happens (or "plain [color] studio background").
+- Lighting: e.g. soft window light, hard studio key, neon glow, golden hour.
+- Color & mood: palette + emotional register aligned to the brand and trend.
+- Rendering cues: texture/finish appropriate to the style (grain, cel shading, glossy, paper texture).
+- In-image text & branding: exact headline/CTA/brand words in quotes, font vibe, placement — only when it strengthens the ad.
+</BUILDING_BLOCKS>
+
+<ASPECT_RATIO>
+Choose the aspect ratio per concept and output it in the `aspect_ratio` field:
+- "9:16" — default; vertical reel / Story / TikTok full-screen.
+- "1:1" — square feed post.
+- "3:4" — portrait feed.
+Compose the scene FOR the chosen ratio (e.g. vertical stacking and headroom for 9:16).
+</ASPECT_RATIO>
 """
 
 MERGE_PLANNERS_INSTR = """Role: You are an expert Strategic Synthesis Analyst. 
@@ -333,8 +400,9 @@ AD_COPY_CRITIC_INSTR = """Role: You are a strategic marketing critic and convers
     <OUTPUT_FORMAT>
     """
 
-VISUAL_CONCEPT_DRAFTER_INSTR = """Role: You are a visionary visual creative director and prompt engineer specializing in high-impact social media advertising (Instagram/TikTok). 
-    Your task is to translate approved ad copy into executable visual concepts.
+VISUAL_CONCEPT_DRAFTER_INSTR = (
+    """Role: You are a visionary visual creative director and prompt engineer specializing in high-impact social media advertising (Instagram/TikTok).
+    Your task is to translate approved ad copy into executable visual concepts, each in a deliberately chosen visual style.
 
     <INSTRUCTIONS>
     1.  **Parse and Map:** Parse the JSON list of final ad copies from the `ad_copy_critique` input in the <CONTEXT> block.
@@ -343,8 +411,9 @@ VISUAL_CONCEPT_DRAFTER_INSTR = """Role: You are a visionary visual creative dire
         *   Leverage or subtly reference the trending topic: {target_search_trends}.
         *   Be optimized for quick consumption on a social media feed (e.g., strong composition, clear focus).
         *   Cleverly market the target product: {target_product}.
-    3.  **Prompt Engineering:** For each concept, generate a professional, high-fidelity text-to-image generation prompt adhering to the <PROMPT_ENGINEERING_GUIDANCE> block.
-    4.  **Strict Output Format:** Ensure the entire output is a single JSON object containing all generated concepts, strictly following the schema in the <OUTPUT_FORMAT> block.
+    3.  **Choose the Style (do NOT default to photorealism):** Using the <IMAGE_PROMPT_GUIDE> below, select the `visual_style` family that best fits each ad copy's TONE and AUDIENCE via the tone→style mapping. Across the set, VARY the styles — cartoons, memes, stickers, 3D, anime, minimalist, and photoreal are all fair game. Record the chosen family in the `visual_style` field.
+    4.  **Prompt Engineering:** For each concept, write the `image_generation_prompt` following the <IMAGE_PROMPT_GUIDE>: name the chosen style first, then build the scene. Also choose and record the `aspect_ratio` per concept.
+    5.  **Strict Output Format:** Ensure the entire output is a single JSON object containing all generated concepts, strictly following the schema in the <OUTPUT_FORMAT> block (including `visual_style` and `aspect_ratio` for each).
     </INSTRUCTIONS>
 
     <CONTEXT>
@@ -353,28 +422,30 @@ VISUAL_CONCEPT_DRAFTER_INSTR = """Role: You are a visionary visual creative dire
         </ad_copy_critique>
     </CONTEXT>
 
-    <PROMPT_ENGINEERING_GUIDANCE>
-    The final generated prompt for the image model must be:
-    -   **Highly descriptive:** Include subject, setting, style, mood, and lighting.
-    -   **Technical:** Specify aspect ratio (e.g., 9:16 for vertical), camera angle, and lens type (e.g., telephoto, wide-angle).
-    -   **Optimized:** Use high-quality keywords (e.g., "photorealistic," "award-winning studio lighting," "8k resolution").
-    </PROMPT_ENGINEERING_GUIDANCE>
+    <IMAGE_PROMPT_GUIDE>
+    """
+    + IMAGE_PROMPT_GUIDE
+    + """
+    </IMAGE_PROMPT_GUIDE>
 
     <OUTPUT_FORMAT>
     **CRITICAL RULE: Your entire output MUST be a single, raw JSON object validating against the 'VisualConceptList' schema**
     </OUTPUT_FORMAT>
     """
+)
 
-VISUAL_CONCEPT_CRITIC_INSTR = """Role: You are an expert Visual Prompt Engineer and Creative Quality Assurance Specialist. 
-    Your task is to apply rigorous technical and creative analysis to a set of draft image generation prompts, refining them for maximum visual impact and adherence to the core brief.
+VISUAL_CONCEPT_CRITIC_INSTR = (
+    """Role: You are an expert Visual Prompt Engineer and Creative Quality Assurance Specialist.
+    Your task is to apply rigorous creative analysis to a set of draft image generation prompts, refining them for maximum visual impact — each WITHIN its own chosen visual style.
 
     <INSTRUCTIONS>
     1.  **Parse and Map:** Retrieve and parse the JSON list of visual concepts from the **`<CONTEXT>` block's `visual_draft`** input.
     2.  **Critical Review and Revision:** For each concept, critique and **REWRITE** the `image_generation_prompt` based on the following criteria:
-        *   **Technical Compliance:** Ensure the prompt is over **100 words**, uses high-fidelity keywords, specifies aspect ratio, and clearly defines lighting, style, and composition elements (as per prompt best practices).
-        *   **Creative Fidelity:** Ensure the revised prompt vividly describes the **{target_product}** and makes a clear visual link to the **{target_search_trends}** trend in a way that aligns with the intended tone.
+        *   **Style fidelity:** Refine the prompt WITHIN its chosen `visual_style`, applying the <IMAGE_PROMPT_GUIDE>. Do NOT force it toward photorealism or a fixed word count — a minimalist or sticker concept should stay short and clean; a cinematic photoreal concept can be long and layered. Length appropriate to the style. PRESERVE the `visual_style` unless it is clearly wrong for the ad's tone (only then change it, and update the field).
+        *   **Creative Fidelity:** Ensure the revised prompt vividly represents the **{target_product}** and makes a clear visual link to the **{target_search_trends}** trend in a way that aligns with the intended tone.
         *   **Stopping Power:** The resulting image must have high visual appeal and "stopping power" for a social media feed.
-    3.  **Strict Output Format:** The output must be a single, structured JSON object containing the **revised** concepts. Do not include any external commentary or separate critique text.
+        *   **Carry-through:** Keep the `aspect_ratio` field (adjust only if the composition demands it).
+    3.  **Strict Output Format:** The output must be a single, structured JSON object containing the **revised** concepts (including `visual_style` and `aspect_ratio`). Do not include any external commentary or separate critique text.
     </INSTRUCTIONS>
 
     <CONTEXT>
@@ -383,10 +454,17 @@ VISUAL_CONCEPT_CRITIC_INSTR = """Role: You are an expert Visual Prompt Engineer 
         </visual_draft>
     </CONTEXT>
 
+    <IMAGE_PROMPT_GUIDE>
+    """
+    + IMAGE_PROMPT_GUIDE
+    + """
+    </IMAGE_PROMPT_GUIDE>
+
     <OUTPUT_FORMAT>
     **CRITICAL RULE: Your entire output MUST be a single, raw JSON object validating against the 'VisualConceptCritiqueList' schema**
     </OUTPUT_FORMAT>
     """
+)
 
 VISUAL_CONCEPT_FINALIZER_INSTR = """Role: You are the Lead Creative Director and Final Gatekeeper. 
     Your task is to apply ultimate strategic judgment to the final set of visual concepts, selecting the absolute best for production (image generation).
@@ -394,11 +472,11 @@ VISUAL_CONCEPT_FINALIZER_INSTR = """Role: You are the Lead Creative Director and
     <INSTRUCTIONS>
     1.  **Parse and Map:** Retrieve and parse the JSON list of revised visual concepts from the **`<CONTEXT>` block's `visual_concept_critique` input.
     2.  **Final Selection Criteria:** Select a subset of **exactly 4** concepts that offer the best balance of:
-        *   **Creative Diversity:** Ensure the final 4 represent a good mix of styles/tones from the original ad copy set.
+        *   **Visual-Style Diversity (enforce this):** The final 4 MUST span a range of `visual_style` families (e.g. do NOT return four photoreal concepts) — favour a mix such as photoreal, cartoon/flat, 3D/character, meme/sticker, minimalist, etc., matched to each ad copy's tone.
         *   **Commercial Viability:** Highest potential to drive engagement and sales, based on the `critique_summary`.
-        *   **Technical Excellence:** Possesses the most compelling and robust `revised_image_generation_prompt`.
-    3.  **Finalize and Enrich:** For the 4 selected concepts, you must combine the original ad copy details with the revised visual details to create a final, unified creative brief.
-    4.  **Strict Output Format:** Output the final selection as a single JSON object, strictly following the schema in the `<OUTPUT_FORMAT>` block.
+        *   **Technical Excellence:** Possesses the most compelling and robust `image_generation_prompt`.
+    3.  **Finalize and Enrich:** For the 4 selected concepts, you must combine the original ad copy details with the revised visual details to create a final, unified creative brief. Carry each concept's `visual_style` and `aspect_ratio` through unchanged.
+    4.  **Strict Output Format:** Output the final selection as a single JSON object, strictly following the schema in the `<OUTPUT_FORMAT>` block (including `visual_style` and `aspect_ratio` per concept).
     </INSTRUCTIONS>
 
     <CONTEXT>

--- a/creative_agent/schemas.py
+++ b/creative_agent/schemas.py
@@ -125,6 +125,14 @@ class VisualConcept(BaseModel):
     concept_summary: str = Field(
         description="A 2-3 sentence explanation of the creative concept and its link to the ad copy's message."
     )
+    visual_style: str = Field(
+        default="",
+        description="The chosen style family for this concept (e.g. 'flat 2D vector cartoon', 'candid 35mm film photo', 'diecut sticker'), selected from the IMAGE_PROMPT_GUIDE style palette to fit the ad's tone/audience — NOT defaulted to photorealism.",
+    )
+    aspect_ratio: str = Field(
+        default="",
+        description="The chosen aspect ratio for this concept: '9:16' (default vertical reel), '1:1' (square feed), or '3:4' (portrait).",
+    )
     image_generation_prompt: str = Field(
         description="A draft prompt for image generation."
     )
@@ -151,11 +159,19 @@ class VisualConceptCritique(BaseModel):
     concept_summary: str = Field(
         description="The original creative concept explanation."
     )
+    visual_style: str = Field(
+        default="",
+        description="The chosen style family for this concept, carried through from the draft (refine within it; do not force to photorealism).",
+    )
+    aspect_ratio: str = Field(
+        default="",
+        description="The chosen aspect ratio ('9:16', '1:1', or '3:4'), carried through from the draft.",
+    )
     image_generation_prompt: str = Field(
-        description="The FINAL, technically perfected, 100+ word, high-fidelity prompt."
+        description="The FINAL, refined image-generation prompt, written in the concept's chosen visual_style and at a length appropriate to that style."
     )
     critique_summary: str = Field(
-        description="A brief (1-2 sentence) summary of the key technical changes made to the prompt."
+        description="A brief (1-2 sentence) summary of the key changes made to the prompt."
     )
 
 
@@ -201,8 +217,16 @@ class VisualConceptFinal(BaseModel):
     concept_summary: str = Field(
         description="A final, brief (2-3 sentence) summary of the combined ad copy and visual concept."
     )
+    visual_style: str = Field(
+        default="",
+        description="The final chosen style family for this concept (carried through from the critique).",
+    )
+    aspect_ratio: str = Field(
+        default="",
+        description="The final chosen aspect ratio ('9:16', '1:1', or '3:4') for this concept.",
+    )
     image_generation_prompt: str = Field(
-        description="The technically perfected, revised_image_generation_prompt."
+        description="The final, revised image-generation prompt, written in the concept's chosen visual_style."
     )
 
 

--- a/creative_agent/tools.py
+++ b/creative_agent/tools.py
@@ -194,6 +194,7 @@ async def save_creative_gallery_html(tool_context: ToolContext) -> dict:
                     <div class="content-card">
                         <dl>
                             <dt>Name:</dt> <dd>{entry["concept_name"]}</dd>
+                            <dt>Style:</dt> <dd>{entry.get("visual_style", "")}</dd>
                             <dt>Trend:</dt> <dd>{entry["trend"]}</dd>
                             <dt>Creative Concept Explained:</dt> <dd>{entry["concept_summary"]}</dd>
                             <dt>Why this will perform well:</dt> <dd>{entry["selection_rationale"]}</dd>

--- a/creative_eval/prompts.py
+++ b/creative_eval/prompts.py
@@ -82,6 +82,7 @@ Target Search Trend: {target_search_trend}
 
 <VISUAL_CONCEPT>
 Concept Name: {concept_name}
+Visual Style: {visual_style}
 Trend: {trend}
 Trend Reference: {trend_reference}
 Markets Product: {markets_product}

--- a/docs/plans/2026-07-16-image-prompting-overhaul.md
+++ b/docs/plans/2026-07-16-image-prompting-overhaul.md
@@ -1,0 +1,276 @@
+# Image-Generation Prompting Overhaul Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Produce dramatically better, style-diverse ad images by (1) giving the visual
+agents a real image-prompt "grammar" grounded in Nano Banana best practices, (2) removing
+the baked-in photoreal bias, (3) enriching the visual pipeline's context, and (4) wiring the
+image model's real config knobs (aspect ratio / size) plus optional reference images.
+
+**Architecture:** All work is inside `creative_agent/` (bundled into both `creative_agent`
+and `interactive_creative` engines) plus a tiny frontend field. New prompt constants in
+`prompts.py`; additive, defaulted schema fields; one new in-pipeline "art director" agent;
+config-knob + reference-image changes in `image_tools.py`. No root-orchestration or tool-name
+changes (keeps ADK evals + root-tool tests intact).
+
+**Tech Stack:** Python 3.13, Google ADK, `google-genai==2.11.0` (confirmed supports
+`types.ImageConfig(aspect_ratio, image_size)` + multimodal `contents`), `uv`/`ruff`/`ty`/
+`pytest`; Next.js 16 + TypeScript frontend.
+
+**Delivery:** Single branch off `main` (e.g. `feat/image-prompting-overhaul`); do NOT commit
+to `main`; open the PR only when asked. Tasks sequenced Phase 1 → 4; run the gate after each
+phase. No `Co-Authored-By` / no "Generated with Claude Code" trailers.
+
+**Task 0 (first step):** copy this plan to `docs/plans/2026-07-16-image-prompting-overhaul.md`
+and work from there.
+
+---
+
+## Context (why)
+
+Today the image model (`gemini-3.1-flash-image`) is under-driven and biased:
+- **Thin guidance.** `VISUAL_CONCEPT_DRAFTER_INSTR` has a 3-bullet `<PROMPT_ENGINEERING_GUIDANCE>`
+  and `VISUAL_CONCEPT_CRITIC_INSTR` says "as per prompt best practices" — which are **never
+  supplied**. There is no VEO3-style taxonomy for stills.
+- **Photoreal bias.** The drafter's example keywords are `"photorealistic," "8k"` and the
+  critic **mandates** "photorealistic, award-winning studio lighting, 8k, 100+ words". This
+  fights the user's explicit goal of many styles (cartoon, meme, sticker, minimalist…).
+- **Style isn't first-class.** No `style` field in any visual schema → can't enforce
+  diversity, log it, or judge it; the style is buried in prose.
+- **Context-starved drafter.** `visual_concept_drafter` receives ONLY `ad_copy_critique` +
+  `target_product` + `target_search_trends` — **not** the research report or brand identity.
+- **Config ignored.** `generate_image` passes only `response_modalities=["IMAGE"]`; no
+  `aspect_ratio` → the model defaults to **1:1 square**, wrong for IG/TikTok (want 9:16).
+- **No reference image.** In-image product/brand fidelity is left to text description only.
+
+Grounding facts (Nano Banana docs): be hyper-specific; describe the scene + **name the
+style**; positive/"semantic negative" framing; state the ad intent; the model renders
+**legible in-image text** (great for headlines/logos); style is specified descriptively (no
+enum); aspect ratio/size are **config params** (`ImageConfig`); reference images are extra
+`contents` parts.
+
+---
+
+## Invariants — the safety net (verified against tests/consumers; DO NOT break)
+
+1. **Root orchestration unchanged.** Keep the root tool set + order and the tool name
+   `visual_production_pipeline` (guards: `test_pipeline_structure.py:4-23`, ADK evalset
+   `tests/eval/evalsets/creative_agent_evalset.json`, `creative_eval_config.json`). The new
+   art-director agent lives **inside** `visual_generation_pipeline`, never as a root tool.
+2. **`visual_production_pipeline` shape unchanged**: `[visual_generation_pipeline,
+   visual_generator_resilient]`, last is `RetryUntilKeyAgent(output_key="_images_generated")`,
+   `sub_agents[0] is visual_generator` (`test_pipeline_structure.py:151-165`).
+3. **New schema fields must be OPTIONAL/defaulted** (`test_schemas.py:97-128` builds models
+   without them): `visual_style: str = ""`, `aspect_ratio: str = ""`.
+4. **`image_tools.generate_image` must use `.get()`** for every new per-concept key
+   (`test_tools_retry.py:127/157/204` pass concepts with only `image_generation_prompt` +
+   `concept_name`). Never `entry["visual_style"]`.
+5. **Preserve substrings** `"ad_copy_critique"` and `"ad_copy_id"` in the finalizer
+   instruction (`test_pipeline_structure.py:665-671`).
+6. **`visual_concept_critic` stays on `config.worker_model`** (`:343-356`).
+7. **Don't remove existing `VisualConceptFinal` fields** — `creative_eval` does
+   `str.format(**visual_concept)` over its template (`evaluate.py:170-173`,
+   `creative_eval/prompts.py:84-94`); a missing key → `KeyError`. Adding fields is safe.
+8. **Don't remove `entry["concept_name"]` / `entry["image_generation_prompt"]`** — gallery
+   builder uses bracket access (`tools.py:196-200`).
+9. Deployment is automatic (whole `creative_agent/` package is bundled); `interactive_creative`
+   imports `creative_agent` so it inherits everything. Only the reference-image **frontend**
+   field needs a `trend-trawler-web` redeploy.
+
+---
+
+## Phase 1 — Wire the image model's config knobs (small, safe, immediate quality win)
+
+Independent of all prompt work. Fixes framing (1:1→9:16) and resolution now.
+
+### Task 1: Add image-config defaults to config
+**Files:** `agent_common/config.py` (next to `image_gen_model`, ~line 59).
+- Add env-overridable fields: `image_size: str = "2K"`, `image_aspect_ratio_default: str =
+  "9:16"`, and `image_aspect_ratios_allowed: tuple = ("9:16", "1:1", "3:4")` (the social-safe
+  set the LLM may choose from; all in the SDK's supported list).
+- Optional: `image_thinking_level: str | None = None` (leave model default) for a future knob.
+
+### Task 2: Pass `ImageConfig` (aspect ratio + size) in `generate_image`
+**Files:** `creative_agent/image_tools.py` (the `GenerateContentConfig` at ~line 117).
+- Per concept: `ar = entry.get("aspect_ratio") or config.image_aspect_ratio_default`; if `ar
+  not in config.image_aspect_ratios_allowed`, fall back to the default (log a warning). Then:
+  ```python
+  config=types.GenerateContentConfig(
+      response_modalities=["IMAGE"],
+      image_config=types.ImageConfig(aspect_ratio=ar, image_size=config.image_size),
+  )
+  ```
+- Verify: `uv run pytest tests/test_tools_retry.py -q` still green (concepts without
+  `aspect_ratio` must fall back — that's the `.get() or default` path).
+- Commit: `feat(creative_agent): render images at 9:16/2K via ImageConfig`.
+
+---
+
+## Phase 2 — `IMAGE_PROMPT_GUIDE` + de-bias drafter/critic + `visual_style` field
+
+The core of "many styles". All prompt literals live in `prompts.py` (project convention).
+
+### Task 3: Author `IMAGE_PROMPT_GUIDE` in `prompts.py`
+**Files:** `creative_agent/prompts.py` (new UPPER_SNAKE constant; may draw on the existing
+`<VISUAL_STYLE_AND_AESTHETICS>` block at `:65-87`).
+Structure (the VEO3 analog, but **style-first + template-driven**, not a flat menu):
+- **Core principles**: hyper-specific; describe the scene as a coherent noun-phrase; **name
+  the style explicitly**; positive/"semantic negative" framing; state it's a social ad;
+  render legible in-image text/CTA/brand when it strengthens the ad.
+- **Style palette** — a menu of families, each with a one-line *when-to-use* + a fill-in
+  template: photoreal/editorial, cinematic film still, 3D character (Pixar-ish), 2D
+  flat/vector cartoon, anime/manga, comic panel, **meme aesthetic** (bold caption / screenshot
+  / sticker), diecut sticker, watercolor/gouache, collage/mixed-media, retro/vaporwave,
+  isometric, minimalist negative-space.
+- **Tone→style mapping** (drives selection): Meme-based→meme/sticker/flat cartoon;
+  Humorous→3D character/comic; Aspirational→cinematic photoreal; Emotional/Authentic→candid
+  35mm; Educational→minimalist + legible text/isometric; Problem-Solution→studio product.
+- **Building blocks**: subject, composition/framing, setting, lighting, color, mood, rendering
+  cues, + an **in-image text & branding** block.
+- **Aspect-ratio note**: choose per concept from `9:16` (default, vertical reel), `1:1` (feed),
+  `3:4` (portrait); output the choice in the `aspect_ratio` field.
+- **Length rule** replacing the old ">100 words": *as detailed as the style needs* (a
+  minimalist/sticker prompt should be short; a photoreal scene long).
+
+### Task 4: Add defaulted `visual_style` + `aspect_ratio` fields to visual schemas
+**Files:** `creative_agent/schemas.py` (`VisualConcept`, `VisualConceptCritique`,
+`VisualConceptFinal`). Add `visual_style: str = ""` and `aspect_ratio: str = ""` with
+`Field(description=...)` to each (defaulted → invariant #3). No new list wrappers.
+
+### Task 5: Rewrite drafter + critic instructions (de-bias + inject the guide)
+**Files:** `creative_agent/prompts.py`.
+- `VISUAL_CONCEPT_DRAFTER_INSTR`: replace `<PROMPT_ENGINEERING_GUIDANCE>` with the
+  `IMAGE_PROMPT_GUIDE` content (embed the constant via f-string/concatenation at author time —
+  these are plain literals today, so keep the ADK `{state}` tokens intact and only splice the
+  guide text). Instruct: pick the `visual_style` from the ad-copy tone/audience/trend using the
+  mapping; DO NOT default to photoreal; emit `visual_style` + `aspect_ratio` per concept.
+- `VISUAL_CONCEPT_CRITIC_INSTR`: drop the "photorealistic/8k/100+ words" mandate; instead
+  "refine the prompt **within its chosen `visual_style`**, applying the guide; length
+  appropriate to the style; preserve the style unless it's clearly wrong for the tone." Keep
+  `visual_concept_critic` on `worker_model` (invariant #6).
+- `VISUAL_CONCEPT_FINALIZER_INSTR`: add "**enforce visual_style diversity** across the final
+  4" and carry `visual_style`/`aspect_ratio` through. **Keep** the `ad_copy_critique` +
+  `ad_copy_id` substrings (invariant #5).
+
+### Task 6: Update tests for the additive fields
+**Files:** `tests/test_schemas.py` (add `visual_style`/`aspect_ratio` assertions to the
+visual-concept construction tests — optional since defaulted, but good coverage).
+- Verify: `uv run pytest tests/test_schemas.py tests/test_pipeline_structure.py -q` green.
+- Commit: `feat(creative_agent): add IMAGE_PROMPT_GUIDE, de-bias visual prompts, add visual_style`.
+
+### Task 7 (optional surfacing): show `visual_style` in gallery + judge it in eval
+**Files:** `creative_agent/tools.py` (gallery `<dd>` for `entry.get("visual_style")`),
+`creative_eval/prompts.py` (add a `{visual_style}` line to `VISUAL_CONCEPT_EVAL_USER` so the
+judge sees the intended style). Both purely additive. Commit separately.
+
+---
+
+## Phase 3 — Context enrichment + art-director step
+
+### Task 8: Add `art_director` agent + enrich drafter context
+**Files:** `creative_agent/prompts.py` (new `ART_DIRECTOR_INSTR`), `creative_agent/agent.py`.
+- New agent `art_director` = `Agent(model=build_gemini(config.worker_model),
+  output_key="visual_direction", ...)` — **plain text output, no output_schema** (keeps it
+  simple). Instruction consumes `{combined_final_cited_report?}`, `{brand}`,
+  `{target_audience}`, `{target_search_trends}`, `{ad_copy_critique}` and produces a concise
+  **Visual Direction Brief**: mood, palette, recurring visual motifs from the trend, brand
+  visual cues, and a recommended style family per selected ad-copy tone.
+- Insert `art_director` as the **FIRST** sub-agent of `visual_generation_pipeline`
+  (`agent.py:415-423`) → `[art_director, visual_concept_drafter, visual_concept_critic,
+  visual_concept_finalizer]`.
+- Rewrite `VISUAL_CONCEPT_DRAFTER_INSTR`'s `<CONTEXT>` to also consume `{visual_direction}` +
+  `{combined_final_cited_report?}` + `{brand}` + `{target_audience}` (was ad_copy only).
+- `from . import prompts` is already module-style (`agent.py:16`) — reference
+  `prompts.ART_DIRECTOR_INSTR`; the `IMAGE_PROMPT_GUIDE` is embedded inside the drafter/critic
+  constants at author time (Task 5), so no new import needed.
+
+### Task 9: Update structure tests for the new sub-agent
+**Files:** `tests/test_pipeline_structure.py`.
+- `:140-148` expected `visual_generation_pipeline` names → add `"art_director"` first.
+- `:287-316` add `art_director → "visual_direction"` output-key assertion.
+- `:358-385` finish-reason-callback list → add `art_director` (attach
+  `log_empty_turn_finish_reason` in `agent.py` for parity).
+- Optional: `experiments/creative_latency/parse_run.py` `_EXACT_PHASES` → map `art_director`
+  to `"visual_concepts"` (+ `tests/test_experiment_parse.py`).
+- Verify: `uv run pytest tests/test_pipeline_structure.py -q` green.
+- Commit: `feat(creative_agent): add art_director step + enrich visual drafter context`.
+
+---
+
+## Phase 4 — Reference-image stretch (URI/URL field)
+
+Chosen input method: a **URI/URL text field** (no upload endpoint). Applies one product/brand
+reference image to all concepts for fidelity/consistency.
+
+### Task 10: Backend plumbing — state key + fetch + multimodal contents
+**Files:** `creative_agent/callbacks.py`, `creative_agent/image_tools.py`,
+`creative_agent/gcs_tools.py` (reuse `_download_blob`).
+- `callbacks.py load_session_state`: add `"reference_image_uri": ""` to the init dict.
+- `image_tools.generate_image`: `ref = tool_context.state.get("reference_image_uri")`. If set:
+  - `gs://…` → parse bucket/object, `bytes = _download_blob(bucket, name)` (add to the
+    `.gcs_tools` import).
+  - `http(s)://…` → fetch via stdlib `urllib.request` with a timeout (no new dep).
+  - mime from extension (`.png`→image/png, `.jpg/.jpeg`→image/jpeg, `.webp`→image/webp),
+    default image/png. Build `types.Part.from_bytes(data=bytes, mime_type=mime)`.
+  - `contents = [entry["image_generation_prompt"], ref_part]`; else the bare prompt string.
+  - Wrap fetch in try/except → on failure log a warning and **fall back to text-only** (never
+    fail the run). Fetch the reference bytes **once** before the concept loop.
+- Verify: `uv run pytest tests/test_tools_retry.py -q` green (no `reference_image_uri` set →
+  text-only path unchanged).
+
+### Task 11: Frontend field
+**Files:** `frontend/src/lib/types.ts` (`CampaignInput` → add `referenceImageUri?: string`),
+`frontend/src/app/page.tsx` (a labeled optional `Input`; on submit for creative agents pass it
+via `createSession` `initialState` as `{ reference_image_uri: form.referenceImageUri }` —
+mirrors the existing `{ interactive_trend_pick: true }` precedent at page.tsx:80-84). No
+`/runs` or `_StartRunBody` change needed (state is set at `createSession`).
+- Verify: `cd frontend && npm run build` + `npm test`.
+
+### Task 12: Tests for reference-image assembly
+**Files:** `tests/test_tools_retry.py` or a new `tests/test_image_reference.py`.
+- Unit test: with `reference_image_uri` a `gs://` URI, mock `_download_blob` + the genai client
+  and assert `contents` is a 2-item `[prompt, Part]` list; without it, assert bare-string
+  contents. Assert an invalid `aspect_ratio` falls back to `9:16`.
+- Commit: `feat(creative_agent): optional product reference image for image generation`.
+
+---
+
+## Convention guard
+
+Add one line to `CLAUDE.md` (Agent Definition Pattern section): *"Image-generation prompt
+guidance lives in `creative_agent/prompts.py` as `IMAGE_PROMPT_GUIDE`; visual agents must
+select a `visual_style` rather than defaulting to photorealism."* Include in the final commit.
+
+---
+
+## Verification (run after each phase; full gate before PR)
+
+**Python:**
+```bash
+uv run python -c "import creative_agent.agent, interactive_creative.agent; print('imports ok')"
+uv run pytest tests/ -q            # requires GCP creds (module-level clients)
+uvx ruff format --check . && uvx ruff check . && uvx ty check
+```
+Expected: imports ok; all green — especially `test_pipeline_structure.py` (new sub-agent
+order + output keys), `test_schemas.py` (defaulted fields), `test_tools_retry.py` (`.get()` +
+aspect-ratio fallback + reference-image path).
+
+**Frontend:** `cd frontend && npm test && npm run build` — green.
+
+**Live smoke (gated per deploy rules; only if the user asks):** run `creative_agent` locally
+via `deployment/async_app.py` + frontend (or `deployment/test_deployment.py`), confirm: images
+render at 9:16, the 4 concepts show **diverse `visual_style`s** (not all photoreal), the
+gallery HTML shows style, and — with a `gs://` product image in `reference_image_uri` — the
+product's likeness is preserved. Quantitatively, re-run the creative_eval judge and check
+`prompt_technical_quality` / `trend_visual_connection` / `stopping_power` did not regress.
+
+## Result
+
+| Concern | Before | After |
+|---|---|---|
+| Prompt guidance | 3 bullets + undefined "best practices" | full `IMAGE_PROMPT_GUIDE` grammar |
+| Style range | photoreal-biased | LLM-selected from ~13 families, diversity enforced |
+| Style visibility | buried in prose | first-class `visual_style` field (logged/judged) |
+| Drafter context | ad copy only | + research report, brand, audience, art-director brief |
+| Framing/res | 1:1 default | per-concept 9:16/1:1/3:4 @ 2K |
+| Product fidelity | text description only | optional real reference image |

--- a/experiments/creative_latency/parse_run.py
+++ b/experiments/creative_latency/parse_run.py
@@ -47,6 +47,7 @@ _PREFIX_PHASES: tuple[tuple[str, str], ...] = (
     ("parallel_planner", "research"),
     ("ad_copy", "ad_copy"),
     ("ad_creative", "ad_copy"),
+    ("art_director", "visual_concepts"),
     ("visual_concept", "visual_concepts"),
     ("visual_generat", "image_gen"),  # visual_generator, visual_generator_resilient
 )

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -44,6 +44,7 @@ function HomeContent() {
     keySellingPoints: "",
     targetSearchTrend: "",
     interactiveTrendPick: false,
+    referenceImageUri: "",
   });
 
   // Pre-fill form from URL params (when clicking a trend card)
@@ -80,7 +81,11 @@ function HomeContent() {
       const initialState =
         form.agent === "trend_scout" && form.interactiveTrendPick
           ? { interactive_trend_pick: true }
-          : undefined;
+          : (form.agent === "creative_agent" ||
+                form.agent === "interactive_creative") &&
+              form.referenceImageUri?.trim()
+            ? { reference_image_uri: form.referenceImageUri.trim() }
+            : undefined;
       const session = await createSession(form.agent, userId, initialState);
 
       // Build the user message with campaign metadata
@@ -327,6 +332,23 @@ function HomeContent() {
                 value={form.targetSearchTrend}
                 onChange={(e) =>
                   setForm({ ...form, targetSearchTrend: e.target.value })
+                }
+                className="bg-background border-border hover:border-foreground/20 focus:border-primary/50 transition-colors"
+              />
+            </div>
+          )}
+
+          {(form.agent === "creative_agent" || form.agent === "interactive_creative") && (
+            <div className="space-y-2 animate-fadeInUpSmooth">
+              <Label htmlFor="referenceImage" className="text-muted-foreground text-xs uppercase tracking-wider">
+                Reference Image URL (optional)
+              </Label>
+              <Input
+                id="referenceImage"
+                placeholder='gs://bucket/product.png or https://…'
+                value={form.referenceImageUri}
+                onChange={(e) =>
+                  setForm({ ...form, referenceImageUri: e.target.value })
                 }
                 className="bg-background border-border hover:border-foreground/20 focus:border-primary/50 transition-colors"
               />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -63,4 +63,11 @@ export interface CampaignInput {
    * `interactive_trend_pick`.
    */
   interactiveTrendPick?: boolean;
+  /**
+   * creative_agent / interactive_creative only: an optional gs:// or http(s)
+   * URL to a product/brand reference image. Threaded into the session's initial
+   * state as `reference_image_uri` so image generation can apply it to every
+   * concept for likeness/consistency.
+   */
+  referenceImageUri?: string;
 }

--- a/tests/test_experiment_parse.py
+++ b/tests/test_experiment_parse.py
@@ -40,6 +40,7 @@ class TestPhaseOf:
         assert phase_of("ad_copy_critic") == "ad_copy"
 
     def test_visual_concepts(self):
+        assert phase_of("art_director") == "visual_concepts"
         assert phase_of("visual_concept_drafter") == "visual_concepts"
         assert phase_of("visual_concept_finalizer") == "visual_concepts"
 

--- a/tests/test_image_reference.py
+++ b/tests/test_image_reference.py
@@ -1,0 +1,165 @@
+"""generate_image assembles multimodal contents + a valid ImageConfig.
+
+Covers the Phase-4 reference-image path (gs:// / http(s):// → a Part appended to
+contents, with a text-only fallback) and the Phase-1 aspect-ratio config
+(per-concept choice with a fallback to the configured default for bad values).
+"""
+
+import asyncio
+
+from creative_agent import image_tools
+
+
+async def _noop_async(*a, **k):
+    return None
+
+
+class MockState(dict):
+    pass
+
+
+class MockToolContext:
+    def __init__(self):
+        self.state = MockState()
+        self.state["gcs_folder"] = "f"
+        self.state["agent_output_dir"] = "d"
+
+    async def save_artifact(self, *a, **k):
+        return None
+
+
+class _Part:
+    class inline_data:
+        data = b"\x89PNG"
+        mime_type = "image/png"
+
+
+class _Content:
+    parts = [_Part()]
+
+
+class _Candidate:
+    content = _Content()
+
+
+class _GoodResponse:
+    candidates = [_Candidate()]
+
+
+class _RecordingModels:
+    """Records the (contents, config) of each generate_content call."""
+
+    def __init__(self):
+        self.calls = []
+
+    def generate_content(self, *a, **k):
+        self.calls.append(k)
+        return _GoodResponse()
+
+
+def _patch_client(monkeypatch):
+    models = _RecordingModels()
+
+    class _Client:
+        pass
+
+    client = _Client()
+    client.models = models
+    monkeypatch.setattr(image_tools, "_get_genai_client", lambda: client)
+    monkeypatch.setattr(image_tools.asyncio, "sleep", _noop_async)
+    monkeypatch.setattr(image_tools, "_save_to_gcs", lambda *a, **k: "gs://b/c.png")
+    return models
+
+
+def test_no_reference_uses_bare_string_contents(monkeypatch):
+    """Without reference_image_uri, contents is the bare prompt string."""
+    models = _patch_client(monkeypatch)
+    ctx = MockToolContext()
+    ctx.state["final_visual_concepts"] = {
+        "visual_concepts": [
+            {"image_generation_prompt": "a flat cartoon", "concept_name": "c"}
+        ]
+    }
+
+    result = asyncio.run(image_tools.generate_image(ctx))
+    assert result["status"] == "success"
+    assert len(models.calls) == 1
+    assert models.calls[0]["contents"] == "a flat cartoon"
+
+
+def test_gs_reference_appends_part_to_contents(monkeypatch):
+    """A gs:// reference_image_uri → contents is [prompt, Part]; _download_blob
+    is called with the parsed bucket/object."""
+    models = _patch_client(monkeypatch)
+    dl = {}
+
+    def fake_download(bucket, obj):
+        dl["bucket"], dl["obj"] = bucket, obj
+        return b"\x89PNGREF"
+
+    monkeypatch.setattr(image_tools, "_download_blob", fake_download)
+
+    ctx = MockToolContext()
+    ctx.state["reference_image_uri"] = "gs://my-bucket/products/guitar.png"
+    ctx.state["final_visual_concepts"] = {
+        "visual_concepts": [
+            {"image_generation_prompt": "a studio shot", "concept_name": "c"}
+        ]
+    }
+
+    result = asyncio.run(image_tools.generate_image(ctx))
+    assert result["status"] == "success"
+    assert dl == {"bucket": "my-bucket", "obj": "products/guitar.png"}
+    contents = models.calls[0]["contents"]
+    assert isinstance(contents, list) and len(contents) == 2
+    assert contents[0] == "a studio shot"
+    # The second element is a genai Part built from the reference bytes.
+    assert getattr(contents[1], "inline_data", None) is not None
+
+
+def test_reference_fetch_failure_falls_back_to_text_only(monkeypatch):
+    """If the reference fetch raises, generation proceeds text-only (no crash)."""
+    models = _patch_client(monkeypatch)
+
+    def boom(*a, **k):
+        raise RuntimeError("gcs down")
+
+    monkeypatch.setattr(image_tools, "_download_blob", boom)
+
+    ctx = MockToolContext()
+    ctx.state["reference_image_uri"] = "gs://my-bucket/x.png"
+    ctx.state["final_visual_concepts"] = {
+        "visual_concepts": [{"image_generation_prompt": "a scene", "concept_name": "c"}]
+    }
+
+    result = asyncio.run(image_tools.generate_image(ctx))
+    assert result["status"] == "success"
+    assert models.calls[0]["contents"] == "a scene"
+
+
+def test_bad_aspect_ratio_falls_back_to_default(monkeypatch):
+    """An aspect_ratio outside the allowed set falls back to the configured
+    default; a valid choice is passed through."""
+    models = _patch_client(monkeypatch)
+    ctx = MockToolContext()
+    ctx.state["final_visual_concepts"] = {
+        "visual_concepts": [
+            {
+                "image_generation_prompt": "p1",
+                "concept_name": "c1",
+                "aspect_ratio": "banana",
+            },
+            {
+                "image_generation_prompt": "p2",
+                "concept_name": "c2",
+                "aspect_ratio": "1:1",
+            },
+        ]
+    }
+
+    result = asyncio.run(image_tools.generate_image(ctx))
+    assert result["status"] == "success"
+    ar0 = models.calls[0]["config"].image_config.aspect_ratio
+    ar1 = models.calls[1]["config"].image_config.aspect_ratio
+    assert ar0 == image_tools.config.image_aspect_ratio_default
+    assert ar1 == "1:1"

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -142,6 +142,7 @@ def test_visual_generation_pipeline_sub_agent_order():
 
     names = [a.name for a in visual_generation_pipeline.sub_agents]
     assert names == [
+        "art_director",
         "visual_concept_drafter",
         "visual_concept_critic",
         "visual_concept_finalizer",
@@ -293,6 +294,7 @@ def test_output_keys_are_set_correctly():
         combined_report_composer,
         ad_copy_drafter,
         ad_copy_critic,
+        art_director,
         visual_concept_drafter,
         visual_concept_critic,
         visual_concept_finalizer,
@@ -306,6 +308,7 @@ def test_output_keys_are_set_correctly():
         (combined_report_composer, "combined_final_cited_report"),
         (ad_copy_drafter, "ad_copy_draft"),
         (ad_copy_critic, "ad_copy_critique"),
+        (art_director, "visual_direction"),
         (visual_concept_drafter, "visual_draft"),
         (visual_concept_critic, "visual_concept_critique"),
         (visual_concept_finalizer, "final_visual_concepts"),
@@ -371,6 +374,7 @@ def test_creative_model_agents_have_finish_reason_callback():
         ca.combined_report_composer,
         ca.ad_copy_drafter,
         ca.ad_copy_critic,
+        ca.art_director,
         ca.visual_concept_drafter,
         ca.visual_concept_critic,
         ca.visual_concept_finalizer,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -105,6 +105,22 @@ def test_visual_concept_schema():
         image_generation_prompt="Photorealistic 9:16 portrait of a guitarist...",
     )
     assert vc.concept_name == "Sunset Serenade"
+    # visual_style / aspect_ratio are additive + defaulted (construction without
+    # them must keep working — see invariant #3 in the overhaul plan).
+    assert vc.visual_style == ""
+    assert vc.aspect_ratio == ""
+
+    styled = VisualConcept(
+        ad_copy_id=2,
+        concept_name="Meme Drop",
+        trend_visual_link="Riffs on the trending meme format.",
+        concept_summary="A bold caption meme of the product.",
+        image_generation_prompt="A meme-style image with top caption '...'.",
+        visual_style="meme aesthetic",
+        aspect_ratio="9:16",
+    )
+    assert styled.visual_style == "meme aesthetic"
+    assert styled.aspect_ratio == "9:16"
 
 
 def test_visual_concept_final_schema():


### PR DESCRIPTION
## Summary

Overhauls image-generation prompting so `creative_agent` (and `interactive_creative`, which imports it) produces **dramatically better, style-diverse** ad images — a stills analog to `VEO3_INSTR`. Removes the baked-in photoreal bias, gives the visual agents a real image-prompt "grammar", enriches their context with a dedicated art-director step, and wires the image model's real config knobs (aspect ratio / size) plus an optional product reference image.

Root orchestration, tool names, and the `visual_production_pipeline` shape are unchanged, so ADK evals and root-tool tests stay intact.

## What changed

**Phase 1 — image config knobs** (`agent_common/config.py`, `creative_agent/image_tools.py`)
- Render at **9:16 / 2K** by default via `types.ImageConfig(aspect_ratio, image_size)` (was 1:1 square). Per-concept aspect ratio chosen from an allowed set (`9:16`, `1:1`, `3:4`) with a safe fallback to the default.

**Phase 2 — `IMAGE_PROMPT_GUIDE` + de-bias + first-class style** (`creative_agent/prompts.py`, `schemas.py`, `tools.py`, `creative_eval/prompts.py`)
- New `IMAGE_PROMPT_GUIDE` grammar: core principles, ~13 style families, tone→style mapping, building blocks, aspect-ratio guidance. Uses `[brackets]` (never `{braces}`) so ADK templating leaves it intact; spliced by string concatenation.
- Drafter/critic de-biased — choose a style, don't default to photoreal; dropped the "photorealistic/8k/100+ words" mandate.
- New defaulted schema fields `visual_style` / `aspect_ratio` on the visual concepts (surfaced in the HTML gallery and shown to the eval judge).

**Phase 3 — art-director step + richer context** (`creative_agent/agent.py`, `prompts.py`)
- New `art_director` agent (plain-text `visual_direction` brief) inserted first in `visual_generation_pipeline`. Drafter context enriched with the brief + research report + brand + audience.

**Phase 4 — optional product reference image** (`creative_agent/callbacks.py`, `image_tools.py`, frontend)
- Optional `reference_image_uri` (gs:// or http(s)://) threaded via `createSession` initialState → fetched once and applied to every concept as a multimodal `contents` part, with a text-only fallback on any fetch failure. New optional frontend field.

## Testing

- **Unit/structure:** 360 Python tests + 99 frontend tests green; `ruff format --check`, `ruff check`, `ty check`, `npm run build` all clean.
- **Live smoke (targeted):** real `gemini-3.1-flash-image` calls rendered 3 diverse styles at the requested ratios — 9:16→1536×2752, 1:1→2048×2048, 3:4→1792×2400 (all 2K); the `gs://` reference-image path worked end-to-end.
- **Live smoke (behavioral):** ran `visual_generation_pipeline` in isolation — `art_director → drafter → critic → finalizer` in order; art-director produced a full Visual Direction Brief; finalizer produced **4 distinct styles** (meme aesthetic, minimalist negative-space, collage/mixed-media, isometric — none photoreal) across varied aspect ratios, with `ad_copy_id` carried through.
