### PR TITLE
fix(crf): reap PROCESSING rows stranded by a hard-crashed worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ bq --location=US mk --dataset $BQ_PROJECT_ID:$BQ_DATASET_ID
 bq mk \
  -t \
  $BQ_PROJECT_ID:$BQ_DATASET_ID.$BQ_TABLE_TARGETS \
- uuid:STRING,processed_status:STRING,target_trend:STRING,refresh_date:DATE,trawler_date:DATE,entry_timestamp:TIMESTAMP,trawler_gcs:STRING,brand:STRING,target_audience:STRING,target_product:STRING,key_selling_point:STRING
+ uuid:STRING,processed_status:STRING,target_trend:STRING,refresh_date:DATE,trawler_date:DATE,entry_timestamp:TIMESTAMP,trawler_gcs:STRING,brand:STRING,target_audience:STRING,target_product:STRING,key_selling_point:STRING,processing_started_at:TIMESTAMP,processing_attempts:INTEGER
 
 # target-trend creatives
 bq mk \

--- a/cloud_functions/creative_fanout/config.py
+++ b/cloud_functions/creative_fanout/config.py
@@ -1,5 +1,7 @@
 # config.py
 
+import os
+
 
 class AppConfig:
     # gcp project
@@ -9,6 +11,14 @@ class AppConfig:
     GCP_REGION = "us-central1"
     GOOGLE_CLOUD_PROJECT_NUMBER = 934903580331
     CREATIVE_WORKER_TOPIC_NAME = "creative-worker-queue-topic"
+    # Reaper: a PROCESSING row older than this (worker presumed hard-crashed) is
+    # reclaimed. Must exceed the worker's 1800s/30min Cloud Run timeout + margin.
+    REAP_STALE_PROCESSING_MINUTES = int(
+        os.environ.get("REAP_STALE_PROCESSING_MINUTES", "45")
+    )
+    # After this many lock acquisitions, a reaped row goes FAILED instead of
+    # QUEUED (poison-pill guard).
+    MAX_PROCESSING_ATTEMPTS = int(os.environ.get("MAX_PROCESSING_ATTEMPTS", "3"))
 
 
 config = AppConfig()

