### PR TITLE
fix: harden visual_generator against MALFORMED_FUNCTION_CALL (#116)

### DIFF
--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -435,11 +435,18 @@ visual_generator = Agent(
 # spend); on exhaustion the wrapper emits _images_generated__retry_exhausted, which
 # collect_degradation_warnings surfaces on the gallery/eval banner. Single shared
 # instance (also used by interactive_creative via AgentTool) to avoid double-parenting.
+#
+# max_attempts=6 (issue #116): the MALFORMED flake is transient — a fresh producer
+# turn usually clears it, and each attempt IS an independent turn — but 3 attempts
+# occasionally weren't enough, dropping the WHOLE run to zero images. A higher cap
+# only costs extra *failed* producer turns (the idempotency guard prevents double
+# image spend, and the first successful turn returns immediately), so the common
+# path is unchanged while rare-failure recovery odds rise materially.
 visual_generator_resilient = RetryUntilKeyAgent(
     name="visual_generator_resilient",
     sub_agents=[visual_generator],
     output_key="_images_generated",
-    max_attempts=3,
+    max_attempts=6,
 )
 
 

--- a/frontend/src/__tests__/images-retry-exhausted.test.ts
+++ b/frontend/src/__tests__/images-retry-exhausted.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { imagesRetryExhausted } from "@/lib/utils";
+
+describe("imagesRetryExhausted", () => {
+  it("is true when the retry-exhaustion marker is set", () => {
+    expect(imagesRetryExhausted({ _images_generated__retry_exhausted: true })).toBe(
+      true,
+    );
+  });
+
+  it("is false when the marker is absent", () => {
+    expect(imagesRetryExhausted({})).toBe(false);
+    expect(imagesRetryExhausted({ _images_generated: true })).toBe(false);
+  });
+
+  it("is false when the marker is present but falsy", () => {
+    expect(
+      imagesRetryExhausted({ _images_generated__retry_exhausted: false }),
+    ).toBe(false);
+  });
+
+  it("returns a boolean (never a raw truthy value)", () => {
+    // ADK could serialize the marker as a truthy non-bool; the helper must coerce.
+    expect(
+      imagesRetryExhausted({ _images_generated__retry_exhausted: "true" }),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/app/results/[sessionId]/page.tsx
+++ b/frontend/src/app/results/[sessionId]/page.tsx
@@ -17,6 +17,7 @@ import { fetchEvalReport } from "@/lib/eval-report";
 import { gcsProxyUrl } from "@/lib/gcs";
 import {
   buildDisplayFields,
+  imagesRetryExhausted,
   VISUAL_DIRECTION_FIELDS,
   type DisplayFieldDef,
 } from "@/lib/utils";
@@ -223,6 +224,7 @@ export default function ResultsPage({
   }
 
   const state = session?.state || {};
+  const noImages = imagesRetryExhausted(state);
   const gcsUri = [state.gcs_bucket, state.gcs_folder, state.agent_output_dir]
     .filter(Boolean)
     .join("/");
@@ -313,6 +315,22 @@ export default function ResultsPage({
 
   return (
     <div className="mx-auto max-w-[1600px] px-6 py-8">
+      {/* Zero-image warning: the image producer exhausted all retries (issue #116),
+          so this run shipped no visuals. Surface it prominently — otherwise the
+          only signal is an easy-to-miss eval-report note and empty image tabs. */}
+      {noImages && (
+        <div className="mb-6 rounded-2xl border border-amber-500/40 bg-amber-500/10 px-5 py-4 animate-fadeIn">
+          <h2 className="text-sm font-semibold text-amber-700">
+            No images were generated for this run
+          </h2>
+          <p className="mt-0.5 text-xs text-amber-700/80">
+            The image model failed repeatedly (MALFORMED_FUNCTION_CALL), so no
+            visual concepts were rendered. This is usually transient — start a new
+            run of the same campaign to generate visuals.
+          </p>
+        </div>
+      )}
+
       {/* Header row */}
       <div className="mb-6 flex items-center justify-between animate-fadeIn">
         <div>

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -25,6 +25,18 @@ export function formatStateValue(value: unknown): string {
   return String(value)
 }
 
+/**
+ * True when the image step exhausted all its retries and produced no visuals
+ * (issue #116). `visual_generator_resilient` (a RetryUntilKeyAgent) writes the
+ * `_images_generated__retry_exhausted` marker to session state on exhaustion, so
+ * a "successful" run can still ship an empty gallery — this lets the results page
+ * flag that clearly. Coerced to a plain boolean since ADK may serialize the
+ * marker as a truthy non-bool.
+ */
+export function imagesRetryExhausted(state: Record<string, unknown>): boolean {
+  return Boolean(state["_images_generated__retry_exhausted"])
+}
+
 /** A label→state-key mapping for a read-only metadata display. */
 export interface DisplayFieldDef {
   label: string

--- a/tests/test_pipeline_structure.py
+++ b/tests/test_pipeline_structure.py
@@ -190,6 +190,9 @@ def test_visual_production_pipeline_wraps_generator_in_retry():
     assert isinstance(w, RetryUntilKeyAgent)
     assert w.output_key == "_images_generated"
     assert w.sub_agents[0] is ca.visual_generator
+    # MALFORMED_FUNCTION_CALL is a transient producer flake (issue #116); each
+    # attempt is an independent turn, so a higher cap materially raises recovery.
+    assert w.max_attempts == 6
 
 
 def test_parallel_planner_has_both_researchers():


### PR DESCRIPTION
Closes #116.

## Problem
`visual_generator` (the image producer) intermittently returns `MALFORMED_FUNCTION_CALL` and never emits the `generate_image` tool call, leaving `_images_generated` unset. `visual_generator_resilient` (a `RetryUntilKeyAgent`) retries on the empty output, but with only **3 attempts** it occasionally exhausted, dropping the **whole run to zero images** — every concept PNG 404s on the results page. The failure is transient (a manual re-run of the same campaign succeeds), so more independent attempts materially raise recovery odds.

The run still completes "successfully"; today the only signal is an easy-to-miss eval-report `warnings` note.

## Changes
**Backend — raise the retry ceiling**
- `visual_generator_resilient` `max_attempts` **3 → 6** (`creative_agent/agent.py`). Each attempt is an independent producer turn, and the `generate_image` idempotency guard means a re-run never double-spends image quota — so the higher cap only costs *failed* producer turns while the common path (first attempt succeeds → returns immediately) is unchanged.
- Guarded by `assert w.max_attempts == 6` in `test_pipeline_structure.py`.

**Frontend — flag zero-image runs**
- New unit-tested `imagesRetryExhausted(state)` helper (`frontend/src/lib/utils.ts`) reading the `_images_generated__retry_exhausted` marker.
- Prominent amber banner at the top of the results page when set, explaining the transient failure and suggesting a re-run — so a zero-image run is obvious instead of only a missable eval note.

## Scope
Out of scope (deliberately): surfacing the eval-report `warnings[]` array, and deeper root-cause work (per-attempt context isolation / thinking-level tuning). Tracked as possible follow-ups if the flake recurs after the higher cap.

## Testing
- Python: `test_pipeline_structure.py` + `test_retry_agent.py` — 65 passed (RED→GREEN on the cap bump).
- Frontend: full Vitest suite — 120 passed (incl. 4 new helper tests, RED→GREEN); `tsc --noEmit` + eslint clean.
- Not driven live: reproducing the banner needs a run that actually exhausts image retries (the transient bug); the banner is gated by the unit-tested helper and typechecks.

## Deploy notes
Touches two services: backend change ships to `trend-trawler-api` (traffic-pin required), frontend to `trend-trawler-web` (auto-routes). Not deployed yet.