### PR TITLE
feat(frontend): surface optional visual art direction in run + results views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ Next.js 16 (App Router) + TypeScript + Tailwind CSS + shadcn/ui. Light theme wit
 - `/run/[sessionId]` — Live run view: the page **polls** the async-job run (fire-and-forget kick-off + `GET /runs/.../{session}?since=N`) and renders new events into a timeline, pipeline state widgets (modal overlays), and a campaign metadata sidebar. Because progress is read from the persistent session log (not a browser-held SSE stream), a run **survives disconnect/reload/IAP re-auth** — reloading re-polls from `since=0` and replays. Interactive mode adds pause/resume review panels at each checkpoint.
 - `/results/[sessionId]` — Artifacts gallery, research PDF viewer, evaluation report, session state inspector
 
+Both the run view and results view also surface the optional visual art-direction inputs (the PR #114 visual-intent keys) read-only in a "Visual Direction" section alongside the campaign metadata — driven by `buildDisplayFields` + `VISUAL_DIRECTION_FIELDS` in `frontend/src/lib/utils.ts`; unset keys collapse to `""` so non-creative/no-intent runs show nothing.
+
 **Key files:**
 - `frontend/src/app/layout.tsx` — Root layout, fonts (Sora + JetBrains Mono), glass header
 - `frontend/src/app/page.tsx` — Campaign input form

--- a/frontend/src/__tests__/display-fields.test.ts
+++ b/frontend/src/__tests__/display-fields.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildDisplayFields,
+  VISUAL_DIRECTION_FIELDS,
+  type DisplayFieldDef,
+} from "@/lib/utils";
+
+describe("buildDisplayFields", () => {
+  it("drops entries whose resolved value is empty/unset", () => {
+    const defs: DisplayFieldDef[] = [
+      { label: "Brand", key: "brand" },
+      { label: "Product", key: "target_product" },
+      { label: "Audience", key: "target_audience" },
+    ];
+    const state = { brand: "PRS", target_product: "", target_audience: null };
+    const fields = buildDisplayFields(state, defs);
+    expect(fields).toEqual([{ label: "Brand", key: "brand", value: "PRS" }]);
+  });
+
+  it("falls back to altKey when the primary key is absent", () => {
+    const defs: DisplayFieldDef[] = [
+      { label: "Trend", key: "target_search_trends", altKey: "target_search_trend" },
+    ];
+    const state = { target_search_trend: "Powerball" };
+    const fields = buildDisplayFields(state, defs);
+    expect(fields).toEqual([
+      { label: "Trend", key: "target_search_trends", value: "Powerball" },
+    ]);
+  });
+
+  it("flattens array/object values via formatStateValue", () => {
+    const defs: DisplayFieldDef[] = [{ label: "Trend", key: "target_search_trends" }];
+    const state = { target_search_trends: ["a", "b"] };
+    const fields = buildDisplayFields(state, defs);
+    expect(fields).toEqual([
+      { label: "Trend", key: "target_search_trends", value: "a, b" },
+    ]);
+  });
+
+  it("returns [] when no field has a value", () => {
+    const defs: DisplayFieldDef[] = [{ label: "Brand", key: "brand" }];
+    expect(buildDisplayFields({}, defs)).toEqual([]);
+  });
+});
+
+describe("VISUAL_DIRECTION_FIELDS", () => {
+  it("maps the seven visual-intent keys", () => {
+    expect(VISUAL_DIRECTION_FIELDS.map((f) => f.key)).toEqual([
+      "visual_intent",
+      "brand_colors",
+      "visual_style_preference",
+      "visual_avoid",
+      "visual_aspect_ratio",
+      "reference_image_uri",
+      "reference_image_role",
+    ]);
+  });
+
+  it("returns only the set visual-direction fields, labelled", () => {
+    const state = {
+      visual_intent: "moody film noir",
+      brand_colors: "",
+      visual_style_preference: "",
+      visual_avoid: "",
+      visual_aspect_ratio: "1:1",
+      reference_image_uri: "",
+      reference_image_role: "",
+    };
+    const fields = buildDisplayFields(state, VISUAL_DIRECTION_FIELDS);
+    expect(fields).toEqual([
+      { label: "Art Direction", key: "visual_intent", value: "moody film noir" },
+      { label: "Aspect Ratio", key: "visual_aspect_ratio", value: "1:1" },
+    ]);
+  });
+});

--- a/frontend/src/app/results/[sessionId]/page.tsx
+++ b/frontend/src/app/results/[sessionId]/page.tsx
@@ -15,7 +15,11 @@ import { GcsWidget } from "@/components/gcs-widget";
 import { getSession, listArtifacts, getArtifact } from "@/lib/api";
 import { fetchEvalReport } from "@/lib/eval-report";
 import { gcsProxyUrl } from "@/lib/gcs";
