### PR TITLE
fix(creative_agent): retry transient 429/503 model calls + throttle eval fan-out

### DIFF
--- a/agent_common/genai_retry.py
+++ b/agent_common/genai_retry.py
@@ -1,0 +1,54 @@
+"""Factory for the shared google-genai HTTP-layer retry options.
+
+This is the STATUS-CODE-based sibling of :mod:`agent_common.retry`. That module
+configures ADK's node-level ``RetryConfig``, which matches by *exact exception
+class name* — useless for genai 429s, because genai raises every 4xx (400/403/404
+*and* 429) as the single class ``google.genai.errors.ClientError``, so its name
+can't distinguish a transient quota error from a permanent bad request.
+
+The genai SDK's own HTTP retry keys off the response **status code** instead, so
+it can retry transient ``429`` (RESOURCE_EXHAUSTED / the shared per-minute Vertex
+quota) and ``503``/``500``/``504`` with exponential backoff while letting the
+permanent 4xx (``400``/``403``/``404``) fail fast. Wired via
+``Gemini(retry_options=...)`` (ADK merges it into the client's ``http_options``)
+for every agent model call, and via a direct ``HttpOptions`` on the standalone
+``creative_eval`` judge client.
+
+Deliberately free of any ``google.adk`` import so the ADK-free ``creative_eval``
+pipeline can share it (mirrors :mod:`agent_common.locations`).
+"""
+
+from google.genai import types
+
+# Transient HTTP statuses worth retrying. 429 is the load-bearing one: the
+# gemini base models are capped at a few RPM project-wide/shared, so concurrent
+# bursts across the pipeline trip 429 RESOURCE_EXHAUSTED. 500/503/504 cover
+# transient server/availability blips. Permanent 4xx (400/403/404) are
+# intentionally EXCLUDED so genuine request errors still surface immediately.
+RETRYABLE_HTTP_STATUS_CODES = [429, 500, 503, 504]
+
+
+def build_genai_http_retry(
+    attempts: int = 5,
+    initial_delay: float = 10.0,
+    max_delay: float = 60.0,
+) -> types.HttpRetryOptions:
+    """Return ``HttpRetryOptions`` retrying transient/quota errors with backoff.
+
+    Defaults are tuned for the shared per-minute Vertex quota: a ~10s initial
+    delay doubling to a 60s cap gives the bucket time to refill between attempts
+    (10 → 20 → 40 → 60 → 60), so a run paced just over quota self-heals instead
+    of aborting mid-pipeline.
+
+    Args:
+        attempts: total attempts, including the original request.
+        initial_delay: seconds before the first retry.
+        max_delay: cap on the per-retry delay.
+    """
+    return types.HttpRetryOptions(
+        attempts=attempts,
+        initial_delay=initial_delay,
+        max_delay=max_delay,
+        exp_base=2,
+        http_status_codes=RETRYABLE_HTTP_STATUS_CODES,
+    )

--- a/agent_common/models.py
+++ b/agent_common/models.py
@@ -6,11 +6,15 @@ rather than via the reserved ``GOOGLE_CLOUD_LOCATION`` env var.
 ADK exposes ``Gemini.client_kwargs`` for exactly this: extra kwargs passed
 straight to the underlying ``google.genai.Client`` constructor, where an explicit
 ``location`` takes precedence over the injected ``GOOGLE_CLOUD_LOCATION``.
+
+It also carries the shared genai HTTP-layer retry (:mod:`agent_common.genai_retry`)
+so every agent model call retries transient 429/503 (the shared per-minute Vertex
+quota) with backoff instead of aborting the run.
 """
 
 from google.adk.models import Gemini
 
-from agent_common import locations
+from agent_common import genai_retry, locations
 
 
 def build_gemini(model_name: str, location: str | None = None) -> Gemini:
@@ -26,7 +30,12 @@ def build_gemini(model_name: str, location: str | None = None) -> Gemini:
     also lands their calls in the *regional* per-base-model quota bucket, which
     is a separate pool from the ``global`` one the gemini-3.x models draw from.
     """
+    # retry_options goes on the top-level param (NOT inside client_kwargs): ADK
+    # merges it into the client's own http_options alongside its tracking
+    # headers, whereas an http_options passed via client_kwargs would overwrite
+    # those wholesale.
     return Gemini(
         model=model_name,
+        retry_options=genai_retry.build_genai_http_retry(),
         client_kwargs={"location": location or locations.MODEL_LOCATION},
     )

