### PR TITLE
fix(crf): recover orphaned QUEUED rows + surface publish failures

### DIFF
--- a/cloud_functions/creative_fanout/main.py
+++ b/cloud_functions/creative_fanout/main.py
@@ -409,11 +409,18 @@ def crf_entrypoint(cloud_event: CloudEvent) -> None:
     # The triggering message should pass the necessary config,
     # OR the orchestrator uses a hardcoded worker topic name.
 
-    # 1. Fetch ALL unprocessed rows (processed_status is NULL)
-    # optionally fetch FAILED rows
+    # 1. Fetch unprocessed rows: brand-new (processed_status IS NULL) AND rows
+    # orphaned in QUEUED by a prior run that set them QUEUED then crashed or only
+    # partially published (a failed publish leaves the row QUEUED). Re-dispatch is
+    # safe: a row a worker already grabbed is PROCESSING/PROCESSED (not selected
+    # here), and a genuinely-stuck QUEUED row is re-sent — the worker's atomic
+    # QUEUED->PROCESSING lock (acquire_processing_lock) dedups any double delivery.
+    # KNOWN FOLLOW-UP (out of scope): a worker that hard-crashes AFTER acquiring
+    # the lock strands its row in PROCESSING forever; recovering that needs a
+    # `processing_started_at` column migration + a reaper for stale PROCESSING rows.
     rows_to_process_query = f"""
         SELECT * FROM `{bq_client.project}.{dataset}.{table}`
-        WHERE processed_status IS NULL
+        WHERE processed_status IS NULL OR processed_status = 'QUEUED'
         ORDER BY entry_timestamp ASC
     """
     try:
@@ -462,8 +469,12 @@ def crf_entrypoint(cloud_event: CloudEvent) -> None:
         # but the next successful run will see these rows are now QUEUED,
         # preventing duplication (assuming the next step succeeds).
 
