### PR TITLE
fix(trend_scout): tempfile-isolate GCS export scratch files (issue #104 class)

### DIFF
--- a/tests/test_trend_scout_concurrency.py
+++ b/tests/test_trend_scout_concurrency.py
@@ -1,0 +1,165 @@
+"""Concurrency regression tests for trend_scout's GCS-export tools.
+
+Same root cause as issue #104 (fixed in creative_agent, see
+``tests/test_export_concurrency.py``): ``write_to_file`` and
+``save_session_state_to_gcs`` wrote scratch files to a FIXED relative directory
+(``trawler_output`` — ``state["agent_output_dir"]``) with FIXED filenames, then
+``shutil.rmtree``'d it. Under ADK's in-process concurrency (many ``run_async``
+tasks in one event loop, one shared CWD), one run's ``rmtree`` raced another
+run's write → wrong-data upload or ``FileNotFoundError``.
+
+These tests reproduce the race deterministically in-process (two invocations via
+``ThreadPoolExecutor``) and assert per-run isolation + zero bare-CWD leaks — no GCP.
+"""
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from trend_scout import tools
+
+
+class MockState(dict):
+    def to_dict(self):
+        return dict(self)
+
+
+class MockToolContext:
+    """A distinct concurrent run per ``gcs_folder``."""
+
+    def __init__(self, gcs_folder: str):
+        self.state = MockState()
+        self.state["gcs_folder"] = gcs_folder
+        self.state["agent_output_dir"] = "trawler_output"
+
+
+class _FakeBlob:
+    def __init__(self, name, uploads):
+        self.name = name
+        self._uploads = uploads
+
+    def upload_from_filename(self, path):
+        # The scratch file must still exist on disk at upload time (a racing
+        # rmtree would have deleted it under the old code).
+        assert os.path.exists(path), path
+        self._uploads.append((self.name, path))
+
+
+class _FakeBucket:
+    def __init__(self, uploads):
+        self._uploads = uploads
+
+    def blob(self, name):
+        return _FakeBlob(name, self._uploads)
+
+
+class _FakeStorageClient:
+    def __init__(self, uploads):
+        self._uploads = uploads
+
+    def bucket(self, name):
+        return _FakeBucket(self._uploads)
+
+
+def test_write_to_file_isolates_concurrent_runs(monkeypatch, tmp_path):
+    """Two concurrent ``write_to_file`` calls must use DISTINCT scratch paths,
+    produce per-run-distinct GCS object names, and leave no bare
+    ``trawler_output`` directory in the CWD."""
+    monkeypatch.chdir(tmp_path)
+    uploads: list[tuple[str, str]] = []
+    monkeypatch.setattr(tools, "_get_gcs_client", lambda: _FakeStorageClient(uploads))
+
+    def _call(folder):
+        return tools.write_to_file(f"# trends for {folder}", MockToolContext(folder))
+
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        results = list(ex.map(_call, ["run_a", "run_b"]))
+
+    assert all(r["status"] == "success" for r in results)
+    assert len(uploads) == 2
+    scratch_paths = [p for _, p in uploads]
+    assert scratch_paths[0] != scratch_paths[1]  # per-run isolation
+    object_names = [n for n, _ in uploads]
+    assert sorted(object_names) == ["run_a/selected_trends.txt", "run_b/selected_trends.txt"]
+    assert not os.path.exists("trawler_output")  # no bare CWD artifact leak
+
+
+def test_save_session_state_isolates_concurrent_runs(monkeypatch, tmp_path):
+    """Two concurrent ``save_session_state_to_gcs`` calls must isolate scratch
+    files and leave no bare ``trawler_output`` directory in the CWD."""
+    monkeypatch.chdir(tmp_path)
+    uploads: list[tuple[str, str]] = []
+    monkeypatch.setattr(tools, "_get_gcs_client", lambda: _FakeStorageClient(uploads))
+
+    def _call(folder):
+        return tools.save_session_state_to_gcs(MockToolContext(folder))
+
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        results = list(ex.map(_call, ["run_a", "run_b"]))
+
+    assert all(r["status"] == "success" for r in results)
+    assert len(uploads) == 2
+    scratch_paths = [p for _, p in uploads]
+    assert scratch_paths[0] != scratch_paths[1]  # per-run isolation
+    object_names = [n for n, _ in uploads]
+    assert sorted(object_names) == [
+        "run_a/trawler_session_state.json",
+        "run_b/trawler_session_state.json",
+    ]
+    assert not os.path.exists("trawler_output")
+
+
+def test_write_to_file_uploads_correct_content(monkeypatch, tmp_path):
+    """Guard against the race's *silent* failure mode: the uploaded scratch file
+    must contain THIS run's content (not another run's), so the object key uses
+    the file basename and the temp dir never leaks into it."""
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, str] = {}
+
+    class _CapBlob(_FakeBlob):
+        def upload_from_filename(self, path):
+            assert os.path.exists(path), path
+            with open(path) as f:
+                captured[self.name] = f.read()
+
+    class _CapBucket(_FakeBucket):
+        def blob(self, name):
+            return _CapBlob(name, self._uploads)
+
+    class _CapClient(_FakeStorageClient):
+        def bucket(self, name):
+            return _CapBucket(self._uploads)
+
+    monkeypatch.setattr(tools, "_get_gcs_client", lambda: _CapClient([]))
+
+    tools.write_to_file("# unique content", MockToolContext("solo"))
+    assert captured["solo/selected_trends.txt"] == "# unique content"
+
+
+def test_save_session_state_uploads_valid_json(monkeypatch, tmp_path):
+    """The session-state export must upload parseable JSON of this run's state."""
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, str] = {}
+
+    class _CapBlob(_FakeBlob):
+        def upload_from_filename(self, path):
+            assert os.path.exists(path), path
+            with open(path) as f:
+                captured[self.name] = f.read()
+
+    class _CapBucket(_FakeBucket):
+        def blob(self, name):
+            return _CapBlob(name, self._uploads)
+
+    class _CapClient(_FakeStorageClient):
+        def bucket(self, name):
+            return _CapBucket(self._uploads)
+
+    monkeypatch.setattr(tools, "_get_gcs_client", lambda: _CapClient([]))
+
+    ctx = MockToolContext("solo")
+    ctx.state["some_key"] = "some_value"
+    tools.save_session_state_to_gcs(ctx)
+
+    parsed = json.loads(captured["solo/trawler_session_state.json"])
+    assert parsed["some_key"] == "some_value"

