### PR TITLE
fix(creative_agent): force generate_image tool call to end #116 empty-gallery flake

### DIFF
--- a/creative_agent/agent.py
+++ b/creative_agent/agent.py
@@ -420,7 +420,15 @@ visual_generator = Agent(
             "subagent": "visual_generator",
         },
     ),
-    before_model_callback=callbacks.rate_limit_callback,
+    # Chain: rate-limit first, then force the generate_image tool call (issue #116).
+    # Both return None, so ADK runs them in order every turn. force_image_tool_call
+    # is gated on _images_generated so it only constrains the turn until the image
+    # step succeeds — belt (deterministic tool_config) AND suspenders (the resilient
+    # retry wrapper below) against the MALFORMED_FUNCTION_CALL empty-gallery flake.
+    before_model_callback=[
+        callbacks.rate_limit_callback,
+        callbacks.force_image_tool_call,
+    ],
     after_model_callback=callbacks.log_empty_turn_finish_reason,
 )
 

--- a/creative_agent/callbacks.py
+++ b/creative_agent/callbacks.py
@@ -8,6 +8,7 @@ from typing import Optional, Dict, Any
 from google.genai import types
 from google.adk.sessions.state import State
 from google.adk.agents.callback_context import CallbackContext
+from google.adk.models.llm_request import LlmRequest
 
 from agent_common import observability, sanitize
 from agent_common.rate_limit import build_rate_limit_callback
@@ -110,6 +111,37 @@ def load_session_state(callback_context: CallbackContext):
 # `callbacks.rate_limit_callback` keeps the same name/signature for the
 # before_model_callback wiring in agent.py (and interactive_creative reuse).
 rate_limit_callback = build_rate_limit_callback(config)
+
+
+def force_image_tool_call(
+    callback_context: CallbackContext, llm_request: LlmRequest
+) -> None:
+    """Constrain the visual_generator turn to actually call `generate_image`.
+
+    Root-cause backstop for issue #116: visual_generator (gemini-3.1-pro-preview)
+    intermittently returns MALFORMED_FUNCTION_CALL and emits NO tool call, leaving
+    `_images_generated` unset and shipping an empty gallery. `RetryUntilKeyAgent`
+    (visual_generator_resilient) retries that, but each retry is still a free-choice
+    turn that can flake again. Setting `tool_config` mode=ANY with
+    `allowed_function_names=["generate_image"]` forces the model to predict that one
+    function call every turn, making the common path deterministic rather than
+    probabilistic (the retry cap remains as defense-in-depth).
+
+    Gated on `_images_generated`: `generate_image` is idempotent (its guard sets that
+    flag on success), and the resilient wrapper may re-enter after success. Once the
+    images exist we must NOT re-force a tool call — leave the turn free so the agent
+    can simply finish. Wired as a `before_model_callback` on `visual_generator`
+    AFTER `rate_limit_callback` (both return None, so both run in order).
+    """
+    if callback_context.state.get("_images_generated"):
+        return None
+    llm_request.config.tool_config = types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode=types.FunctionCallingConfigMode.ANY,
+            allowed_function_names=["generate_image"],
+        )
+    )
+    return None
 
 
 def collect_research_sources_callback(callback_context: CallbackContext) -> None:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -2,6 +2,7 @@
 
 import re
 import time
+import types as pytypes
 
 
 # --- Citation replacement regex ---
@@ -217,3 +218,46 @@ class TestRateLimitLogic:
             state["request_count"] = request_count
 
         assert state["request_count"] == 51
+
+
+# --- Force-image-tool-call callback (issue #116) ---
+class TestForceImageToolCall:
+    """`force_image_tool_call` deterministically constrains the visual_generator
+    turn to emit the `generate_image` function call (tool_config mode=ANY),
+    eliminating the intermittent MALFORMED_FUNCTION_CALL empty-gallery flake —
+    but ONLY while the image step has not yet succeeded (gated on
+    `_images_generated`), so a resilient re-run after success stays a no-op.
+    """
+
+    @staticmethod
+    def _fake_request():
+        from google.adk.models.llm_request import LlmRequest
+
+        return LlmRequest()
+
+    @staticmethod
+    def _ctx(state):
+        return pytypes.SimpleNamespace(state=state)
+
+    def test_forces_tool_call_when_images_not_generated(self):
+        from google.genai.types import FunctionCallingConfigMode
+
+        from creative_agent.callbacks import force_image_tool_call
+
+        req = self._fake_request()
+        result = force_image_tool_call(self._ctx({}), req)
+
+        assert result is None  # callbacks must not short-circuit the model call
+        cfg = req.config.tool_config.function_calling_config
+        assert cfg.mode == FunctionCallingConfigMode.ANY
+        assert cfg.allowed_function_names == ["generate_image"]
+
+    def test_noop_once_images_generated(self):
+        from creative_agent.callbacks import force_image_tool_call
+
+        req = self._fake_request()
+        result = force_image_tool_call(self._ctx({"_images_generated": True}), req)
+
+        assert result is None
+        # Already succeeded → must NOT re-force the tool (idempotent re-run).
+        assert req.config.tool_config is None


### PR DESCRIPTION
## Problem

`visual_generator` (gemini-3.1-pro-preview) intermittently returns `MALFORMED_FUNCTION_CALL` and emits **no** tool call, leaving `_images_generated` unset and shipping an **empty gallery** (issue #116). `generate_image` is a *no-arg* tool, so the malformed call is a spurious model-side decode failure of the function *name*, not bad arguments.

`#118` bumped `max_attempts` 3→6 on the `RetryUntilKeyAgent` wrapper — a real backstop, since retries are genuinely independent (the malformed turn isn't persisted + `include_contents="none"`), but only *probabilistic*.

## Fix

Add a gated `before_model_callback` (`force_image_tool_call`) on `visual_generator` that sets:

```python
tool_config = ToolConfig(function_calling_config=FunctionCallingConfig(
    mode=ANY, allowed_function_names=["generate_image"]))
```

This constrains the model to predict that one function call **every turn**, making the common path deterministic rather than probabilistic — MALFORMED becomes structurally impossible on the producing turn.

- **Gated on `_images_generated`**: `generate_image` is idempotent (its guard sets that flag on success) and the resilient wrapper may re-enter after success. Once images exist the callback is a no-op, leaving the turn free to finish.
- **Chained after `rate_limit_callback`** (`before_model_callback` is now a list; both return `None`, so both run in order).
- **Kept as defense-in-depth**: `thinking_level=LOW` (prevents duplicate parallel calls — mode=ANY doesn't cap call *count*), the `_images_generated` idempotency guard, and the `max_attempts=6` retry cap.

## Tests

- New `tests/test_callbacks.py::TestForceImageToolCall` (RED→GREEN): unset `_images_generated` → forces `mode=ANY` + `allowed=["generate_image"]`; already-set → no-op.
- Full suite: **451 passed**. `ruff check`/`format --check` clean; `ty check` clean.

Structure/behavior change only — no deploy required for correctness. UI runs execute agents in-process on `trend-trawler-api`, so a routine `--source` api redeploy would ship it.