### PR TITLE
fix(bq): raise on BigQuery insert job errors instead of reporting success

### DIFF
--- a/creative_agent/bq_tools.py
+++ b/creative_agent/bq_tools.py
@@ -136,6 +136,7 @@ def write_trends_to_bq(tool_context: ToolContext) -> dict:
             logging.error(
                 f"DML INSERT job for trend: '{target_trend}' failed: {job.errors}"
             )
+            raise RuntimeError(f"BigQuery insert returned errors: {job.errors}")
         else:
             logging.info(
                 f"DML INSERT job {job.job_id} for trend: '{target_trend}' completed; added {job.num_dml_affected_rows} rows."

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,6 +2,8 @@
 
 import string
 
+import pytest
+
 
 # --- Artifact name sanitization ---
 REMOVE_PUNCTUATION = str.maketrans("", "", string.punctuation)
@@ -413,3 +415,72 @@ class TestWriteTrendsUuidStash:
         assert "tswift engaged" not in captured["sql"]
         param_names = {p.name for p in captured["job_config"].query_parameters}
         assert "target_trend" in param_names
+
+
+class TestWriteTrendsRaisesOnBqErrors:
+    """A BigQuery insert that reports job-level errors must NOT be reported as
+    success (silent data loss). Both write_trends_to_bq implementations must
+    raise, matching write_eval_report_to_bq's contract, so ADK RetryConfig can
+    retry and a genuine failure surfaces instead of masquerading as success."""
+
+    class _FailingJob:
+        errors = [{"reason": "invalid", "message": "boom"}]
+        job_id = "j-fail"
+        num_dml_affected_rows = 0
+
+        def result(self):
+            return None
+
+    def test_creative_agent_write_trends_raises(self, monkeypatch):
+        import creative_agent.bq_tools as t
+
+        outer = self
+
+        class _BQ:
+            def query(self, sql, job_config=None):
+                return outer._FailingJob()
+
+        monkeypatch.setattr(t, "_get_bigquery_client", lambda: _BQ())
+
+        ctx = MockToolContext()
+        ctx.state.update(
+            {
+                "gcs_folder": "2026_07_13_run",
+                "agent_output_dir": "creative_output",
+                "target_search_trends": "tswift engaged",
+                "brand": "PRS",
+                "target_audience": "musicians",
+                "target_product": "SE CE24",
+                "key_selling_points": "wide tonal range",
+            }
+        )
+        with pytest.raises(RuntimeError, match="BigQuery insert returned errors"):
+            t.write_trends_to_bq(ctx)
+
+    def test_trend_scout_write_trends_raises(self, monkeypatch):
+        import trend_scout.tools as t
+
+        outer = self
+
+        class _BQ:
+            def query(self, sql, job_config=None):
+                return outer._FailingJob()
+
+        monkeypatch.setattr(t, "_get_bigquery_client", lambda: _BQ())
+        # avoid the live max-date lookup used to build the insert SQL
+        monkeypatch.setattr(t, "_get_gtrends_max_date", lambda: "2026-07-17")
+
+        ctx = MockToolContext()
+        ctx.state.update(
+            {
+                "gcs_folder": "2026_07_13_run",
+                "agent_output_dir": "trawler_output",
+                "target_search_trends": {"target_search_trends": ["tswift engaged"]},
+                "brand": "PRS",
+                "target_audience": "musicians",
+                "target_product": "SE CE24",
+                "key_selling_points": "wide tonal range",
+            }
+        )
+        with pytest.raises(RuntimeError, match="BigQuery insert returned errors"):
+            t.write_trends_to_bq(ctx)

--- a/trend_scout/tools.py
+++ b/trend_scout/tools.py
@@ -417,6 +417,7 @@ def write_trends_to_bq(tool_context: ToolContext) -> dict:
                 logging.error(
                     f"DML INSERT job for trend: '{trend}' failed: {job.errors}"
                 )
+                raise RuntimeError(f"BigQuery insert returned errors: {job.errors}")
             else:
                 logging.info(
                     f"DML INSERT job {job.job_id} for trend: `{trend}` completed; added {job.num_dml_affected_rows} rows."


### PR DESCRIPTION
## What

`write_trends_to_bq` — in **both** `creative_agent/bq_tools.py` and `trend_scout/tools.py` — logged `job.errors` and then fell through to `return {"status": "success", ...}`. A BigQuery insert that reports job-level errors was therefore reported to the agent as a **success**: silent data loss, and no chance for ADK's `RetryConfig` to retry a transient failure.

This is inconsistent with `write_eval_report_to_bq` (same file), which correctly logs and then `raise`s.

## Fix

In the `if job.errors:` branch of both functions, after logging, `raise RuntimeError(f"BigQuery insert returned errors: {job.errors}")`. It falls into the existing outer `except Exception: ... raise`, so the contract matches `write_eval_report_to_bq` and transient infra errors become retryable.

## Tests

New `TestWriteTrendsRaisesOnBqErrors` in `tests/test_tools.py` (extends the existing `TestWriteTrendsUuidStash` double pattern): a `_FailingJob` with `errors=[...]` for each module; asserts the call now **raises** (previously it wrongly returned `success`). Full suite green (398 passed); ruff clean.

Note: disjoint-file with the trend_scout export-concurrency PR (#108) — different functions in `trend_scout/tools.py`.