--- a/trend_scout/tools.py
+++ b/trend_scout/tools.py
@@ -3,7 +3,7 @@ import logging
 import datetime
 import warnings
 import json
-import shutil
+import tempfile
 import uuid
 from pathlib import Path
 from google.cloud import storage
@@ -167,38 +167,28 @@ def write_to_file(content: str, tool_context: ToolContext) -> dict:
         dict: A dictionary containing the status and the markdown file's Cloud Storage URI (gcs_uri).
     """
 
-    LOCAL_DIR = tool_context.state["agent_output_dir"]
     gcs_folder = tool_context.state["gcs_folder"]
-
-    # Construct the output filename e.g., "trawler_output/selected_trends.md"
     artifact_key = "selected_trends.txt"
-    local_file = f"{LOCAL_DIR}/{artifact_key}"
 
-    # Ensure the "trawler_output" directory exists. If it doesn’t, create it.
-    # `exist_ok=True` prevents an error if the directory already exists.
-    Path(LOCAL_DIR).mkdir(exist_ok=True)
-
-    # Write the markdown content to the constructed file.
-    # `encoding='utf-8'` ensures proper character encoding.
-    Path(local_file).write_text(content)
-
-    # save to GCS
     storage_client = _get_gcs_client()
     gcs_bucket = config.GCS_BUCKET_NAME
     bucket = storage_client.bucket(gcs_bucket)
-    blob = bucket.blob(os.path.join(gcs_folder, local_file))
-    blob.upload_from_filename(local_file)
 
-    # save to session state
-    gcs_blob_name = f"{gcs_folder}/{LOCAL_DIR}/{artifact_key}"
+    # Per-invocation temp dir: concurrent runs share this process's CWD, so a
+    # fixed scratch dir (state["agent_output_dir"] == "trawler_output") + fixed
+    # filename collided (issue #104) — one run's rmtree raced another's write.
+    # A TemporaryDirectory is unique per call and auto-removed on context exit.
+    # The GCS object key uses the file BASENAME so the temp path never leaks in.
+    with tempfile.TemporaryDirectory() as td:
+        local_file = os.path.join(td, artifact_key)
+        Path(local_file).write_text(content)
+
+        gcs_blob_name = f"{gcs_folder}/{artifact_key}"
+        blob = bucket.blob(gcs_blob_name)
+        blob.upload_from_filename(local_file)
+
     gcs_uri = f"gs://{gcs_bucket}/{gcs_blob_name}"
     tool_context.state["select_trends_markdown_gcs_uri"] = gcs_uri
-
-    try:
-        shutil.rmtree(LOCAL_DIR)
-        logging.info(f"Directory '{LOCAL_DIR}' and its contents removed successfully")
-    except FileNotFoundError:
-        logging.exception(f"Directory '{LOCAL_DIR}' not found")
 
     # Return a dictionary indicating success, and the artifact_key that was written.
     return {
@@ -243,36 +233,25 @@ def save_session_state_to_gcs(tool_context: ToolContext) -> dict:
     """
 
     session_state = tool_context.state.to_dict()