--- a/creative_eval/config.py
+++ b/creative_eval/config.py
@@ -24,14 +24,16 @@ class EvalConfig:
 
     # Max concurrent judge calls. Each creative is scored by an independent judge
     # call. On the DEFAULT judge (gemini-3.1-pro-preview @ `global`) the base
-    # model is capped at **5 RPM** project-wide/shared, so fanning out 12 at once
-    # trips 503 UNAVAILABLE / 429 — a single run's eval alone exceeds the pro
-    # quota. Keep this at/below the pro RPM there. If the judge is moved to a
-    # DEDICATED regional bucket (EVAL_MODEL_LOCATION=us-central1, an unused pool),
-    # this can be raised via EVAL_MAX_WORKERS for a faster single-wave eval.
-    # See docs/notes/ambient-agents-vs-cloud-functions.md.
+    # model is capped at **5 RPM** project-wide/shared. It's not just the initial
+    # wave: at ~28s/call, 3 workers land ~6 calls inside a rolling 60s window,
+    # which exceeds the pro quota and trips 429/503; 2 workers stay under it
+    # (~4/min). Default is therefore 2. Transient 429s are also retried at the
+    # HTTP layer (see _get_client), so this is defence-in-depth, not the only
+    # guard. If the judge is moved to a DEDICATED regional bucket
+    # (EVAL_MODEL_LOCATION=us-central1, an unused pool), raise via EVAL_MAX_WORKERS
+    # for a faster eval. See docs/notes/ambient-agents-vs-cloud-functions.md.
     max_eval_workers: int = field(
-        default_factory=lambda: int(os.getenv("EVAL_MAX_WORKERS", "3"))
+        default_factory=lambda: int(os.getenv("EVAL_MAX_WORKERS", "2"))
     )
 
     # Scoring dimensions and weights for ad copy

--- a/creative_eval/evaluate.py
+++ b/creative_eval/evaluate.py
@@ -17,6 +17,8 @@ from concurrent.futures import ThreadPoolExecutor
 
 from google import genai
 