--- a/cloud_functions/creative_fanout/main.py
+++ b/cloud_functions/creative_fanout/main.py
@@ -305,18 +305,31 @@ async def _execute_agent_and_update_status(
         raise
 
 
+def _build_lock_sql(project, dataset, table, timestamp):
+    """Atomic QUEUED->PROCESSING lock UPDATE for a single row.
+
+    Also stamps `processing_started_at` (so a worker that hard-crashes while
+    holding the lock can be aged out by the reaper) and increments
+    `processing_attempts` (bounded-retry / poison-pill guard). Gating on
+    `processed_status = 'QUEUED'` preserves the exactly-once lock semantics.
+    """
+    return f"""
+        UPDATE `{project}.{dataset}.{table}`
+        SET processed_status = 'PROCESSING',
+            processing_started_at = CURRENT_TIMESTAMP(),
+            processing_attempts = COALESCE(processing_attempts, 0) + 1
+        WHERE
+            entry_timestamp = TIMESTAMP('{timestamp}')
+            AND processed_status = 'QUEUED'
+    """
+
+
 def acquire_processing_lock(bq_client, dataset, table, timestamp):
     """
     Atomically changes status from 'QUEUED' to 'PROCESSING' for a single row.
     Returns True if the lock was acquired (1 row updated), False otherwise.
     """
-    lock_query = f"""
-        UPDATE `{bq_client.project}.{dataset}.{table}`
-        SET processed_status = 'PROCESSING'
-        WHERE 
-            entry_timestamp = TIMESTAMP('{timestamp}')
-            AND processed_status = 'QUEUED'
-    """
+    lock_query = _build_lock_sql(bq_client.project, dataset, table, timestamp)
 
     # Execute the update
     try:
@@ -343,6 +356,58 @@ def acquire_processing_lock(bq_client, dataset, table, timestamp):
         logging.error(f"Failed to acquire lock for row {timestamp}: {e}")
         # Re-raise to ensure the Pub/Sub message retries in case of system error
         raise
+
+
+def _build_reap_sql(project, dataset, table, stale_minutes, max_attempts):
+    """Reclaim rows stranded in PROCESSING by a hard-crashed worker.
+
+    A row still legitimately running holds PROCESSING for at most the worker's
+    Cloud Run timeout, so only rows older than `stale_minutes` are reaped. Rows
+    already attempted `max_attempts` times go FAILED (poison-pill guard); the
+    rest go back to QUEUED to be re-dispatched.
+
+    NULL `processing_started_at` is excluded by the `<` comparison (SQL NULL
+    semantics) — pre-migration stranded rows are handled by the one-time cleanup
+    in the deploy runbook, not by this recurring reaper.
+    """
+    return f"""
+        UPDATE `{project}.{dataset}.{table}`
+        SET processed_status = CASE
+                WHEN COALESCE(processing_attempts, 0) >= {max_attempts} THEN 'FAILED'
+                ELSE 'QUEUED'
+            END
+        WHERE processed_status = 'PROCESSING'
+            AND processing_started_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {stale_minutes} MINUTE)
+    """
+
+
+def reap_stale_processing_rows(bq_client, dataset, table):
+    """Reclaim rows stranded in PROCESSING by a hard-crashed worker.
+
+    Re-queues stale rows under the attempt cap (re-dispatched by the re-query
+    that follows) and fails them over it. Returns the number of rows reclaimed.
+    Best-effort: a failure here is logged and swallowed so it never crashes the
+    orchestrator's normal dispatch.
+    """
+    sql = _build_reap_sql(
+        bq_client.project,
+        dataset,
+        table,
+        config.REAP_STALE_PROCESSING_MINUTES,
+        config.MAX_PROCESSING_ATTEMPTS,
+    )
+    try:
+        n = bq_client.query(sql).result().num_dml_affected_rows or 0
+        if n:
+            logging.warning(
+                f"Reaped {n} stale PROCESSING row(s) "
+                f"(>{config.REAP_STALE_PROCESSING_MINUTES}min): re-queued under "
+                f"{config.MAX_PROCESSING_ATTEMPTS} attempts, else FAILED."
+            )
+        return n
+    except Exception as e:
+        logging.error(f"Reaper failed (continuing without reaping): {e}")
+        return 0
 
 
 # ==================================================
@@ -409,15 +474,19 @@ def crf_entrypoint(cloud_event: CloudEvent) -> None:
     # The triggering message should pass the necessary config,
     # OR the orchestrator uses a hardcoded worker topic name.
 
+    # 0. Reap stale PROCESSING rows: a worker that hard-crashes AFTER acquiring
+    # the lock strands its row in PROCESSING forever (a clean failure self-reports
+    # FAILED). Re-queue those older than the staleness bound under the attempt cap
+    # so the re-query below re-dispatches them (or fail them over the cap).
+    reap_stale_processing_rows(bq_client, dataset, table)
+
     # 1. Fetch unprocessed rows: brand-new (processed_status IS NULL) AND rows
     # orphaned in QUEUED by a prior run that set them QUEUED then crashed or only
-    # partially published (a failed publish leaves the row QUEUED). Re-dispatch is
-    # safe: a row a worker already grabbed is PROCESSING/PROCESSED (not selected
-    # here), and a genuinely-stuck QUEUED row is re-sent — the worker's atomic
-    # QUEUED->PROCESSING lock (acquire_processing_lock) dedups any double delivery.
-    # KNOWN FOLLOW-UP (out of scope): a worker that hard-crashes AFTER acquiring
-    # the lock strands its row in PROCESSING forever; recovering that needs a
-    # `processing_started_at` column migration + a reaper for stale PROCESSING rows.
+    # partially published (a failed publish leaves the row QUEUED), plus rows the
+    # reap step above just re-queued. Re-dispatch is safe: a row a worker already
+    # grabbed is PROCESSING/PROCESSED (not selected here), and a genuinely-stuck
+    # QUEUED row is re-sent — the worker's atomic QUEUED->PROCESSING lock
+    # (acquire_processing_lock) dedups any double delivery.
     rows_to_process_query = f"""
         SELECT * FROM `{bq_client.project}.{dataset}.{table}`
         WHERE processed_status IS NULL OR processed_status = 'QUEUED'

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -189,6 +189,40 @@ gcloud pubsub topics create $CREATIVE_WORKER_TOPIC_NAME
 * see [gcloud reference doc](https://cloud.google.com/sdk/gcloud/reference/run/deploy)
 
 
+**3.0 Schema migration — `processing_started_at` + `processing_attempts`** (stale-PROCESSING reaper)
+
+The orchestrator reaps rows a worker stranded in `PROCESSING` by hard-crashing
+after acquiring its lock (OOM / the 1800s Cloud Run timeout kill / segfault).
+The worker's lock stamps `processing_started_at` + bumps `processing_attempts`;
+the orchestrator re-queues rows older than `REAP_STALE_PROCESSING_MINUTES`
+(default 45, > the worker's 30-min timeout) under `MAX_PROCESSING_ATTEMPTS`
+(default 3), failing them over the cap. Both are env-configurable.
+
+Run the additive migration **FIRST, before deploying the code that writes these
+columns** — a DML naming a missing column fails (same ordering rule as the
+`research_gaps` migration in `docs/plans/2026-07-15-trend-scout-degradation-surfacing.md`):
+
+```sql
+-- 1. Additive migration (idempotent; preserves all rows):
+ALTER TABLE `<BQ_PROJECT_ID>.<BQ_DATASET_ID>.target_trends_crf`
+  ADD COLUMN IF NOT EXISTS processing_started_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS processing_attempts INT64;
+
+-- 2. One-time cleanup of any PRE-EXISTING stranded rows. Their
+--    processing_started_at is NULL, so the recurring reaper (which compares
+--    `< TIMESTAMP_SUB(...)`) will never catch them. Run ONLY when no run is in
+--    flight (serialized single worker + no live users makes this trivial):
+UPDATE `<BQ_PROJECT_ID>.<BQ_DATASET_ID>.target_trends_crf`
+  SET processed_status = 'QUEUED'
+  WHERE processed_status = 'PROCESSING' AND processing_started_at IS NULL;
+```
+
+**Redeploy order (the reaper spans both functions):** migration → **worker**
+`$CREATIVE_WORKER_CRF_NAME` (3.3 — ships the timestamp/attempt-stamping lock) →
+**orchestrator** `$CREATIVE_CRF_NAME` (3.1 — ships the reap call). CRF functions
+auto-route to LATEST and the Eventarc triggers bind by service name, so triggers
+survive a redeploy and are **not** re-created.
+
 **3.1 Creative Agent Orchestrator:** cloud run function
 
 ```bash

--- a/tests/test_crf_entrypoint.py
+++ b/tests/test_crf_entrypoint.py
@@ -135,10 +135,25 @@ def test_requery_recovers_stuck_queued_rows(mocked_clients):
     bq.query.return_value.to_dataframe.return_value = pd.DataFrame()
     payload = {"bq_dataset": "ds", "bq_table": "tbl", "agent_resource_id": "123"}
     main.crf_entrypoint(_pubsub_event(payload))
-    # empty df → only the SELECT runs (no update/dispatch); it is the first query.
-    select_sql = bq.query.call_args_list[0][0][0]
+    # empty df → the reap UPDATE runs first, then the SELECT (no dispatch); the
+    # SELECT is the second query.
+    select_sql = bq.query.call_args_list[1][0][0]
+    assert "SELECT" in select_sql
     assert "QUEUED" in select_sql
     assert "IS NULL" in select_sql  # still picks up brand-new rows too
+
+
+def test_crf_entrypoint_reaps_before_requery(mocked_clients):
+    """The orchestrator must reap stale PROCESSING rows BEFORE the unprocessed
+    re-query, so any reaped (re-queued) rows are picked up and re-dispatched in
+    the same invocation."""
+    bq, publisher = mocked_clients
+    bq.query.return_value.to_dataframe.return_value = pd.DataFrame()  # nothing to dispatch
+    payload = {"bq_dataset": "ds", "bq_table": "tbl", "agent_resource_id": "123"}
+    main.crf_entrypoint(_pubsub_event(payload))
+    first_sql = bq.query.call_args_list[0].args[0]
+    assert "processed_status = 'PROCESSING'" in first_sql  # the reap UPDATE ran first
+    assert "TIMESTAMP_SUB" in first_sql
 
 
 def test_publish_failure_is_counted_and_does_not_crash(mocked_clients, caplog):
@@ -179,3 +194,39 @@ def test_acquire_processing_lock_false_when_zero_rows_updated():
     bq.query.return_value.result.return_value.num_dml_affected_rows = 0
     got = main.acquire_processing_lock(bq, "ds", "tbl", "2026-07-12T00:00:00")
     assert got is False
+
+
+def test_lock_sql_stamps_started_at_and_increments_attempts():
+    """The lock UPDATE must record when PROCESSING began (so a hard-crashed
+    worker's row can be aged out) and bump an attempt counter (poison-pill
+    guard) — while preserving the exactly-once QUEUED->PROCESSING semantics."""
+    sql = main._build_lock_sql("p", "d", "t", "2026-07-18T00:00:00+00:00")
+    assert "processing_started_at = CURRENT_TIMESTAMP()" in sql
+    assert "processing_attempts = COALESCE(processing_attempts, 0) + 1" in sql
+    assert "SET processed_status = 'PROCESSING'" in sql
+    assert "AND processed_status = 'QUEUED'" in sql  # lock semantics preserved
+
+
+def test_reap_sql_requeues_under_cap_and_fails_over_cap():
+    """The reaper UPDATE must target only stale PROCESSING rows, re-queue those
+    under the attempt cap and fail those at/over it."""
+    sql = main._build_reap_sql("p", "d", "t", stale_minutes=45, max_attempts=3)
+    assert "processed_status = 'PROCESSING'" in sql  # only targets PROCESSING
+    assert "TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 45 MINUTE)" in sql
+    assert "COALESCE(processing_attempts, 0) >= 3 THEN 'FAILED'" in sql
+    assert "ELSE 'QUEUED'" in sql
+
+
+def test_reap_returns_reclaimed_count(mocked_clients):
+    """reap_stale_processing_rows returns the number of rows reclaimed."""
+    bq, _ = mocked_clients
+    bq.query.return_value.result.return_value.num_dml_affected_rows = 2
+    n = main.reap_stale_processing_rows(bq, "d", "t")
+    assert n == 2
+
+
+def test_reap_is_non_fatal_on_bq_error(mocked_clients):
+    """A BQ error while reaping must not crash the orchestrator: returns 0."""
+    bq, _ = mocked_clients
+    bq.query.side_effect = RuntimeError("bq boom")
+    assert main.reap_stale_processing_rows(bq, "d", "t") == 0


### PR DESCRIPTION
## Problem

PR #111 recovers rows orphaned in `QUEUED`, but left a documented follow-up: a worker that **hard-crashes** (OOM, the 1800s Cloud Run timeout kill, segfault) *after* acquiring its atomic `QUEUED->PROCESSING` lock and *before* writing `PROCESSED`/`FAILED` strands its row in `PROCESSING` forever. The orchestrator's unprocessed re-query deliberately excludes `PROCESSING`, so nothing ever re-selects it. (Clean worker failures already self-report `FAILED` and are **not** affected.)

## Fix

Reclaim policy = **re-queue with bounded retries** (poison-pill guard):

- **`acquire_processing_lock`** now stamps `processing_started_at = CURRENT_TIMESTAMP()` and bumps `processing_attempts = COALESCE(..., 0) + 1`, extracted into a pure `_build_lock_sql` helper. The `WHERE ... AND processed_status = 'QUEUED'` gate — and thus the exactly-once lock semantics — is unchanged.
- **`reap_stale_processing_rows`** (pure `_build_reap_sql`) re-queues `PROCESSING` rows older than `REAP_STALE_PROCESSING_MINUTES` (default **45** min, comfortably above the worker's 30-min Cloud Run timeout) under `MAX_PROCESSING_ATTEMPTS` (default **3**), and fails them over the cap. Both env-configurable. Best-effort — a BQ error while reaping is logged and swallowed so it never crashes the orchestrator.
- **`crf_entrypoint`** reaps **before** the unprocessed re-query, so re-queued rows are re-dispatched in the same invocation through the existing #111 recovery path — no new infra/trigger.
- NULL `processing_started_at` is excluded by the `<` comparison (SQL NULL semantics); pre-migration stranded rows are handled by a documented one-time cleanup `UPDATE`.

## Migration (deploy-gated, documented in `deployment/README.md`)

Additive `ALTER TABLE ... ADD COLUMN IF NOT EXISTS processing_started_at TIMESTAMP, processing_attempts INT64` — run **FIRST**, then redeploy in order **worker → orchestrator** (the reaper spans both functions, unlike #111 which was orchestrator-only). CRF functions auto-route to LATEST; Eventarc triggers bind by service name and survive the redeploy.

## Tests

5 new tests in `tests/test_crf_entrypoint.py` (lock stamping, reap SQL cap/threshold, reclaimed-count return, non-fatal on BQ error, reap-before-requery ordering). Full suite **413 green**, ruff clean.