-    LOCAL_DIR = session_state["agent_output_dir"]
     gcs_folder = session_state["gcs_folder"]
-
     filename = "trawler_session_state.json"
-    local_file = f"{LOCAL_DIR}/{filename}"
 
-    # Ensure the `LOCAL_DIR` directory exists. If it doesn’t, create it.
-    # `exist_ok=True` prevents an error if the directory already exists.
-    Path(LOCAL_DIR).mkdir(exist_ok=True)
-
-    # Write to local file
-    with open(local_file, "w") as f:
-        json.dump(session_state, f, indent=4)
-
-    # save to GCS
     storage_client = _get_gcs_client()
     gcs_bucket = config.GCS_BUCKET_NAME
     bucket = storage_client.bucket(gcs_bucket)
-    blob = bucket.blob(os.path.join(gcs_folder, local_file))
-    blob.upload_from_filename(local_file)
 
-    # save to session state
-    gcs_blob_name = f"{gcs_folder}/{LOCAL_DIR}/{filename}"
+    # Per-invocation temp dir (see write_to_file): isolates concurrent runs that
+    # share this process's CWD; the GCS object key uses the file BASENAME.
+    with tempfile.TemporaryDirectory() as td:
+        local_file = os.path.join(td, filename)
+        with open(local_file, "w") as f:
+            json.dump(session_state, f, indent=4)
+
+        gcs_blob_name = f"{gcs_folder}/{filename}"
+        blob = bucket.blob(gcs_blob_name)
+        blob.upload_from_filename(local_file)
+
     gcs_uri = f"gs://{gcs_bucket}/{gcs_blob_name}"
-
-    try:
-        shutil.rmtree(LOCAL_DIR)
-        logging.info(f"Directory '{LOCAL_DIR}' and its contents removed successfully")
-    except FileNotFoundError:
-        logging.exception(f"Directory '{LOCAL_DIR}' not found")
 
     # Return a dictionary indicating status and the Cloud Storage URI.
     return {


### PR DESCRIPTION
## What

`trend_scout`'s `write_to_file` and `save_session_state_to_gcs` carried the exact same shared-CWD race that #104 fixed in `creative_agent` — the fix had only landed on the creative side.

Both tools wrote scratch files to a **fixed** relative directory (`trawler_output`, from `state["agent_output_dir"]`) with **fixed** filenames (`selected_trends.txt`, `trawler_session_state.json`), then `shutil.rmtree`'d it. Under ADK's in-process concurrency (many `run_async` tasks in one event loop sharing one CWD), one run's cleanup races another run's write → wrong-data upload or `FileNotFoundError`.

## Fix

Mirror the shipped #104 pattern (`creative_agent/gcs_tools.py::_get_high_res_img`): a per-invocation `tempfile.TemporaryDirectory()` (unique per call, auto-removed on context exit), with the GCS object key using the file **basename** so the temp path never leaks into the object name.

Side effect: the GCS object key drops the redundant `trawler_output/` segment (`{gcs_folder}/{name}` instead of `{gcs_folder}/trawler_output/{name}`). Nothing downstream hardcodes that segment (grep-verified).

## Tests

New `tests/test_trend_scout_concurrency.py` (modeled on `tests/test_export_concurrency.py`): drives two concurrent invocations via `ThreadPoolExecutor`, asserts distinct scratch paths, per-run-distinct GCS object names, correct per-run content, and zero bare-CWD (`trawler_output`) leak. Full suite green (400 passed); ruff clean.