### PR TITLE
fix(creative_agent): retry structured-output producers on ValidationError + 503 (#104)

### DIFF
--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -10,7 +10,7 @@ from google.adk.agents import Agent, SequentialAgent, ParallelAgent
 from .sub_agents.campaign_researcher.agent import ca_sequential_planner
 from .sub_agents.trend_researcher.agent import gs_sequential_planner
 from agent_common import build_gemini, RetryUntilKeyAgent, RunIfAgent
-from .config import config, INFRA_RETRY
+from .config import config, INFRA_RETRY, SCHEMA_RETRY
 from . import callbacks
 from . import tools
 from . import prompts
@@ -70,6 +70,7 @@ combined_web_evaluator = Agent(
     description="Critically evaluates research about the campaign guide and generates follow-up queries.",
     instruction=prompts.COMBINED_WEB_EVALUATOR_INSTR,
     output_schema=ResearchFeedback,
+    retry_config=SCHEMA_RETRY,
     disallow_transfer_to_parent=True,
     disallow_transfer_to_peers=True,
     output_key="combined_research_evaluation",
@@ -229,6 +230,7 @@ ad_copy_drafter = Agent(
         },
     ),
     output_schema=AdCopyList,
+    retry_config=SCHEMA_RETRY,
     output_key="ad_copy_draft",
     after_model_callback=[
         callbacks.scrub_surrogates_in_response,
@@ -259,6 +261,7 @@ ad_copy_critic = Agent(
         },
     ),
     output_schema=FinalAdCopyList,
+    retry_config=SCHEMA_RETRY,
     output_key="ad_copy_critique",
     after_model_callback=[
         callbacks.scrub_surrogates_in_response,
@@ -324,6 +327,7 @@ visual_concept_drafter = Agent(
         },
     ),
     output_schema=VisualConceptList,
+    retry_config=SCHEMA_RETRY,
     output_key="visual_draft",
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
@@ -350,6 +354,7 @@ visual_concept_critic = Agent(
         },
     ),
     output_schema=VisualConceptCritiqueList,
+    retry_config=SCHEMA_RETRY,
     output_key="visual_concept_critique",
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
@@ -371,6 +376,7 @@ visual_concept_finalizer = Agent(
         },
     ),
     output_schema=VisualConceptFinalList,
+    retry_config=SCHEMA_RETRY,
     output_key="final_visual_concepts",
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )

--- a/creative_agent/config.py
+++ b/creative_agent/config.py
@@ -3,6 +3,7 @@ import warnings
 from dataclasses import dataclass
 
 from google.genai import errors as genai_errors
+from pydantic import ValidationError
 
 from agent_common.config import BaseAgentConfiguration
 from agent_common.retry import build_infra_retry
@@ -12,6 +13,17 @@ warnings.filterwarnings("ignore")
 # creative_agent calls genai directly (image gen), so it also retries the genai
 # 5xx ServerError on top of the shared transient set.
 INFRA_RETRY = build_infra_retry(extra_exceptions=[genai_errors.ServerError])
+
+# Structured-output producers additionally retry a Pydantic ValidationError: at
+# high temperature the model can emit invalid JSON (e.g. raw ESC control chars)
+# that fails output_schema parsing, which crashed the run unretried under N=5
+# concurrency (issue #104). ADK's RetryConfig matches on the exact exception class
+# name, and pydantic raises `ValidationError`, so a bad sample is simply re-drawn.
+# The infra set is included too (defense-in-depth for a 503 that escapes the genai
+# HTTP-retry layer).
+SCHEMA_RETRY = build_infra_retry(
+    extra_exceptions=[genai_errors.ServerError, ValidationError]
+)
 
 # Arm C (DoE `global_altbucket`) model. Task 0a probe (2026-07-17) confirmed this
 # is the one DISTINCT global gemini-3.x flash base model that both calls AND

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -249,3 +249,14 @@ class TestBuildInfraRetry:
         names = set(rc.exceptions)
         assert "ServerError" in names
         assert "ServiceUnavailable" in names  # base still present
