### PR TITLE
fix(creative_agent): isolate export scratch files per-run (fixes N=5 artifact race, #104)

### DIFF
--- a/creative_agent/gcs_tools.py
+++ b/creative_agent/gcs_tools.py
@@ -3,8 +3,8 @@
 import os
 import json
 import string
-import shutil
 import asyncio
+import tempfile
 import logging
 import functools
 
@@ -182,51 +182,50 @@ async def save_draft_report_artifact(tool_context: ToolContext) -> dict:
     gcs_blob_name = f"{gcs_folder}/{gcs_subdir}/{artifact_key}"
 
     try:
-        DIR = "report_creatives"
-        local_filepath = f"{DIR}/{artifact_key}"
+        # Per-invocation temp dir: concurrent runs share this process's CWD, so a
+        # bare relative scratch path let one run's cleanup race another's write
+        # (issue #104 — [Errno 2] under N=5). TemporaryDirectory is unique per call
+        # and auto-removed on context exit, even on a mid-function raise.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_filepath = os.path.join(tmpdir, artifact_key)
 
-        def _render_pdf() -> bytes:
-            """Blocking: build the PDF on disk and return its bytes."""
-            if not os.path.exists(DIR):
-                os.makedirs(DIR)
-            # create markdown PDF object
-            pdf = MarkdownPdf(toc_level=4)
-            pdf.add_section(Section(f" {processed_report}\n"))
-            pdf.meta["title"] = "[Draft] Trend & Campaign Research Report"
-            pdf.save(local_filepath)
-            # open pdf and read bytes for types.Part() object
-            with open(local_filepath, "rb") as f:
-                return f.read()
+            def _render_pdf() -> bytes:
+                """Blocking: build the PDF on disk and return its bytes."""
+                # create markdown PDF object
+                pdf = MarkdownPdf(toc_level=4)
+                pdf.add_section(Section(f" {processed_report}\n"))
+                pdf.meta["title"] = "[Draft] Trend & Campaign Research Report"
+                pdf.save(local_filepath)
+                # open pdf and read bytes for types.Part() object
+                with open(local_filepath, "rb") as f:
+                    return f.read()
 
-        # PDF render + read is multi-second blocking work — run off the event loop.
-        document_bytes = await asyncio.to_thread(_render_pdf)
+            # PDF render + read is multi-second blocking work — run off the event loop.
+            document_bytes = await asyncio.to_thread(_render_pdf)
 
-        document_part = types.Part(
-            inline_data=types.Blob(data=document_bytes, mime_type="application/pdf")
-        )
-        version = await tool_context.save_artifact(
-            filename=artifact_key, artifact=document_part
-        )
-        # save to gcs (blocking network I/O — off the loop)
-        await asyncio.to_thread(
-            _upload_blob_to_gcs,
-            source_file_name=local_filepath,
-            destination_blob_name=gcs_blob_name,
-        )
-        # save to session state (must stay on the loop)
-        gcs_uri = f"gs://{gcs_bucket}/{gcs_blob_name}"
-        tool_context.state["research_report_gcs_uri"] = gcs_uri
-        logging.info(
-            f"\n\nSaved artifact doc '{artifact_key}', version {version}, to: '{gcs_uri}' \n\n"
-        )
-        # clean up (blocking filesystem work — off the loop)
-        await asyncio.to_thread(shutil.rmtree, DIR)
-        logging.info(f"Directory '{DIR}' and its contents removed successfully")
+            document_part = types.Part(
+                inline_data=types.Blob(data=document_bytes, mime_type="application/pdf")
+            )
+            version = await tool_context.save_artifact(
+                filename=artifact_key, artifact=document_part
+            )
+            # save to gcs (blocking network I/O — off the loop)
+            await asyncio.to_thread(
+                _upload_blob_to_gcs,
+                source_file_name=local_filepath,
+                destination_blob_name=gcs_blob_name,
+            )
+            # save to session state (must stay on the loop)
+            gcs_uri = f"gs://{gcs_bucket}/{gcs_blob_name}"
+            tool_context.state["research_report_gcs_uri"] = gcs_uri
+            logging.info(
+                f"\n\nSaved artifact doc '{artifact_key}', version {version}, to: '{gcs_uri}' \n\n"
+            )
 
-        return {
-            "status": "success",
-            "gcs_uri": gcs_uri,
-        }
+            return {
+                "status": "success",
+                "gcs_uri": gcs_uri,
+            }
 
     except Exception as e:
         # Propagate so ADK 2.0 RetryConfig can retry transient infra failures.

--- a/creative_agent/gcs_tools.py
+++ b/creative_agent/gcs_tools.py
@@ -123,44 +123,47 @@ def _get_high_res_img(gcs_folder: str, gcs_subdir: str, artifact_key: str):
     storage_client = _get_gcs_client()
     bucket = storage_client.bucket(config.GCS_BUCKET_NAME)
     blob = bucket.blob(f"{gcs_folder}/{gcs_subdir}/{artifact_key}")
-    LOCAL_FILENAME = f"local_{artifact_key}"
-    XL_LOCAL_FILENAME = f"XL_{LOCAL_FILENAME}"
+    # Per-invocation temp dir: concurrent runs share this process's CWD, so bare
+    # scratch names collided (issue #104) when two runs resized a like-named
+    # concept — one run's cleanup raced the other's download/resize. A
+    # TemporaryDirectory is unique per call and auto-removed on context exit.
+    local_name = f"local_{artifact_key}"
+    xl_name = f"XL_{local_name}"
     img = None
 
-    try:
-        with open(LOCAL_FILENAME, "wb") as file_obj:
-            # Download the blob contents to the opened file object
-            blob.download_to_file(file_obj)
+    with tempfile.TemporaryDirectory() as td:
+        local_path = os.path.join(td, local_name)
+        xl_path = os.path.join(td, xl_name)
+        try:
+            with open(local_path, "wb") as file_obj:
+                # Download the blob contents to the opened file object
+                blob.download_to_file(file_obj)
 
-        # convert to higher res
-        img = Image.open(LOCAL_FILENAME)
-        current_w, current_h = img.size
-        new_w = int(current_w * 1.5)
-        new_h = int(current_h * 1.5)
-        resized_image = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
-        resized_image.save(XL_LOCAL_FILENAME)
+            # convert to higher res
+            img = Image.open(local_path)
+            current_w, current_h = img.size
+            new_w = int(current_w * 1.5)
+            new_h = int(current_h * 1.5)
+            resized_image = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+            resized_image.save(xl_path)
 
-        # upload to gcs
-        mTLS_GCS_PREFIX = "https://storage.mtls.cloud.google.com"
-        NEW_BLOB_NAME = f"{gcs_folder}/{gcs_subdir}/resized/{XL_LOCAL_FILENAME}"
-        new_blob = bucket.blob(NEW_BLOB_NAME)
-        new_blob.upload_from_filename(XL_LOCAL_FILENAME)
+            # upload to gcs — the object name is the file BASENAME, not the temp
+            # path, so the scratch dir never leaks into the GCS object key.
+            mTLS_GCS_PREFIX = "https://storage.mtls.cloud.google.com"
+            NEW_BLOB_NAME = f"{gcs_folder}/{gcs_subdir}/resized/{xl_name}"
+            new_blob = bucket.blob(NEW_BLOB_NAME)
+            new_blob.upload_from_filename(xl_path)
 
-        high_res_auth_gcs_uri = (
-            f"{mTLS_GCS_PREFIX}/{config.GCS_BUCKET_NAME}/{NEW_BLOB_NAME}?authuser=3"
-        )
-        return high_res_auth_gcs_uri
+            high_res_auth_gcs_uri = (
+                f"{mTLS_GCS_PREFIX}/{config.GCS_BUCKET_NAME}/{NEW_BLOB_NAME}?authuser=3"
+            )
+            return high_res_auth_gcs_uri
 
-    finally:
-        # Always release the PIL handle and remove both temp files, even on a
-        # mid-function raise (download/resize/upload), so we never leak them.
-        if img is not None:
-            img.close()
-        for tmp in (LOCAL_FILENAME, XL_LOCAL_FILENAME):
-            try:
-                os.remove(tmp)
-            except OSError:
-                pass
+        finally:
+            # Release the PIL handle even on a mid-function raise; the enclosing
+            # TemporaryDirectory removes both scratch files on context exit.
+            if img is not None:
+                img.close()
 
 
 async def save_draft_report_artifact(tool_context: ToolContext) -> dict:

--- a/creative_agent/tools.py
+++ b/creative_agent/tools.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import logging
+import tempfile
 import warnings
 
 from google.adk.tools import ToolContext
@@ -242,24 +243,26 @@ async def save_creative_gallery_html(tool_context: ToolContext) -> dict:
             + gt.HTML_END_JAVASCRIPT
         )
 
