### PR TITLE
fix(runserver): guard terminal-marker append + bound detached runs with a timeout

### DIFF
--- a/runserver/async_runs.py
+++ b/runserver/async_runs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 
 from fastapi import APIRouter, Query
 from google.adk.events import Event, EventActions
@@ -13,6 +14,18 @@ from pydantic import BaseModel
 RUNSERVER_AUTHOR = "__runserver__"
 RUN_STATUS_KEY = "__run_status"
 RUN_ERROR_KEY = "__run_error"
+
+# Hard ceiling on a single detached run (seconds). A wedged model call would
+# otherwise keep the asyncio task — and, with --no-cpu-throttling --min-instances
+# 1, the Cloud Run instance — alive indefinitely with no server-side stall
+# detection, leaving the run polling 'running' forever. Default 1800s is well
+# beyond a normal ~6-8 min run; override via the RUN_MAX_SECONDS env var.
+RUN_MAX_SECONDS = int(os.environ.get("RUN_MAX_SECONDS", "1800"))
+
+# Bounded attempts for writing the terminal status marker (see
+# _append_terminal_safe). The marker IS the poller contract, so its own write is
+# retried a little against a transient session service, then dropped (never raised).
+_MARKER_APPEND_ATTEMPTS = 2
 
 
 def get_root_agent(app_name: str):