+
+    def test_schema_retry_covers_validation_and_infra(self):
+        """Structured-output producers additionally retry a bad-JSON
+        ValidationError (issue #104) on top of the infra set (defense-in-depth for
+        a 503 that escapes the genai HTTP-retry layer)."""
+        from creative_agent.config import SCHEMA_RETRY
+
+        names = set(SCHEMA_RETRY.exceptions)
+        assert "ValidationError" in names  # the invalid-JSON crash
+        assert "ServiceUnavailable" in names  # infra set included (503)
+        assert "ServerError" in names  # genai 5xx included

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -149,6 +149,32 @@ def test_visual_generation_pipeline_sub_agent_order():
     ]
 
 
+def test_structured_output_producers_carry_schema_retry():
+    """Structured-output producers retry on ValidationError + infra (issue #104):
+    a bad-JSON model turn (e.g. visual_concept_finalizer at high temp emitting raw
+    control chars) crashed the run unretried. Identity check keeps them on one
+    shared config."""
+    from creative_agent.config import SCHEMA_RETRY
+    from creative_agent.agent import (
+        combined_web_evaluator,
+        ad_copy_drafter,
+        ad_copy_critic,
+        visual_concept_drafter,
+        visual_concept_critic,
+        visual_concept_finalizer,
+    )
+
+    for producer in (
+        combined_web_evaluator,
+        ad_copy_drafter,
+        ad_copy_critic,
+        visual_concept_drafter,
+        visual_concept_critic,
+        visual_concept_finalizer,
+    ):
+        assert producer.retry_config is SCHEMA_RETRY, producer.name
+
+
 def test_visual_production_pipeline_wraps_generator_in_retry():
     """The image step must be retry-wrapped: visual_generator intermittently
     returns MALFORMED_FUNCTION_CALL and never emits generate_image, shipping an


### PR DESCRIPTION
## What

Fixes the remaining 3 of 6 N=5 concurrency failures in `creative_agent` (issue #104): the invalid-JSON crash + the unretried 503s.

- **New `SCHEMA_RETRY`** (`config.py`) = the `INFRA_RETRY` transient set + genai `ServerError` + Pydantic **`ValidationError`**.
- Applied to the six structured-output **producer** agents (`agent.py`): `combined_web_evaluator`, `ad_copy_drafter`, `ad_copy_critic`, `visual_concept_drafter`, `visual_concept_critic`, `visual_concept_finalizer`.

## Why

At `temperature=0.8` a producer occasionally emits invalid JSON (e.g. raw ESC control chars) that fails `output_schema` parsing → Pydantic `ValidationError`. `visual_concept_finalizer` (and the other producers) had **no `retry_config`**, so the run died. ADK's `RetryConfig` matches on the **exact exception class name** and pydantic raises `ValidationError`, so adding it means a bad sample is simply re-drawn — a pure model call, so the retry is idempotent. `RetryUntilKeyAgent` can't help here: it only re-runs on an unpopulated `output_key` and does not catch exceptions.

The same config folds in the infra set, giving 503 **defense-in-depth** on producers that previously carried no `retry_config` (a 503 that escapes the genai HTTP-retry layer now retries at the node level).

`interactive_creative` imports these same agent objects, so it inherits the fix.

## Tests

- `test_config.py::test_schema_retry_covers_validation_and_infra` — `SCHEMA_RETRY` includes `ValidationError` + infra + `ServerError`.
- `test_pipeline_structure.py::test_structured_output_producers_carry_schema_retry` — all six producers reference the shared `SCHEMA_RETRY`.

Full suite: **393 passed**, ruff clean.

## Relation to #106

Independent of #106 (disjoint files: this touches `config.py`/`agent.py`; #106 touches `gcs_tools.py`/`tools.py`). Together they close issue #104.