-        # 5. Dispatch Step: Publish one message per row to the worker topic
-        dispatched_count = 0
+        # 5. Dispatch Step: Publish one message per row to the worker topic, then
+        # confirm each publish resolved. A publish that fails silently would leave
+        # its row QUEUED forever under the old IS-NULL-only re-query; now such a row
+        # is recovered by the broadened re-query on the next orchestrator run, so we
+        # only need to surface the failure (don't crash the whole batch over one).
+        publish_futures = []
         for row_dict in row_list:
             # Create a dedicated payload for the worker
             worker_payload = {
@@ -475,13 +486,23 @@ def crf_entrypoint(cloud_event: CloudEvent) -> None:
 
             data_str = json.dumps(worker_payload)
             data_bytes = data_str.encode("utf-8")
+            publish_futures.append(pubsub_publisher.publish(_WORKER_TOPIC_NAME, data_bytes))
 
-            # Publish the message
-            # Note: We don't await the publish result here, fire-and-forget is usually fine,
-            # but you might want to handle publishing errors.
-            pubsub_publisher.publish(_WORKER_TOPIC_NAME, data_bytes)
-            dispatched_count += 1
+        dispatched_count = 0
+        failed_count = 0
+        for future in publish_futures:
+            try:
+                future.result()
+                dispatched_count += 1
+            except Exception as e:  # noqa: BLE001 — one bad publish shouldn't sink the batch
+                failed_count += 1
+                logging.error(f"Failed to publish a worker message: {e}")
 
+        if failed_count:
+            logging.warning(
+                f"{failed_count}/{len(row_list)} worker publishes failed; those rows "
+                "remain QUEUED and will be recovered on the next orchestrator run."
+            )
         logging.info(
             f"Successfully dispatched {dispatched_count} tasks to the worker queue."
         )

--- a/tests/test_crf_entrypoint.py
+++ b/tests/test_crf_entrypoint.py
@@ -9,6 +9,7 @@ the fix for #46: a malformed or empty trigger message must not raise
 
 import base64
 import json
+import logging
 import types
 from unittest.mock import MagicMock
 
@@ -101,3 +102,80 @@ def test_valid_payload_with_rows_dispatches_one_message_per_row(mocked_clients):
     payload = {"bq_dataset": "ds", "bq_table": "tbl", "agent_resource_id": "123"}
     main.crf_entrypoint(_pubsub_event(payload))
     assert publisher.publish.call_count == 2
+
+
+def _two_row_df():
+    return pd.DataFrame(
+        [
+            {
+                "entry_timestamp": pd.Timestamp("2026-07-12T00:00:00Z"),
+                "target_trend": "trend A",
+                "brand": "BrandX",
+                "target_audience": "aud",
+                "target_product": "prod",
+                "key_selling_point": "ksp",
+            },
+            {
+                "entry_timestamp": pd.Timestamp("2026-07-12T01:00:00Z"),
+                "target_trend": "trend B",
+                "brand": "BrandX",
+                "target_audience": "aud",
+                "target_product": "prod",
+                "key_selling_point": "ksp",
+            },
+        ]
+    )
+
+
+def test_requery_recovers_stuck_queued_rows(mocked_clients):
+    """The unprocessed-rows SELECT must recover rows orphaned in QUEUED (a prior
+    run set them QUEUED then crashed / partially published), not only IS NULL —
+    otherwise those rows are never re-selected and never dispatched again."""
+    bq, publisher = mocked_clients
+    bq.query.return_value.to_dataframe.return_value = pd.DataFrame()
+    payload = {"bq_dataset": "ds", "bq_table": "tbl", "agent_resource_id": "123"}
+    main.crf_entrypoint(_pubsub_event(payload))
+    # empty df → only the SELECT runs (no update/dispatch); it is the first query.
+    select_sql = bq.query.call_args_list[0][0][0]
+    assert "QUEUED" in select_sql
+    assert "IS NULL" in select_sql  # still picks up brand-new rows too
+
+
+def test_publish_failure_is_counted_and_does_not_crash(mocked_clients, caplog):
+    """A worker-message publish that fails must not crash the batch. The failure
+    is logged/counted; the row stays QUEUED and is recovered on the next run."""
+    bq, publisher = mocked_clients
+    bq.query.return_value.to_dataframe.return_value = _two_row_df()
+
+    ok_future = MagicMock()
+    bad_future = MagicMock()
+    bad_future.result.side_effect = RuntimeError("publish boom")
+    publisher.publish.side_effect = [ok_future, bad_future]
+
+    payload = {"bq_dataset": "ds", "bq_table": "tbl", "agent_resource_id": "123"}
+    with caplog.at_level(logging.WARNING):
+        main.crf_entrypoint(_pubsub_event(payload))  # must NOT raise
+
+    assert publisher.publish.call_count == 2  # both rows attempted
+    assert "publishes failed" in caplog.text  # failure surfaced, not swallowed
+
+
+def test_acquire_processing_lock_true_when_one_row_updated():
+    """Real-function coverage for the exactly-once worker lock: 1 affected row
+    → True, and the UPDATE gates on the row still being QUEUED."""
+    bq = MagicMock()
+    bq.project = "test-project"
+    bq.query.return_value.result.return_value.num_dml_affected_rows = 1
+    got = main.acquire_processing_lock(bq, "ds", "tbl", "2026-07-12T00:00:00")
+    assert got is True
+    lock_sql = bq.query.call_args[0][0]
+    assert "AND processed_status = 'QUEUED'" in lock_sql
+
+
+def test_acquire_processing_lock_false_when_zero_rows_updated():
+    """0 affected rows (another worker won the race) → False."""
+    bq = MagicMock()
+    bq.project = "test-project"
+    bq.query.return_value.result.return_value.num_dml_affected_rows = 0
+    got = main.acquire_processing_lock(bq, "ds", "tbl", "2026-07-12T00:00:00")
+    assert got is False


### PR DESCRIPTION
## What

The fan-out orchestrator (`crf_entrypoint`) could **permanently orphan** batch rows:

1. It flips rows to `QUEUED` (`update_rows_status`), then **fire-and-forget** publishes one worker message per row — the publish futures' `.result()` was never checked.
2. The unprocessed-rows re-query was `WHERE processed_status IS NULL`.

So a crash or a partial/failed publish *between* the QUEUED update and dispatch left rows stranded in `QUEUED` that the next run **never re-selected and never dispatched again** — silent data loss, invisibly.

## Fix (minimal, no schema migration)

- **Broaden the re-query** to `WHERE processed_status IS NULL OR processed_status = 'QUEUED'`, so orphaned `QUEUED` rows are recovered on the next orchestrator run. Re-dispatch is safe: a row a worker already grabbed is `PROCESSING`/`PROCESSED` (not re-selected), and a genuinely-stuck `QUEUED` row is re-sent — the worker's atomic `QUEUED→PROCESSING` lock (`acquire_processing_lock`) dedups any double delivery.
- **Keep QUEUED-before-publish ordering.** (Publishing *before* the QUEUED write — as a naive "publish then mark" would — would let a worker receive a message while the row is still `NULL`, fail the lock, ACK, and lose the row. So recovery + observability are fixed instead of reordering.)
- **Check each publish future** and log/count failures instead of dropping them. A failed publish leaves the row `QUEUED` → recovered next run.
- **Document the known follow-up** (out of scope per decision): a worker that hard-crashes *after* acquiring the lock strands its row in `PROCESSING` forever; recovering that needs a `processing_started_at` column migration + a reaper for stale `PROCESSING` rows.

## Tests

Extends `tests/test_crf_entrypoint.py` (drives the **real** `main.py` with fake CloudEvents + mocked BQ/Pub-Sub):
- `test_requery_recovers_stuck_queued_rows` — the SELECT SQL now includes `QUEUED` (and still `IS NULL`).
- `test_publish_failure_is_counted_and_does_not_crash` — a failing publish future is surfaced (logged) and doesn't sink the batch.
- Real-function coverage for `acquire_processing_lock` (1 row → `True`, 0 → `False`, SQL gates on `AND processed_status = 'QUEUED'`) — previously only an inline reimplementation in `test_crf_logic.py` covered this.

Full suite green (400 passed); ruff clean. Requires redeploying the two CRF cloud functions (from `cloud_functions/creative_fanout/`) when merged + deployed.