### PR TITLE
fix(creative_agent): spread campaign research onto a regional quota bucket (mirrors #94)

### DIFF
--- a/creative_agent/config.py
+++ b/creative_agent/config.py
@@ -15,7 +15,35 @@ INFRA_RETRY = build_infra_retry(extra_exceptions=[genai_errors.ServerError])
 
 @dataclass
 class ResearchConfiguration(BaseAgentConfiguration):
-    """Research config for creative_agent — all fields shared via the base."""
+    """Research config for creative_agent.
+
+    Quota spread (mirrors trend_scout PR #94): the one ``ParallelAgent`` in the
+    tree, ``parallel_planner_agent``, runs the trend- and campaign-research
+    pipelines at the same time. Both used to drive off the same global buckets,
+    so each step fired *two* concurrent calls into one ~5-RPM pool
+    (``gemini-3.1-flash-lite`` planners, then ``gemini-3.5-flash`` searchers +
+    synthesizers) → ``429 RESOURCE_EXHAUSTED``. Vertex quota is **per-base-model**
+    (and, off ``global``, **per-region**), so we pin the *campaign* half to a
+    separate regional pool:
+
+    - trend planner/searcher/synthesizer  → base ``lite_planner_model`` /
+      ``worker_model`` (gemini-3.x)                                @ global
+    - campaign planner                    → ``regional_lite_planner_model``
+      (gemini-2.5-flash-lite)                                      @ us-central1
+    - campaign searcher + synthesizer     → ``regional_worker_model``
+      (gemini-2.5-flash)                                           @ us-central1
+
+    This drops each global family's bucket from 2 concurrent callers to 1 during
+    the parallel phase. gemini-2.5 models 404 on ``global`` and must run
+    regionally (the inverse of gemini-3.x); sibling/alias names
+    (``gemini-flash-early-exp*``) 404, so these must be genuine base models.
+    The eval judge (gemini-3.1-pro-preview @ global) is deliberately left on its
+    bucket — a prior A/B rejected gemini-2.5-pro there (grades softer).
+    """
+
+    regional_model_location: str = "us-central1"
+    regional_worker_model: str = "gemini-2.5-flash"  # campaign searcher + synthesizer
+    regional_lite_planner_model: str = "gemini-2.5-flash-lite"  # campaign planner
 
 
 config = ResearchConfiguration()

--- a/creative_agent/sub_agents/campaign_researcher/agent.py
+++ b/creative_agent/sub_agents/campaign_researcher/agent.py
@@ -33,7 +33,11 @@ class CampaignQueryList(BaseModel):
 
 # --- AGENT DEFINITIONS ---
 campaign_web_planner = Agent(
-    model=build_gemini(config.lite_planner_model),
+    # Quota spread (#94): campaign half runs on the regional gemini-2.5 pool so
+    # it doesn't double up on the global flash-lite bucket with the trend planner.
+    model=build_gemini(
+        config.regional_lite_planner_model, location=config.regional_model_location
+    ),
     name="campaign_web_planner",
     include_contents="none",
     description="Generates initial queries to guide web research about concepts described in the campaign metadata.",
@@ -89,7 +93,11 @@ campaign_web_planner = Agent(
 # no single turn has to think, search, AND author a long report. Grounding
 # metadata lives on this turn, so `collect_research_sources_callback` stays here.
 campaign_web_searcher = Agent(
-    model=build_gemini(config.worker_model),
+    # Quota spread (#94): regional gemini-2.5-flash bucket. google_search
+    # grounding is supported on this model @ us-central1 (verified via probe).
+    model=build_gemini(
+        config.regional_worker_model, location=config.regional_model_location
+    ),
     name="campaign_web_searcher",
     include_contents="none",
     description="Performs the crucial first pass of web research about the campaign guide.",
@@ -134,7 +142,10 @@ campaign_web_searcher = Agent(
 # wrapper retries the whole pair rather than raising KeyError inside it) and shapes
 # them into the existing consumer-facing report.
 campaign_web_synthesizer = Agent(
-    model=build_gemini(config.worker_model),
+    # Quota spread (#94): regional gemini-2.5-flash bucket (no grounding here).
+    model=build_gemini(
+        config.regional_worker_model, location=config.regional_model_location
+    ),
     name="campaign_web_synthesizer",
     include_contents="none",
     description="Synthesizes the raw campaign findings into a structured strategic report.",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -154,6 +154,23 @@ class TestBaseAgentConfiguration:
         assert tt.config.picker_model == "gemini-2.5-pro"
         assert tt.config.regional_model_location == "us-central1"
 
+    def test_creative_agent_regional_model_spread(self):
+        """creative_agent pins its campaign-research pipeline to a separate
+        regional (gemini-2.5 @ us-central1) quota bucket (mirrors trend_scout #94).
+
+        Halves parallel_planner_agent's contention: the trend-research half stays
+        on the global flash/flash-lite buckets while the campaign half draws from
+        the regional pool instead of doubling up on the same global buckets.
+        """
+        import creative_agent.config as ca
+
+        assert ca.config.regional_model_location == "us-central1"
+        assert ca.config.regional_worker_model == "gemini-2.5-flash"
+        assert ca.config.regional_lite_planner_model == "gemini-2.5-flash-lite"
+        # the global base-model names must be UNCHANGED (spread != rename)
+        assert ca.config.worker_model == "gemini-3.5-flash"
+        assert ca.config.lite_planner_model == "gemini-3.1-flash-lite"
+
 
 class TestBuildInfraRetry:
     def test_base_exceptions_present_no_serrver_error(self):

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -274,6 +274,39 @@ def test_gs_searcher_keeps_source_collection():
     assert gs_web_synthesizer.after_agent_callback is None
 
 
+def test_campaign_pipeline_uses_regional_bucket():
+    """Quota spread (#94-style): the campaign-research half of the one
+    ParallelAgent is pinned to gemini-2.5 @ us-central1, a separate per-base-model
+    quota pool from the global buckets the trend half uses."""
+    from creative_agent.sub_agents.campaign_researcher.agent import (
+        campaign_web_planner,
+        campaign_web_searcher,
+        campaign_web_synthesizer,
+    )
+
+    for a in (campaign_web_planner, campaign_web_searcher, campaign_web_synthesizer):
+        assert a.model.client_kwargs["location"] == "us-central1"
+    assert campaign_web_planner.model.model == "gemini-2.5-flash-lite"
+    assert campaign_web_searcher.model.model == "gemini-2.5-flash"
+    assert campaign_web_synthesizer.model.model == "gemini-2.5-flash"
+
+
+def test_trend_pipeline_stays_global():
+    """The trend-research half is left on the global buckets, becoming their sole
+    occupant during the parallel phase (the other side of the #94-style spread)."""
+    from creative_agent.sub_agents.trend_researcher.agent import (
+        gs_web_planner,
+        gs_web_searcher,
+        gs_web_synthesizer,
+    )
+
+    for a in (gs_web_planner, gs_web_searcher, gs_web_synthesizer):
+        assert a.model.client_kwargs["location"] == "global"
+    assert gs_web_planner.model.model == "gemini-3.1-flash-lite"
+    assert gs_web_searcher.model.model == "gemini-3.5-flash"
+    assert gs_web_synthesizer.model.model == "gemini-3.5-flash"
+
+
 def test_merge_planners_inputs_are_optional():
     """merge_planners' two research inputs must use the optional `{var?}` syntax so
     a producer that exhausted its retries (key unset) degrades observably instead of


### PR DESCRIPTION
## Problem

`creative_agent` UI runs were aborting on Vertex `429 RESOURCE_EXHAUSTED`. The one `ParallelAgent` in the tree — `parallel_planner_agent` — runs the trend- and campaign-research pipelines at the same time, and both drove off the **same** `global` buckets. So at each step **two** concurrent calls hit one shared ~5-RPM pool (two `gemini-3.1-flash-lite` planners, then two `gemini-3.5-flash` searchers + synthesizers). PR #100 made runs *survive* transient 429s (HTTP-status retry) but did not reduce the underlying concurrent load.

## Fix

Mirror the merged `trend_scout` quota-bucket spread (#94): pin the **campaign** half to a separate regional pool while leaving the **trend** half on global as its sole occupant. Vertex quota is per-base-model and, off `global`, per-region — so regional `gemini-2.5` @ `us-central1` is an entirely separate pool.

- campaign planner → `gemini-2.5-flash-lite` @ us-central1
- campaign searcher + synthesizer → `gemini-2.5-flash` @ us-central1
- trend pipeline → unchanged (global gemini-3.x)

This drops each contended global family from **2 concurrent callers to 1** during the parallel phase. Uses the `location=` arg `build_gemini` already supports — no new plumbing.

The eval judge (`gemini-3.1-pro-preview` @ global) is **deliberately left untouched** — a prior A/B rejected `gemini-2.5-pro` there (grades systematically softer).

## Verification

- **Probe:** confirmed regional `gemini-2.5-flash` @ us-central1 supports `google_search` grounding (2 search queries issued, grounding chunks returned) before committing to the searcher move.
- **Local:** `ruff` clean; 58 tests pass across `test_config` / `test_pipeline_structure` / `test_agent_common_models` (incl. new RED→GREEN tests asserting campaign=regional, trend=global).
- **Live smoke:** full end-to-end run completed with **0 × 429** — campaign side fired `gemini-2.5-flash` ×2 + `gemini-2.5-flash-lite` ×1 regionally while the trend side stayed global; all research keys populated, no retry-exhaustion, 4 images + eval report produced.