### PR TITLE
feat(frontend): surface research degradation warnings on results page

### DIFF
--- a/frontend/src/__tests__/non-image-warnings.test.ts
+++ b/frontend/src/__tests__/non-image-warnings.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { nonImageWarnings } from "@/lib/utils"
+
+/**
+ * `nonImageWarnings` filters the eval report's degradation warnings down to the
+ * ones NOT already surfaced by the dedicated zero-image banner (issue #116), so
+ * the two amber banners never duplicate the same "images exhausted" note.
+ */
+describe("nonImageWarnings", () => {
+  const IMAGE_WARNING =
+    "Step '_images_generated' exhausted retries and produced no output."
+  const TREND_WARNING =
+    "Step 'gs_web_search_insights' exhausted retries and produced no output."
+  const CAMPAIGN_WARNING =
+    "Step 'campaign_web_search_insights' exhausted retries and produced no output."
+
+  it("returns [] for undefined", () => {
+    expect(nonImageWarnings(undefined)).toEqual([])
+  })
+
+  it("returns [] for an empty list", () => {
+    expect(nonImageWarnings([])).toEqual([])
+  })
+
+  it("drops the image-exhaustion warning (covered by the zero-image banner)", () => {
+    expect(nonImageWarnings([IMAGE_WARNING])).toEqual([])
+  })
+
+  it("keeps research-producer warnings", () => {
+    expect(nonImageWarnings([TREND_WARNING, CAMPAIGN_WARNING])).toEqual([
+      TREND_WARNING,
+      CAMPAIGN_WARNING,
+    ])
+  })
+
+  it("filters only the image warning out of a mixed list", () => {
+    expect(
+      nonImageWarnings([TREND_WARNING, IMAGE_WARNING, CAMPAIGN_WARNING]),
+    ).toEqual([TREND_WARNING, CAMPAIGN_WARNING])
+  })
+})

--- a/frontend/src/app/results/[sessionId]/page.tsx
+++ b/frontend/src/app/results/[sessionId]/page.tsx
@@ -18,6 +18,7 @@ import { gcsProxyUrl } from "@/lib/gcs";
 import {
   buildDisplayFields,
   imagesRetryExhausted,
+  nonImageWarnings,
   VISUAL_DIRECTION_FIELDS,
   type DisplayFieldDef,
 } from "@/lib/utils";
@@ -62,6 +63,8 @@ interface EvalReport {
   target_search_trend: string;
   ad_copy_evaluations: AdCopyEvaluation[];
   visual_concept_evaluations: VisualConceptEvaluation[];
+  /** Degradation notes from retry-exhausted pipeline steps (may be absent on older reports). */
+  warnings?: string[];
   summary: {
     total_ad_copies: number;
     ad_copies_passed: number;
@@ -225,6 +228,10 @@ export default function ResultsPage({
 
   const state = session?.state || {};
   const noImages = imagesRetryExhausted(state);
+  // Degradation warnings from the eval report, minus the image-exhaustion note
+  // (already surfaced by the dedicated zero-image banner above) — what remains is
+  // the research-producer exhaustions worth flagging on their own.
+  const degradationWarnings = nonImageWarnings(evalReport?.warnings);
   const gcsUri = [state.gcs_bucket, state.gcs_folder, state.agent_output_dir]
     .filter(Boolean)
     .join("/");
@@ -429,6 +436,26 @@ export default function ResultsPage({
             </Button>
           </div>
         )}
+
+      {/* Degraded-research warning: one or more research producers exhausted their
+          retries and shipped no output, so the creative brief was built on partial
+          research. Distinct from (and filtered against) the zero-image banner. */}
+      {degradationWarnings.length > 0 && (
+        <div className="mb-6 rounded-2xl border border-amber-500/40 bg-amber-500/10 px-5 py-4 animate-fadeIn">
+          <h2 className="text-sm font-semibold text-amber-700">
+            Some research steps produced no output
+          </h2>
+          <p className="mt-0.5 text-xs text-amber-700/80">
+            Parts of the pipeline exhausted their retries, so this run&apos;s
+            creative was built on incomplete research:
+          </p>
+          <ul className="mt-2 list-disc space-y-0.5 pl-5 text-xs text-amber-700/80">
+            {degradationWarnings.map((w) => (
+              <li key={w}>{w}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {/* Eval summary header */}
       {evalReport && (

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -37,6 +37,19 @@ export function imagesRetryExhausted(state: Record<string, unknown>): boolean {
   return Boolean(state["_images_generated__retry_exhausted"])
 }
 
+/**
+ * The eval report's degradation warnings (from `collect_degradation_warnings`),
+ * minus the image-exhaustion note — that one is already surfaced by the dedicated
+ * zero-image banner (issue #116) via {@link imagesRetryExhausted}, so filtering it
+ * here keeps the two amber banners from duplicating the same message. What remains
+ * is the research-producer exhaustions (e.g. `gs_web_search_insights`,
+ * `campaign_web_search_insights`). Tolerates `undefined` (reports predating the
+ * `warnings` field simply show nothing).
+ */
+export function nonImageWarnings(warnings: string[] | undefined): string[] {
+  return (warnings ?? []).filter((w) => !w.includes("_images_generated"))
+}
+
 /** A label→state-key mapping for a read-only metadata display. */
 export interface DisplayFieldDef {
   label: string


### PR DESCRIPTION
## What

Surface the eval report's `warnings[]` (research-step retry exhaustions) on the results page. These already flow to the GCS `creative_eval_report.json` via `collect_degradation_warnings`, but nothing in the UI consumed them — so a run whose creative was built on **partial research** looked fully successful.

## Why now

Follow-up to #118 (issue #116). That PR added a dedicated banner for the *image* exhaustion (`_images_generated__retry_exhausted`). This closes the analogous gap for the **research producers** (`gs_web_search_insights`, `campaign_web_search_insights`), which had no UI signal at all.

## Changes

- **`lib/utils.ts`** — new pure helper `nonImageWarnings(warnings)` that drops the `_images_generated` note (already covered by the #116 zero-image banner) so the two amber banners never duplicate. Tolerates `undefined` (older reports without the field show nothing).
- **`results/[sessionId]/page.tsx`** — add `warnings?: string[]` to the `EvalReport` interface; render an amber list-banner (matching the #116 banner style) beside the eval summary card, shown only when `nonImageWarnings(...)` is non-empty.
- **`__tests__/non-image-warnings.test.ts`** — 5 Vitest cases (undefined, empty, image-only filtered, research kept, mixed).

Purely additive frontend work — no backend/schema change; the data already reaches GCS.

## Verification

- `npx vitest run` → 125/125 pass (20 files)
- `npx tsc --noEmit` → clean
- `npx eslint` (changed files) → clean