-        # Save the HTML to a new file (blocking file + network I/O — off the loop)
+        # Save the HTML to a temp file then upload (blocking file + network I/O —
+        # off the loop). A per-invocation temp dir keeps concurrent runs from racing
+        # on a shared CWD filename (issue #104): the bare 'creative_portfolio_...html'
+        # let one run's os.remove delete the file another run was still uploading.
+        # TemporaryDirectory is unique per call and auto-cleaned on context exit.
         REPORT_NAME = "creative_portfolio_gallery.html"
-
-        def _write_html() -> None:
-            with open(REPORT_NAME, "w", encoding="utf-8") as html_file:
-                html_file.write(FINAL_HTML)
-
-        await asyncio.to_thread(_write_html)
-
-        # save HTML file to cloud storage
         gcs_blob_name = f"{gcs_folder}/{gcs_subdir}/{REPORT_NAME}"
         gcs_uri = f"gs://{config.GCS_BUCKET_NAME}/{gcs_blob_name}"
-        await asyncio.to_thread(
-            _upload_blob_to_gcs,
-            source_file_name=REPORT_NAME,
-            destination_blob_name=gcs_blob_name,
-        )
-        await asyncio.to_thread(os.remove, REPORT_NAME)
+
+        def _write_and_upload() -> None:
+            with tempfile.TemporaryDirectory() as td:
+                path = os.path.join(td, REPORT_NAME)
+                with open(path, "w", encoding="utf-8") as html_file:
+                    html_file.write(FINAL_HTML)
+                _upload_blob_to_gcs(
+                    source_file_name=path,
+                    destination_blob_name=gcs_blob_name,
+                )
+
+        await asyncio.to_thread(_write_and_upload)
 
         return {
             "status": "success",

--- a/tests/test_export_concurrency.py
+++ b/tests/test_export_concurrency.py
@@ -94,3 +94,34 @@ def test_save_draft_report_artifact_isolates_concurrent_runs(monkeypatch, tmp_pa
     assert len(recorded) == 2
     assert recorded[0] != recorded[1]  # per-run isolation (distinct scratch paths)
     assert not os.path.exists("report_creatives")  # no bare CWD artifact leak
+
+
+def test_save_creative_gallery_html_isolates_concurrent_runs(monkeypatch, tmp_path):
+    """Two concurrent gallery exports must use DISTINCT scratch paths and leave no
+    bare ``creative_portfolio_gallery.html`` in the CWD."""
+    monkeypatch.chdir(tmp_path)
+
+    recorded: list[str] = []
+
+    def _fake_upload(source_file_name, destination_blob_name):
+        assert os.path.exists(source_file_name), source_file_name
+        recorded.append(source_file_name)
+        return "ok"
+
+    monkeypatch.setattr(tools, "_upload_blob_to_gcs", _fake_upload)
+
+    ctx_a = MockToolContext("run_a")
+    ctx_b = MockToolContext("run_b")
+
+    async def _both():
+        return await asyncio.gather(
+            tools.save_creative_gallery_html(ctx_a),
+            tools.save_creative_gallery_html(ctx_b),
+        )
+
+    results = asyncio.run(_both())
+
+    assert all(r["status"] == "success" for r in results)
+    assert len(recorded) == 2
+    assert recorded[0] != recorded[1]
+    assert not os.path.exists("creative_portfolio_gallery.html")

--- a/tests/test_export_concurrency.py
+++ b/tests/test_export_concurrency.py
@@ -12,6 +12,7 @@ These tests reproduce the race deterministically in-process (two invocations und
 
 import asyncio
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 from creative_agent import gcs_tools, tools
 
@@ -125,3 +126,90 @@ def test_save_creative_gallery_html_isolates_concurrent_runs(monkeypatch, tmp_pa
     assert len(recorded) == 2
     assert recorded[0] != recorded[1]
     assert not os.path.exists("creative_portfolio_gallery.html")
+
+
+class _FakeBlob:
+    def __init__(self, name, uploads):
+        self.name = name
+        self._uploads = uploads
+
+    def download_to_file(self, file_obj):
+        file_obj.write(b"origbytes")
+
+    def upload_from_filename(self, path):
+        assert os.path.exists(path), path
+        self._uploads.append((self.name, path))
+
+
+class _FakeBucket:
+    def __init__(self, uploads):
+        self._uploads = uploads
+
+    def blob(self, name):
+        return _FakeBlob(name, self._uploads)
+
+
+class _FakeStorageClient:
+    def __init__(self, uploads):
+        self._uploads = uploads
+
+    def bucket(self, name):
+        return _FakeBucket(self._uploads)
+
+
+class _FakeResized:
+    def save(self, path):
+        with open(path, "wb") as f:
+            f.write(b"resized")
+
+
+class _FakeImg:
+    size = (10, 10)
+
+    def resize(self, size, resample):
+        return _FakeResized()
+
+    def close(self):
+        pass
+
+
+class _FakeImage:
+    class Resampling:
+        LANCZOS = 1
+
+    @staticmethod
+    def open(path):
+        assert os.path.exists(path), path
+        return _FakeImg()
+
+
+def test_get_high_res_img_isolates_concurrent_runs(monkeypatch, tmp_path):
+    """Two concurrent resizes of the SAME artifact_key (as two runs producing a
+    like-named concept would) must not collide on a shared CWD scratch file, and
+    must leave no bare local_*/XL_* files behind. Also guards the gotcha: the GCS
+    object name must be the file basename, not the temp-dir path."""
+    monkeypatch.chdir(tmp_path)
+    uploads: list[tuple[str, str]] = []
+    monkeypatch.setattr(gcs_tools, "_get_gcs_client", lambda: _FakeStorageClient(uploads))
+    monkeypatch.setattr(gcs_tools, "Image", _FakeImage)
+
+    artifact_key = "concept.png"  # identical key => same bare filename on old code
+
+    def _call(folder):
+        return gcs_tools._get_high_res_img(
+            gcs_folder=folder, gcs_subdir="creative_output", artifact_key=artifact_key
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        uris = list(ex.map(_call, ["run_a", "run_b"]))
+
+    assert all(u for u in uris)  # both returned a URI
+    assert len(uploads) == 2
+    xl_paths = [p for _, p in uploads]
+    assert xl_paths[0] != xl_paths[1]  # per-run isolation
+    # no bare scratch files leaked into CWD
+    assert not os.path.exists("local_concept.png")
+    assert not os.path.exists("XL_local_concept.png")
+    # gotcha: blob name uses the basename, not the temp-dir path
+    for name, _ in uploads:
+        assert name.endswith("resized/XL_local_concept.png"), name

--- a/tests/test_export_concurrency.py
+++ b/tests/test_export_concurrency.py
@@ -1,0 +1,96 @@
+"""Concurrency regression tests for creative_agent's artifact-export tools.
+
+Root cause of issue #104's N=5 artifact failures: the export tools wrote scratch
+files to BARE RELATIVE PATHS in the one shared process CWD, then deleted them.
+Under ADK's in-process concurrency (many ``run_async`` tasks in one event loop),
+one run's cleanup (``shutil.rmtree`` / ``os.remove``) raced another run's write →
+``[Errno 2] No such file or directory``.
+
+These tests reproduce the race deterministically in-process (two invocations under
+``asyncio.gather``) and assert per-run isolation + zero bare-CWD leaks — no GCP.
+"""
+
+import asyncio
+import os
+
+from creative_agent import gcs_tools, tools
+
+
+class MockState(dict):
+    pass
+
+
+class MockToolContext:
+    """Mirror of the double in tests/test_tools_retry.py, with the extra state
+    keys the export tools read. ``gcs_folder`` is parameterized so two contexts
+    represent two distinct concurrent runs."""
+
+    def __init__(self, gcs_folder: str):
+        self.state = MockState()
+        self.state["gcs_folder"] = gcs_folder
+        self.state["agent_output_dir"] = "creative_output"
+        self.state["final_report_with_citations"] = f"# Report {gcs_folder}"
+        self.state["final_visual_concepts"] = {"visual_concepts": []}
+        self.state["ad_copy_critique"] = {"ad_copies": []}
+        self.state["brand"] = "b"
+        self.state["target_audience"] = "a"
+        self.state["target_product"] = "p"
+        self.state["key_selling_points"] = "k"
+        self.state["target_search_trends"] = {"target_search_trends": ["t1"]}
+
+    async def save_artifact(self, *a, **k):
+        return None
+
+
+class _FakeSection:
+    def __init__(self, *a, **k):
+        pass
+
+
+class _FakeMarkdownPdf:
+    """Stand-in for markdown_pdf.MarkdownPdf: .save writes a trivial file so the
+    tool's subsequent open()/read() works without invoking the real renderer."""
+
+    def __init__(self, *a, **k):
+        self.meta: dict = {}
+
+    def add_section(self, *a, **k):
+        return None
+
+    def save(self, path):
+        with open(path, "wb") as f:
+            f.write(b"%PDF-1.4 fake")
+
+
+def test_save_draft_report_artifact_isolates_concurrent_runs(monkeypatch, tmp_path):
+    """Two concurrent draft-report exports must use DISTINCT scratch paths and
+    leave no bare ``report_creatives`` directory in the CWD."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gcs_tools, "MarkdownPdf", _FakeMarkdownPdf)
+    monkeypatch.setattr(gcs_tools, "Section", _FakeSection)
+
+    recorded: list[str] = []
+
+    def _fake_upload(source_file_name, destination_blob_name):
+        # The scratch file must still exist on disk at upload time.
+        assert os.path.exists(source_file_name), source_file_name
+        recorded.append(source_file_name)
+        return "ok"
+
+    monkeypatch.setattr(gcs_tools, "_upload_blob_to_gcs", _fake_upload)
+
+    ctx_a = MockToolContext("run_a")
+    ctx_b = MockToolContext("run_b")
+
+    async def _both():
+        return await asyncio.gather(
+            gcs_tools.save_draft_report_artifact(ctx_a),
+            gcs_tools.save_draft_report_artifact(ctx_b),
+        )
+
+    results = asyncio.run(_both())
+
+    assert all(r["status"] == "success" for r in results)
+    assert len(recorded) == 2
+    assert recorded[0] != recorded[1]  # per-run isolation (distinct scratch paths)
+    assert not os.path.exists("report_creatives")  # no bare CWD artifact leak


### PR DESCRIPTION
## What

Fixes 3 of the 6 N=5 concurrency failures in `creative_agent` (issue #104): the artifact-export tools wrote scratch files to **bare relative paths in the one shared process CWD**, then deleted them. Under ADK's in-process concurrency (many `run_async` tasks in one event loop), one run's cleanup (`shutil.rmtree` / `os.remove`) raced another run's write → `[Errno 2] No such file or directory`.

Three tools converted to a per-invocation `tempfile.TemporaryDirectory` (unique per call, auto-removed on context exit — even on a mid-function raise):

- `save_draft_report_artifact` (`gcs_tools.py`) — was `report_creatives/` + `shutil.rmtree`
- `save_creative_gallery_html` (`tools.py`) — was bare `creative_portfolio_gallery.html` + `os.remove`
- `_get_high_res_img` (`gcs_tools.py`) — was bare `local_*`/`XL_*`; latent same bug (two runs resizing a like-named concept collide). The GCS object name now uses the file **basename**, so the temp path never leaks into the object key.

## Why

The quota-bucket-spread DoE (48 runs, 2026-07-17) measured 6/40 N=5 runs failing vs 0/8 at N=1 — see issue #104. This PR removes the artifact-export class (3/6). Retry coverage for the JSON-validation crash + 503 (the other 3) follows in a separate PR.

## Tests

New `tests/test_export_concurrency.py` reproduces each race deterministically in-process (two invocations via `asyncio.gather`/threads) and asserts per-run isolation + zero bare-CWD leaks. Each test failed with the exact production error before the fix.

Full suite: **394 passed**, ruff clean.