@@ -160,36 +173,100 @@ async def get_run_status(
 _BACKGROUND_TASKS: set = set()
 
 
+async def _append_terminal_safe(
+    session_service, app_name, user_id, session_id, event
+) -> None:
+    """Append a terminal status marker, absorbing any failure.
+
+    The terminal marker IS the completion/failure contract pollers read, so a
+    marker write that itself fails must NOT escape the detached task — that would
+    leave the exception unretrieved and the run polling ``running`` forever,
+    violating ``_drive_run``'s never-re-raise guarantee. ``get_session`` +
+    ``append_event`` are retried a bounded number of times against the
+    (documented-transient) ``VertexAiSessionService``, then logged loudly and
+    dropped. A missing session is unrecoverable → log and give up."""
+    for attempt in range(1, _MARKER_APPEND_ATTEMPTS + 1):
+        try:
+            session = await session_service.get_session(
+                app_name=app_name, user_id=user_id, session_id=session_id
+            )
+            if session is None:
+                logging.error(
+                    "cannot append terminal marker: session missing app=%s session=%s",
+                    app_name,
+                    session_id,
+                )
+                return
+            await session_service.append_event(session, event)
+            return
+        except Exception:  # noqa: BLE001 — bounded retry; final failure logged, never raised
+            logging.exception(
+                "terminal marker append failed (attempt %d/%d) app=%s session=%s",
+                attempt,
+                _MARKER_APPEND_ATTEMPTS,
+                app_name,
+                session_id,
+            )
+    logging.error(
+        "gave up writing terminal marker after %d attempts app=%s session=%s",
+        _MARKER_APPEND_ATTEMPTS,
+        app_name,
+        session_id,
+    )
+
+
 async def _drive_run(
     runner, session_service, app_name, user_id, session_id, new_message
 ) -> None:
     """Drive a Runner to completion detached from any request, then append a
     terminal status marker to the session. Never re-raises — the terminal
-    ``error`` marker IS the failure contract for pollers."""
+    ``error`` marker IS the failure contract for pollers (even when the marker
+    write itself fails; see ``_append_terminal_safe``). Bounded by
+    ``RUN_MAX_SECONDS`` so a wedged run can't hang ``running`` forever."""
     # Reuse the run's own invocation id on the terminal marker (Vertex requires a
     # non-empty invocation_id); fall back to the marker author if the run emitted
     # no events (e.g. an immediate error).
     invocation_id = RUNSERVER_AUTHOR
     try:
-        async for event in runner.run_async(
-            user_id=user_id, session_id=session_id, new_message=new_message
-        ):
-            # Runner persists final events to the session service itself.
-            if getattr(event, "invocation_id", None):
-                invocation_id = event.invocation_id
-        session = await session_service.get_session(
-            app_name=app_name, user_id=user_id, session_id=session_id
+        async with asyncio.timeout(RUN_MAX_SECONDS):
+            async for event in runner.run_async(
+                user_id=user_id, session_id=session_id, new_message=new_message
+            ):
+                # Runner persists final events to the session service itself.
+                if getattr(event, "invocation_id", None):
+                    invocation_id = event.invocation_id
+        await _append_terminal_safe(
+            session_service,
+            app_name,
+            user_id,
+            session_id,
+            build_terminal_event("done", invocation_id=invocation_id),
         )
-        await session_service.append_event(
-            session, build_terminal_event("done", invocation_id=invocation_id)
+    except TimeoutError:
+        logging.error(
+            "detached run timed out after %ss app=%s session=%s",
+            RUN_MAX_SECONDS,
+            app_name,
+            session_id,
+        )
+        await _append_terminal_safe(
+            session_service,
+            app_name,
+            user_id,
+            session_id,
+            build_terminal_event(
+                "error",
+                f"run exceeded {RUN_MAX_SECONDS}s timeout",
+                invocation_id=invocation_id,
+            ),
         )
     except Exception as exc:  # noqa: BLE001 — terminal marker is the contract; log+persist, never raise
         logging.exception("detached run failed app=%s session=%s", app_name, session_id)
-        session = await session_service.get_session(
-            app_name=app_name, user_id=user_id, session_id=session_id
-        )
-        await session_service.append_event(
-            session,
+        await _append_terminal_safe(
+            session_service,
+            app_name,
+            user_id,
+            session_id,
             build_terminal_event("error", str(exc), invocation_id=invocation_id),
         )
 

--- a/tests/test_async_runs.py
+++ b/tests/test_async_runs.py
@@ -15,9 +15,11 @@ from google.adk.events import Event, EventActions
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
+from runserver import async_runs
 from runserver.async_runs import (
     RUN_ERROR_KEY,
     RUN_STATUS_KEY,
+    RUNSERVER_AUTHOR,
     build_resume_message,
     build_terminal_event,
     build_user_message,
@@ -266,6 +268,95 @@ def test_kickoff_uses_existing_session():
     session = asyncio.run(_go())
     # Pre-existing state survives — the run appended events, didn't recreate/wipe.
     assert session.state.get("brand") == "X"
+
+
+class _TerminalMarkerFailingService:
+    """Wraps InMemorySessionService but raises when appending a terminal
+    (runserver) marker — exercising _drive_run's guarantee that a failing marker
+    write never escapes the detached task (which would leave the run hung
+    ``running`` forever). Normal agent events pass through to the real service."""
+
+    def __init__(self):
+        self._inner = InMemorySessionService()
+
+    async def create_session(self, **kwargs):
+        return await self._inner.create_session(**kwargs)
+
+    async def get_session(self, **kwargs):
+        return await self._inner.get_session(**kwargs)
+
+    async def append_event(self, session, event):
+        if event.author == RUNSERVER_AUTHOR:
+            raise RuntimeError("marker append boom")
+        return await self._inner.append_event(session, event)
+
+
+def test_kickoff_does_not_raise_when_terminal_marker_append_fails():
+    """If the terminal-marker append itself fails (transient session service),
+    the detached task must still complete cleanly — never re-raise — so the run
+    doesn't hang ``running`` forever with an unretrieved task exception."""
+
+    async def _go():
+        svc = _TerminalMarkerFailingService()
+        fake = _FakeRunner(svc, "creative_agent", "u", "s", [_agent_event("one")])
+        _result, task = await start_run(
+            app_name="creative_agent",
+            user_id="u",
+            session_id="s",
+            message="hi",
+            session_service=svc,
+            runner_factory=lambda app_name: fake,
+        )
+        await task  # must NOT raise even though every marker write fails
+        return await svc.get_session(
+            app_name="creative_agent", user_id="u", session_id="s"
+        )
+
+    session = asyncio.run(_go())
+    # The run's own event survives; the marker never landed (its write failed).
+    texts = [e.content.parts[0].text for e in session.events if e.content]
+    assert texts == ["one"]
+    assert not any(
+        (getattr(getattr(e, "actions", None), "state_delta", None) or {}).get(
+            RUN_STATUS_KEY
+        )
+        for e in session.events
+    )
+
+
+class _SlowRunner:
+    """Runner double whose run_async blocks past the injected deadline, to trip
+    _drive_run's asyncio.timeout guard."""
+
+    async def run_async(self, *, user_id, session_id, new_message, **kwargs):
+        await asyncio.sleep(10)
+        yield _agent_event("never")  # unreachable — cancelled by the timeout
+
+
+def test_kickoff_times_out_and_writes_error_marker(monkeypatch):
+    """A wedged run must be bounded by RUN_MAX_SECONDS and resolve to a terminal
+    ``error`` marker (timeout), not hang ``running`` forever."""
+    monkeypatch.setattr(async_runs, "RUN_MAX_SECONDS", 0.05)
+
+    async def _go():
+        svc = InMemorySessionService()
+        _result, task = await start_run(
+            app_name="creative_agent",
+            user_id="u",
+            session_id="s",
+            message="hi",
+            session_service=svc,
+            runner_factory=lambda app_name: _SlowRunner(),
+        )
+        await task  # must not raise
+        return await svc.get_session(
+            app_name="creative_agent", user_id="u", session_id="s"
+        )
+
+    session = asyncio.run(_go())
+    delta = session.events[-1].actions.state_delta
+    assert delta[RUN_STATUS_KEY] == "error"
+    assert "timeout" in delta[RUN_ERROR_KEY].lower()
 
 
 # --- Task 3: poll (status + events-since + state) -----------------------------


### PR DESCRIPTION
## What

Two ways a detached async run could get stuck `running` forever:

1. **Unguarded terminal-marker write.** `_drive_run` appended its terminal `done`/`error` marker via a bare `get_session` + `append_event` in **both** branches. The terminal marker is the completion/failure contract pollers read — but if the (documented-transient) `VertexAiSessionService` raised *there*, the marker was never written, the exception escaped the detached task (the done-callback only `discard`s it), and the run polled `running` forever. That directly violates `_drive_run`'s own "never re-raise" docstring.

2. **No bound on `run_async`.** A wedged model call kept the asyncio task — and, under `--no-cpu-throttling --min-instances 1`, the Cloud Run instance — alive indefinitely with no server-side stall detection.

## Fix

- Extract **`_append_terminal_safe(...)`**: wraps `get_session` + `append_event` in a bounded retry (`_MARKER_APPEND_ATTEMPTS = 2`), logs loudly on final failure, treats a missing session as unrecoverable, and **never re-raises**. Both `_drive_run` branches call it, so the contract holds even when the marker write itself fails.
- Wrap the `run_async` loop in **`async with asyncio.timeout(RUN_MAX_SECONDS)`** (new env knob `RUN_MAX_SECONDS`, default `1800`s — well beyond a normal ~6-8 min run). On `TimeoutError`, write a terminal timeout/`error` marker via `_append_terminal_safe`.

## Tests

Two new tests in `tests/test_async_runs.py` (mirroring its `InMemorySessionService` + `_FakeRunner` + `asyncio.run` conventions), both confirmed RED against the original impl:
- `test_kickoff_does_not_raise_when_terminal_marker_append_fails` — a session-service double that raises on marker appends; `await task` completes cleanly, no marker lands, no unretrieved exception.
- `test_kickoff_times_out_and_writes_error_marker` — a runner that blocks past an injected `RUN_MAX_SECONDS=0.05`; asserts a terminal timeout `error` marker.

Full suite green (398 passed); ruff clean. Backend-only change.