+from agent_common.genai_retry import build_genai_http_retry
+
 from .config import EvalConfig
 from .schemas import (
     AdCopyEvaluation,
@@ -32,11 +34,21 @@ logger = logging.getLogger(__name__)
 
 
 def _get_client(config: EvalConfig) -> genai.Client:
-    """Create a Gemini client."""
+    """Create a Gemini client with HTTP-layer retry for transient 429/503.
+
+    Each creative is judged by an independent, concurrent call, so a fan-out that
+    briefly outpaces the shared per-minute Vertex quota would otherwise 429 and
+    (via evaluate_ad_copy/evaluate_visual_concept's except) degrade that creative
+    to a zero score — sinking the report for a transient error. Retrying at the
+    HTTP layer lets those calls self-heal instead. See agent_common.genai_retry.
+    """
     return genai.Client(
         vertexai=True,
         project=config.project_id,
         location=config.location,
+        http_options=genai.types.HttpOptions(
+            retry_options=build_genai_http_retry()
+        ),
     )
 
 

--- a/tests/test_agent_common_models.py
+++ b/tests/test_agent_common_models.py
@@ -29,7 +29,37 @@ def test_build_gemini_pins_location(monkeypatch):
 
     gem = build_gemini("gemini-3.1-pro-preview")
     assert gem.model == "gemini-3.1-pro-preview"
+    # location stays in client_kwargs; retry_options must NOT be smuggled in as an
+    # http_options here (that would clobber ADK's tracking headers).
     assert gem.client_kwargs == {"location": "global"}
+    assert "http_options" not in gem.client_kwargs
+
+
+def test_build_gemini_sets_http_retry(monkeypatch):
+    """Every agent model call carries the HTTP-layer retry for transient 429/503."""
+    monkeypatch.delenv("MODEL_LOCATION", raising=False)
+    import agent_common.locations as locations
+
+    importlib.reload(locations)
+    from agent_common.models import build_gemini
+
+    gem = build_gemini("gemini-3.5-flash")
+    assert gem.retry_options is not None
+    codes = set(gem.retry_options.http_status_codes)
+    assert {429, 503} <= codes
+    # permanent request errors must still fail fast, not retry
+    assert codes.isdisjoint({400, 403, 404})
+
+
+def test_build_genai_http_retry_scoped_to_transient():
+    """The shared genai HTTP-retry retries quota/transient codes, not permanent 4xx."""
+    from agent_common.genai_retry import build_genai_http_retry
+
+    opts = build_genai_http_retry()
+    codes = set(opts.http_status_codes)
+    assert {429, 500, 503, 504} <= codes
+    assert codes.isdisjoint({400, 403, 404})
+    assert opts.attempts >= 2
 
 
 def test_model_location_env_override(monkeypatch):

--- a/tests/test_creative_eval.py
+++ b/tests/test_creative_eval.py
@@ -312,13 +312,16 @@ class TestEvalConfig:
 
     def test_max_eval_workers_within_pro_rpm_quota(self):
         """The judge is gemini-3.1-pro-preview, capped at 5 RPM (global,
-        project-wide). Fanning out more concurrent judge calls than that trips
-        503/429, so the default must stay at/below the quota. See
-        docs/notes/ambient-agents-vs-cloud-functions.md."""
+        project-wide). At ~28s/call, N workers land ~2N calls inside a rolling
+        60s window, so the default must stay low enough that the *sustained* rate
+        (not just the first wave) stays under 5 RPM. 2 workers ≈ 4/min; 3 ≈ 6/min
+        (over quota). See docs/notes/ambient-agents-vs-cloud-functions.md."""
         from creative_eval.config import EvalConfig
 
         _PRO_RPM_QUOTA = 5
-        assert EvalConfig().max_eval_workers <= _PRO_RPM_QUOTA
+        assert EvalConfig().max_eval_workers == 2
+        # sustained rate (~2 calls per worker per minute) stays under the quota
+        assert EvalConfig().max_eval_workers * 2 <= _PRO_RPM_QUOTA
 
     def test_custom_threshold(self):
         from creative_eval.config import EvalConfig


### PR DESCRIPTION
## Problem

Running `creative_agent` surfaces `Vertex AI quota exhausted (429): the shared per-minute request quota was hit`. The pipeline funnels many model calls into shared, **unraisable** per-minute Vertex buckets (flash/pro = 5 RPM, image = 2 RPM), and nothing retried ordinary agent-model 429s — so a run paced just over quota **aborts mid-pipeline** instead of pacing through.

This is the low-risk **B + C** pair (retry + throttle). The larger quota-bucket **spread (A)** — mirroring #94 for trend_scout — is a deliberate follow-up.

## B — survive/retry transient 429/503 (one place, all agents)

- New ADK-free `agent_common/genai_retry.py` → `build_genai_http_retry()`, the genai SDK's HTTP-layer `HttpRetryOptions` for statuses `[429, 500, 503, 504]` with exponential backoff (10→20→40→60→60s).
- Keying off the **status code** sidesteps ADK's exact-class-name retry matching: genai raises *every* 4xx (400/403/404 **and** 429) as the single `ClientError`, so its name can't distinguish transient from permanent. The HTTP retry retries the transient/quota codes while permanent 4xx still **fail fast**.
- Wired into `build_gemini` via the top-level `retry_options=` param, so **every** agent model call is covered in a single edit. Confirmed against ADK 2.4.0 source that `retry_options` merges into ADK's own `http_options` (keeping its tracking headers); passing `http_options` via `client_kwargs` would have clobbered them.

## C — retry + throttle the creative_eval judge fan-out

- `creative_eval/evaluate.py::_get_client` now carries the same `HttpRetryOptions`, so a transient 429 **retries** instead of degrading that creative to a zero score (which previously sank the eval report for a transient error).
- `creative_eval/config.py`: `max_eval_workers` default **3 → 2**. At ~28s/call, 3 workers land ~6 pro calls in a rolling 60s window (over the 5-RPM bucket); 2 keeps sustained rate ~4/min, under quota — with the HTTP retry as backstop. Still `EVAL_MAX_WORKERS`-overridable.

`creative_agent/image_tools.py` is left as-is — it already hand-rolls longer backoff tuned to the 2-RPM image bucket.

## Testing

- `uvx ruff check` clean on all changed files.
- New unit tests: `build_genai_http_retry` retries `{429,500,503,504}` and excludes `{400,403,404}`; `build_gemini` sets `retry_options` and does not smuggle `http_options` into `client_kwargs`; eval-workers default locked to 2.
- `uv run pytest` green across `test_agent_common_models`, `test_creative_eval`, `test_retry_config`, `test_config`, `test_pipeline_structure` (99 passed).

## Not in scope (follow-up)

- **A**: quota-bucket spread for creative_agent (fan flash/pro agents across separate per-base-model buckets, à la #94).