-import { formatStateValue } from "@/lib/utils";
+import {
+  buildDisplayFields,
+  VISUAL_DIRECTION_FIELDS,
+  type DisplayFieldDef,
+} from "@/lib/utils";
 import type { Session } from "@/lib/types";
 
 interface ArtifactData {
@@ -102,6 +106,14 @@ interface AdCopy {
 function conceptNameToFilename(name: string): string {
   return name.replace(/[^\w\s]/g, "").replace(/ /g, "_") + ".png";
 }
+
+const CAMPAIGN_FIELD_DEFS: DisplayFieldDef[] = [
+  { label: "Brand", key: "brand" },
+  { label: "Audience", key: "target_audience" },
+  { label: "Product", key: "target_product" },
+  { label: "Selling Points", key: "key_selling_points" },
+  { label: "Trend", key: "target_search_trends" },
+];
 
 export default function ResultsPage({
   params,
@@ -291,15 +303,10 @@ export default function ResultsPage({
   );
 
   // Campaign metadata fields
-  const campaignFields = [
-    { label: "Brand", key: "brand" },
-    { label: "Audience", key: "target_audience" },
-    { label: "Product", key: "target_product" },
-    { label: "Selling Points", key: "key_selling_points" },
-    { label: "Trend", key: "target_search_trends" },
-  ]
-    .map((f) => ({ ...f, value: formatStateValue(state[f.key]) }))
-    .filter((f) => f.value);
+  const campaignFields = buildDisplayFields(state, CAMPAIGN_FIELD_DEFS);
+
+  // Optional user visual art-direction inputs (PR #114) — hidden when unset
+  const visualDirectionFields = buildDisplayFields(state, VISUAL_DIRECTION_FIELDS);
 
   // Does this run have the creative asset + eval view?
   const hasCreativeView = (appName === "creative_agent" || appName === "interactive_creative") && visualConcepts.length > 0;
@@ -351,6 +358,27 @@ export default function ResultsPage({
           {gcsUri && <GcsWidget uri={gcsUri} />}
         </div>
       </div>
+
+      {/* Visual Direction bar — optional user art direction (PR #114) */}
+      {visualDirectionFields.length > 0 && (
+        <div className="-mx-6 px-6 pb-3 mb-6 border-b border-border/50">
+          <p className="mb-2 text-center text-[10px] font-bold uppercase tracking-wider text-primary">
+            Visual Direction
+          </p>
+          <div className="grid gap-3 justify-center" style={{ gridTemplateColumns: `repeat(${visualDirectionFields.length}, minmax(0, 240px))` }}>
+            {visualDirectionFields.map((f) => (
+              <div key={f.key} className="glass rounded-xl px-4 py-2.5 text-center">
+                <dt className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                  {f.label}
+                </dt>
+                <dd className="mt-0.5 text-sm font-medium leading-snug break-words break-all text-foreground">
+                  {f.value}
+                </dd>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Eval still generating / failed — offer a manual refresh (race: the report
           is the last artifact written, so it can lag the page load). */}

--- a/frontend/src/app/run/[sessionId]/page.tsx
+++ b/frontend/src/app/run/[sessionId]/page.tsx
@@ -14,7 +14,11 @@ import {
   getSession,
   getEventError,
 } from "@/lib/api";
-import { formatStateValue } from "@/lib/utils";
+import {
+  buildDisplayFields,
+  VISUAL_DIRECTION_FIELDS,
+  type DisplayFieldDef,
+} from "@/lib/utils";
 import { gcsProxyUrl, parseGsUri } from "@/lib/gcs";
 import { hasStartedRun, markRunStarted } from "@/lib/run-kickoff";
 import type { AgentEvent } from "@/lib/types";
@@ -25,6 +29,14 @@ import {
 } from "./run-config";
 import { PipelineWidget } from "./run-widgets";
 import { ReviewPanel } from "./ReviewPanel";
+
+const CAMPAIGN_FIELD_DEFS: DisplayFieldDef[] = [
+  { label: "Brand", key: "brand" },
+  { label: "Target Audience", key: "target_audience" },
+  { label: "Target Product", key: "target_product" },
+  { label: "Key Selling Points", key: "key_selling_points" },
+  { label: "Search Trend", key: "target_search_trends", altKey: "target_search_trend" },
+];
 
 type Status = "running" | "completed" | "error" | "paused" | "stalled";
 
@@ -327,21 +339,16 @@ export default function RunPage({
   ]);
 
   // Campaign metadata fields for left sidebar
-  const campaignFields = useMemo(() => {
-    const fields: { label: string; key: string; altKey?: string }[] = [
-      { label: "Brand", key: "brand" },
-      { label: "Target Audience", key: "target_audience" },
-      { label: "Target Product", key: "target_product" },
-      { label: "Key Selling Points", key: "key_selling_points" },
-      { label: "Search Trend", key: "target_search_trends", altKey: "target_search_trend" },
-    ];
-    return fields
-      .map((f) => ({
-        ...f,
-        value: formatStateValue(sessionState[f.key] ?? (f.altKey ? sessionState[f.altKey] : undefined)),
-      }))
-      .filter((f) => f.value);
-  }, [sessionState]);
+  const campaignFields = useMemo(
+    () => buildDisplayFields(sessionState, CAMPAIGN_FIELD_DEFS),
+    [sessionState],
+  );
+
+  // Optional user visual art-direction inputs (PR #114) — hidden when unset
+  const visualDirectionFields = useMemo(
+    () => buildDisplayFields(sessionState, VISUAL_DIRECTION_FIELDS),
+    [sessionState],
+  );
 
   // Pipeline state widgets — newest first
   const pipelineWidgets = useMemo(() => {
@@ -418,6 +425,24 @@ export default function RunPage({
                 </dd>
               </div>
             ))
+          )}
+
+          {visualDirectionFields.length > 0 && (
+            <>
+              <h2 className="text-[10px] font-bold text-primary tracking-wider uppercase pt-3">
+                Visual Direction
+              </h2>
+              {visualDirectionFields.map((f) => (
+                <div key={f.key} className="glass rounded-xl px-4 py-3 animate-fadeInUpSmooth">
+                  <dt className="text-[10px] font-bold uppercase tracking-wider text-indigo-500">
+                    {f.label}
+                  </dt>
+                  <dd className="mt-1 text-sm font-medium leading-snug text-foreground break-words break-all">
+                    {f.value}
+                  </dd>
+                </div>
+              ))}
+            </>
           )}
         </div>
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -24,3 +24,54 @@ export function formatStateValue(value: unknown): string {
   }
   return String(value)
 }
+
+/** A label→state-key mapping for a read-only metadata display. */
+export interface DisplayFieldDef {
+  label: string
+  key: string
+  /** Fallback state key when `key` is absent (e.g. singular/plural variants). */
+  altKey?: string
+}
+
+/** A resolved display field ready to render. */
+export interface DisplayField {
+  label: string
+  key: string
+  value: string
+}
+
+/**
+ * Resolve a set of {@link DisplayFieldDef}s against a session-state object into
+ * renderable {@link DisplayField}s, dropping any whose value is empty. Values are
+ * normalized with {@link formatStateValue}, so unset keys (which default to `""`)
+ * collapse out — an unseeded run simply shows nothing.
+ */
+export function buildDisplayFields(
+  state: Record<string, unknown>,
+  defs: DisplayFieldDef[],
+): DisplayField[] {
+  return defs
+    .map((def) => ({
+      label: def.label,
+      key: def.key,
+      value: formatStateValue(
+        state[def.key] ?? (def.altKey ? state[def.altKey] : undefined),
+      ),
+    }))
+    .filter((f) => f.value !== "")
+}
+
+/**
+ * Optional user visual art-direction inputs (PR #114), surfaced read-only
+ * alongside campaign metadata. Unset keys default to `""` in session state, so
+ * `buildDisplayFields` filters them out and non-creative runs show nothing.
+ */
+export const VISUAL_DIRECTION_FIELDS: DisplayFieldDef[] = [
+  { label: "Art Direction", key: "visual_intent" },
+  { label: "Brand Colors", key: "brand_colors" },
+  { label: "Preferred Style", key: "visual_style_preference" },
+  { label: "Avoid", key: "visual_avoid" },
+  { label: "Aspect Ratio", key: "visual_aspect_ratio" },
+  { label: "Reference Image", key: "reference_image_uri" },
+  { label: "Reference Role", key: "reference_image_role" },
+]


### PR DESCRIPTION
## Summary

PR #114 added optional visual-intent capture (art direction, brand colors, preferred style, avoid, aspect ratio, reference image + role) — but once submitted these were **invisible** in the UI. This adds a read-only **"Visual Direction"** section that surfaces them alongside the existing campaign metadata, in both places metadata already appears: the live run view and the results view.

## What changed

- **`frontend/src/lib/utils.ts`** — new pure helper `buildDisplayFields(state, defs)` + shared `VISUAL_DIRECTION_FIELDS` constant (the 7 visual-intent keys). Reuses the existing `formatStateValue` normalization; filters out empty/unset values.
- **Run page** (`run/[sessionId]/page.tsx`) — refactored `campaignFields` onto the shared helper (behavior unchanged) and added a "Visual Direction" sidebar block below the campaign cards.
- **Results page** (`results/[sessionId]/page.tsx`) — same refactor + a second horizontal "Visual Direction" metadata bar.
- **`CLAUDE.md`** — one-line note.

## Behavior

The 7 intent keys default to `""` in session state, so `formatStateValue` collapses unset ones and the whole section is gated on `length > 0`. Result: `trend_scout` runs and creative runs with no visual intent look **exactly as before** — the section only appears when the user actually supplied direction. The spaceless `gs://` reference URI wraps via `break-all`.

## Testing

- New `display-fields.test.ts` (6 cases, TDD RED→GREEN): empty-filtering, `altKey` fallback, array/object flattening, `VISUAL_DIRECTION_FIELDS` mapping.
- `npx tsc --noEmit` clean, `eslint` clean on all touched files.
- Full frontend suite: **116/116** green (110 prior + 6 new).

No new Next.js APIs introduced (pure React render + lib helper).